### PR TITLE
Add UI panel toggle keybinds (J/C/A/P)

### DIFF
--- a/crates/ui/src/graphs.rs
+++ b/crates/ui/src/graphs.rs
@@ -51,10 +51,19 @@ pub fn record_history(
     }
 }
 
-pub fn graphs_ui(mut contexts: EguiContexts, history: Res<HistoryData>) {
+pub fn graphs_ui(
+    mut contexts: EguiContexts,
+    history: Res<HistoryData>,
+    visible: Res<crate::info_panel::ChartsVisible>,
+) {
+    if !visible.0 {
+        return;
+    }
+
     egui::Window::new("Trends")
-        .default_open(false)
+        .default_open(true)
         .show(contexts.ctx_mut(), |ui| {
+            ui.small("Press [C] to toggle");
             if history.population.is_empty() {
                 ui.label("No data yet...");
                 return;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -16,6 +16,9 @@ impl Plugin for UiPlugin {
             .init_resource::<graphs::HistoryData>()
             .init_resource::<toolbar::OpenCategory>()
             .init_resource::<info_panel::JournalVisible>()
+            .init_resource::<info_panel::ChartsVisible>()
+            .init_resource::<info_panel::AdvisorVisible>()
+            .init_resource::<info_panel::PoliciesVisible>()
             .add_systems(Startup, theme::apply_cute_theme)
             .add_systems(
                 Update,
@@ -33,8 +36,9 @@ impl Plugin for UiPlugin {
                     milestones::milestones_ui,
                     graphs::graphs_ui,
                     info_panel::policies_ui,
-                    info_panel::toggle_journal_visibility,
+                    info_panel::panel_keybinds,
                     info_panel::event_journal_ui,
+                    info_panel::advisor_window_ui,
                 ),
             );
     }


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts to toggle four UI panels: **J** (Event Journal), **C** (Charts/Trends), **A** (City Advisors), **P** (Policies)
- Panels start hidden and toggle on/off with their respective key press
- Keys are suppressed when egui has keyboard focus (e.g. text input fields) to prevent accidental toggling
- Add standalone City Advisors window (previously only available as a collapsing section inside the info panel)
- Each panel shows its keybind hint (e.g. "Press [J] to toggle")

## Test plan
- [ ] Press J key -- Event Journal window should appear/disappear
- [ ] Press C key -- Charts/Trends window should appear/disappear
- [ ] Press A key -- City Advisors window should appear/disappear
- [ ] Press P key -- Policies window should appear/disappear
- [ ] Verify keys do not trigger while typing in an egui text field
- [ ] Verify multiple panels can be open simultaneously
- [ ] Verify panels remember their position when toggled off and back on

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)