### PR TITLE
Add numpad +/- as camera zoom alternative (UX-058)

### DIFF
--- a/crates/rendering/src/camera.rs
+++ b/crates/rendering/src/camera.rs
@@ -272,3 +272,18 @@ pub fn camera_zoom(mut scroll_evts: EventReader<MouseWheel>, mut orbit: ResMut<O
         orbit.distance = (orbit.distance * factor).clamp(MIN_DISTANCE, MAX_DISTANCE);
     }
 }
+
+/// Numpad +/-: zoom in/out (same step as one scroll line).
+pub fn camera_zoom_keyboard(keys: Res<ButtonInput<KeyCode>>, mut orbit: ResMut<OrbitCamera>) {
+    let mut dy = 0.0;
+    if keys.pressed(KeyCode::NumpadAdd) {
+        dy += 1.0;
+    }
+    if keys.pressed(KeyCode::NumpadSubtract) {
+        dy -= 1.0;
+    }
+    if dy != 0.0 {
+        let factor = 1.0 - dy * ZOOM_SPEED;
+        orbit.distance = (orbit.distance * factor).clamp(MIN_DISTANCE, MAX_DISTANCE);
+    }
+}

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -53,6 +53,7 @@ impl Plugin for RenderingPlugin {
                     camera::camera_left_drag,
                     camera::camera_orbit_drag,
                     camera::camera_zoom,
+                    camera::camera_zoom_keyboard,
                     camera::apply_orbit_camera,
                 ),
             )


### PR DESCRIPTION
## Summary
- Adds `NumpadAdd` and `NumpadSubtract` as keyboard zoom controls, using the same zoom step as one scroll-wheel line
- New `camera_zoom_keyboard` system registered alongside the existing `camera_zoom` system

Closes #927

## Test plan
- [ ] Press Numpad `+` and verify the camera zooms in
- [ ] Press Numpad `-` and verify the camera zooms out
- [ ] Hold either key and verify continuous smooth zoom
- [ ] Verify scroll-wheel zoom still works unchanged
- [ ] Verify zoom clamps to MIN_DISTANCE / MAX_DISTANCE bounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)