### PR TITLE
Add budget breakdown panel (UX-055)

### DIFF
--- a/crates/ui/src/info_panel.rs
+++ b/crates/ui/src/info_panel.rs
@@ -2146,8 +2146,13 @@ pub struct AdvisorVisible(pub bool);
 #[derive(Resource, Default)]
 pub struct PoliciesVisible(pub bool);
 
+/// Resource controlling whether the budget breakdown window is visible.
+/// Toggle with 'B' key.
+#[derive(Resource, Default)]
+pub struct BudgetPanelVisible(pub bool);
+
 /// Toggles UI panel visibility when keybinds are pressed.
-/// J = Event Journal, C = Charts, A = Advisors, P = Policies.
+/// J = Event Journal, C = Charts, A = Advisors, P = Policies, B = Budget.
 /// Keys are ignored when egui has keyboard focus (e.g. text input).
 pub fn panel_keybinds(
     keyboard: Res<ButtonInput<KeyCode>>,
@@ -2155,6 +2160,7 @@ pub fn panel_keybinds(
     mut charts: ResMut<ChartsVisible>,
     mut advisor: ResMut<AdvisorVisible>,
     mut policies: ResMut<PoliciesVisible>,
+    mut budget_panel: ResMut<BudgetPanelVisible>,
     mut contexts: EguiContexts,
 ) {
     // Don't toggle panels when a text field or other egui widget wants keyboard input
@@ -2173,6 +2179,9 @@ pub fn panel_keybinds(
     }
     if keyboard.just_pressed(KeyCode::KeyP) {
         policies.0 = !policies.0;
+    }
+    if keyboard.just_pressed(KeyCode::KeyB) {
+        budget_panel.0 = !budget_panel.0;
     }
 }
 
@@ -2327,4 +2336,119 @@ fn event_type_color(event_type: &simulation::events::CityEventType) -> egui::Col
         CityEventType::EconomicBoom => egui::Color32::from_rgb(50, 220, 50),
         CityEventType::ResourceDepleted(_) => egui::Color32::from_rgb(200, 150, 50),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Budget Breakdown Panel
+// ---------------------------------------------------------------------------
+
+/// Displays a detailed budget breakdown window with income and expense lines.
+/// Shows per-zone tax income, per-category expenses, and net income.
+pub fn budget_panel_ui(
+    mut contexts: EguiContexts,
+    budget: Res<CityBudget>,
+    ext_budget: Res<simulation::budget::ExtendedBudget>,
+    visible: Res<BudgetPanelVisible>,
+) {
+    if !visible.0 {
+        return;
+    }
+
+    let income = &ext_budget.income_breakdown;
+    let expenses = &ext_budget.expense_breakdown;
+
+    let total_income = income.residential_tax
+        + income.commercial_tax
+        + income.industrial_tax
+        + income.office_tax
+        + income.trade_income;
+    let total_expenses = expenses.road_maintenance
+        + expenses.service_costs
+        + expenses.policy_costs
+        + expenses.loan_payments;
+    let net = total_income - total_expenses;
+
+    egui::Window::new("Budget Breakdown")
+        .default_open(true)
+        .default_width(320.0)
+        .show(contexts.ctx_mut(), |ui| {
+            ui.small("Press [B] to toggle");
+            ui.separator();
+
+            // Treasury
+            ui.horizontal(|ui| {
+                ui.strong("Treasury:");
+                ui.label(format!("${:.0}", budget.treasury));
+            });
+            ui.separator();
+
+            // --- Income section ---
+            ui.heading("Income");
+            budget_line(ui, "Residential Tax", income.residential_tax);
+            budget_line(ui, "Commercial Tax", income.commercial_tax);
+            budget_line(ui, "Industrial Tax", income.industrial_tax);
+            budget_line(ui, "Office Tax", income.office_tax);
+            budget_line(ui, "Trade / Tourism", income.trade_income);
+            ui.separator();
+            ui.horizontal(|ui| {
+                ui.strong("Total Income:");
+                ui.colored_label(
+                    egui::Color32::from_rgb(80, 200, 80),
+                    format!("${:.0}/mo", total_income),
+                );
+            });
+            ui.add_space(4.0);
+
+            // --- Expense section ---
+            ui.heading("Expenses");
+            budget_line(ui, "Road Maintenance", expenses.road_maintenance);
+            budget_line(ui, "Service Costs", expenses.service_costs);
+            budget_line(ui, "Policy Costs", expenses.policy_costs);
+            budget_line(ui, "Loan Payments", expenses.loan_payments);
+            ui.separator();
+            ui.horizontal(|ui| {
+                ui.strong("Total Expenses:");
+                ui.colored_label(
+                    egui::Color32::from_rgb(220, 80, 80),
+                    format!("${:.0}/mo", total_expenses),
+                );
+            });
+            ui.add_space(8.0);
+
+            // --- Net income ---
+            ui.separator();
+            let net_color = if net >= 0.0 {
+                egui::Color32::from_rgb(80, 220, 80)
+            } else {
+                egui::Color32::from_rgb(255, 60, 60)
+            };
+            let net_sign = if net >= 0.0 { "+" } else { "" };
+            ui.horizontal(|ui| {
+                ui.strong("Net Income:");
+                ui.colored_label(net_color, format!("{}{:.0}/mo", net_sign, net));
+            });
+
+            // Debt summary (only when loans exist)
+            if !ext_budget.loans.is_empty() {
+                ui.add_space(4.0);
+                ui.separator();
+                ui.heading("Outstanding Debt");
+                ui.label(format!(
+                    "Total debt: ${:.0} ({} loan{})",
+                    ext_budget.total_debt(),
+                    ext_budget.loans.len(),
+                    if ext_budget.loans.len() == 1 { "" } else { "s" }
+                ));
+            }
+        });
+}
+
+/// Helper to render a single budget line item.
+fn budget_line(ui: &mut egui::Ui, label: &str, amount: f64) {
+    ui.horizontal(|ui| {
+        ui.label(format!("  {label}:"));
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            ui.label(format!("${:.0}", amount));
+        });
+    });
 }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -19,6 +19,7 @@ impl Plugin for UiPlugin {
             .init_resource::<info_panel::ChartsVisible>()
             .init_resource::<info_panel::AdvisorVisible>()
             .init_resource::<info_panel::PoliciesVisible>()
+            .init_resource::<info_panel::BudgetPanelVisible>()
             .add_systems(Startup, theme::apply_cute_theme)
             .add_systems(
                 Update,
@@ -39,6 +40,7 @@ impl Plugin for UiPlugin {
                     info_panel::panel_keybinds,
                     info_panel::event_journal_ui,
                     info_panel::advisor_window_ui,
+                    info_panel::budget_panel_ui,
                 ),
             );
     }


### PR DESCRIPTION
## Summary
- Add **Budget Breakdown** egui window (toggle with **B** key) showing detailed income and expense line items
- Income section: residential, commercial, industrial, and office tax plus trade/tourism income
- Expense section: road maintenance, service costs, policy costs, and loan payments
- Net income displayed prominently with green/red color coding
- Outstanding debt summary shown when loans exist
- New `BudgetPanelVisible` resource and `budget_panel_ui` system registered in UI plugin

## Test plan
- [ ] Press **B** to open/close the Budget Breakdown window
- [ ] Verify income lines match zone taxes from `ExtendedBudget`
- [ ] Verify expense lines match road maintenance, service, policy, and loan costs
- [ ] Confirm net income is green when positive, red when negative
- [ ] Take a loan and verify the Outstanding Debt section appears
- [ ] Ensure the panel does not interfere with other keybind-toggled panels (J/C/A/P)

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)