### PR TITLE
Add Ctrl+S/Ctrl+L/Ctrl+N quick save/load/new game shortcuts (UX-050)

### DIFF
--- a/crates/ui/src/info_panel.rs
+++ b/crates/ui/src/info_panel.rs
@@ -2176,6 +2176,35 @@ pub fn panel_keybinds(
     }
 }
 
+/// Keyboard shortcuts for quick save (Ctrl+S), quick load (Ctrl+L), and new game (Ctrl+N).
+/// Skipped when egui wants keyboard input (e.g. a text field is focused).
+pub fn quick_save_load_keybinds(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut contexts: EguiContexts,
+    mut save_events: EventWriter<save::SaveGameEvent>,
+    mut load_events: EventWriter<save::LoadGameEvent>,
+    mut new_game_events: EventWriter<save::NewGameEvent>,
+) {
+    if contexts.ctx_mut().wants_keyboard_input() {
+        return;
+    }
+
+    let ctrl = keyboard.pressed(KeyCode::ControlLeft) || keyboard.pressed(KeyCode::ControlRight);
+    if !ctrl {
+        return;
+    }
+
+    if keyboard.just_pressed(KeyCode::KeyS) {
+        save_events.send(save::SaveGameEvent);
+    }
+    if keyboard.just_pressed(KeyCode::KeyL) {
+        load_events.send(save::LoadGameEvent);
+    }
+    if keyboard.just_pressed(KeyCode::KeyN) {
+        new_game_events.send(save::NewGameEvent);
+    }
+}
+
 /// Displays the Event Journal as a collapsible egui window.
 /// Shows the last 10 events with day/hour and description.
 /// Also shows active effects status.

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -37,6 +37,7 @@ impl Plugin for UiPlugin {
                     graphs::graphs_ui,
                     info_panel::policies_ui,
                     info_panel::panel_keybinds,
+                    info_panel::quick_save_load_keybinds,
                     info_panel::event_journal_ui,
                     info_panel::advisor_window_ui,
                 ),


### PR DESCRIPTION
## Summary
- Add `quick_save_load_keybinds` system that listens for **Ctrl+S** (save), **Ctrl+L** (load), and **Ctrl+N** (new game) key combos
- Fires the existing `SaveGameEvent`, `LoadGameEvent`, and `NewGameEvent` respectively -- same events used by the toolbar buttons
- Respects egui keyboard focus (`wants_keyboard_input()`) to avoid triggering while typing in text fields
- Follows the same pattern as the existing `panel_keybinds` system in `info_panel.rs`

## Test plan
- [ ] Press Ctrl+S -- game saves to `megacity_save.bin`
- [ ] Press Ctrl+L -- game loads from save file
- [ ] Press Ctrl+N -- game resets to a fresh map
- [ ] Focus an egui text field, press Ctrl+S -- shortcut should NOT fire
- [ ] Verify existing panel keybinds (J/C/A/P) still work
- [ ] Verify toolbar Save/Load/New buttons still work

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)