### PR TITLE
Fix LifeSimTimer serialization (SAVE-003)

### DIFF
--- a/crates/simulation/src/life_simulation.rs
+++ b/crates/simulation/src/life_simulation.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use rand::Rng;
+use serde::{Deserialize, Serialize};
 
 use crate::buildings::Building;
 use crate::citizen::{
@@ -14,7 +15,7 @@ use crate::time_of_day::GameClock;
 // Timers
 // ---------------------------------------------------------------------------
 
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Serialize, Deserialize, Clone, Debug)]
 pub struct LifeSimTimer {
     pub needs_tick: u32,
     pub life_event_tick: u32,


### PR DESCRIPTION
## Summary
- Serializes `LifeSimTimer` resource so life event tick counters (needs, marriage, births, salary, education, personality, health) are preserved across save/load cycles
- Previously all 7 tick counters reset to zero on load, causing every life event subsystem to fire simultaneously
- Adds `SaveLifeSimTimer` struct with all 7 fields, `restore_life_sim_timer()` function, and backward-compatible `#[serde(default)]` `Option<SaveLifeSimTimer>` field on `SaveData`
- Bumps save version from v3 to v4 with migration support for older saves
- Adds unit tests for round-trip serialization, full encode/decode cycle, backward compatibility, and v3->v4 migration

Closes #696

## Test plan
- [ ] `cargo test --workspace` passes (4 new tests: `test_life_sim_timer_roundtrip`, `test_life_sim_timer_full_roundtrip`, `test_life_sim_timer_backward_compat`, `test_migrate_from_v3`)
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] Loading a v3 save file works correctly (timer defaults to zero, no crash)
- [ ] Saving and reloading preserves life event timer state (events do not all fire simultaneously)

🤖 Generated with [Claude Code](https://claude.com/claude-code)