### PR TITLE
Add waste collection system with service areas (WASTE-003)

### DIFF
--- a/crates/simulation/src/happiness.rs
+++ b/crates/simulation/src/happiness.rs
@@ -199,6 +199,7 @@ pub struct HappinessExtras<'w> {
     pub death_care_grid: Res<'w, DeathCareGrid>,
     pub heating_grid: Res<'w, HeatingGrid>,
     pub postal_coverage: Res<'w, PostalCoverage>,
+    pub waste_collection: Res<'w, crate::garbage::WasteCollectionGrid>,
 }
 
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
@@ -231,6 +232,7 @@ pub fn update_happiness(
     let death_care_grid = &extras.death_care_grid;
     let heating_grid = &extras.heating_grid;
     let postal_coverage = &extras.postal_coverage;
+    let waste_collection = &extras.waste_collection;
     if !tick.0.is_multiple_of(10) {
         return;
     }
@@ -313,6 +315,13 @@ pub fn update_happiness(
             // Garbage penalty
             if garbage_grid.get(home.grid_x, home.grid_y) > 10 {
                 happiness -= GARBAGE_PENALTY;
+            }
+
+            // Uncollected waste penalty (WASTE-003): buildings outside waste
+            // collection service areas or with high uncollected waste suffer -5.
+            let uncollected = waste_collection.uncollected(home.grid_x, home.grid_y);
+            if uncollected > 100.0 {
+                happiness -= crate::garbage::UNCOLLECTED_WASTE_HAPPINESS_PENALTY;
             }
 
             // Crime penalty (based on crime level at home cell)

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -91,7 +91,7 @@ use education_jobs::EmploymentStats;
 use events::{ActiveCityEffects, EventJournal, MilestoneTracker};
 use fire::FireGrid;
 use forest_fire::{ForestFireGrid, ForestFireStats};
-use garbage::{GarbageGrid, WasteSystem};
+use garbage::{GarbageGrid, WasteCollectionGrid, WasteSystem};
 use grid::{CellType, RoadType, WorldGrid, ZoneType};
 use groundwater::{GroundwaterGrid, GroundwaterStats, WaterQualityGrid};
 use health::HealthGrid;
@@ -179,6 +179,7 @@ impl Plugin for SimulationPlugin {
             .init_resource::<LandValueGrid>()
             .init_resource::<GarbageGrid>()
             .init_resource::<WasteSystem>()
+            .init_resource::<WasteCollectionGrid>()
             .init_resource::<VirtualPopulation>()
             .init_resource::<Policies>()
             .init_resource::<Weather>()
@@ -291,6 +292,7 @@ impl Plugin for SimulationPlugin {
                     garbage::sync_recycling_policy,
                     garbage::update_garbage,
                     garbage::update_waste_generation,
+                    garbage::update_waste_collection,
                     districts::aggregate_districts,
                     districts::district_stats,
                     lifecycle::age_citizens,

--- a/crates/simulation/src/services.rs
+++ b/crates/simulation/src/services.rs
@@ -152,7 +152,7 @@ impl ServiceBuilding {
             ServiceType::Landfill => 20.0 * CELL_SIZE,
             ServiceType::RecyclingCenter => 25.0 * CELL_SIZE,
             ServiceType::Incinerator => 30.0 * CELL_SIZE,
-            ServiceType::TransferStation => 15.0 * CELL_SIZE,
+            ServiceType::TransferStation => 20.0 * CELL_SIZE,
             ServiceType::Cemetery => 120.0,
             ServiceType::Crematorium => 80.0,
             ServiceType::CityHall => 40.0 * CELL_SIZE,
@@ -437,7 +437,8 @@ impl ServiceBuilding {
             ServiceType::SubwayStation
             | ServiceType::TramDepot
             | ServiceType::DataCenter
-            | ServiceType::DistrictHeatingPlant => (2, 2),
+            | ServiceType::DistrictHeatingPlant
+            | ServiceType::TransferStation => (2, 2),
             ServiceType::GeothermalPlant => (3, 3),
             _ => (1, 1),
         }


### PR DESCRIPTION
## Summary
Closes #947

- **Waste collection coverage**: Each waste facility (transfer station, landfill, recycling center, incinerator) provides coverage within a 20-cell service radius. `WasteCollectionGrid` tracks per-cell coverage and uncollected waste accumulation.
- **Collection rate & capacity**: Transfer station = 200 tons/day, landfill = 150, recycling center = 100, incinerator = 250. Collection rate = `min(1.0, total_capacity / total_generated)`. Uncollected waste accumulates at uncovered buildings.
- **Penalties**: Uncollected waste (>100 lbs) causes happiness -5 penalty and land value -10% reduction. Transport cost computed from collected tons and average haul distance.
- **Service building updates**: Transfer station radius updated to 20 cells (from 15), footprint updated to 2x2 per ticket spec.
- **14 new unit tests** covering facility capacities, coverage grid, service radius, collection rate at various capacity levels, uncollected waste accumulation and capping, and grid clearing behavior.

### Files changed
- `crates/simulation/src/garbage.rs` — `WasteCollectionGrid` resource, `update_waste_collection` system, constants, 14 tests
- `crates/simulation/src/happiness.rs` — Uncollected waste happiness penalty via `HappinessExtras`
- `crates/simulation/src/land_value.rs` — Uncollected waste land value penalty
- `crates/simulation/src/lib.rs` — Register `WasteCollectionGrid` resource and `update_waste_collection` system
- `crates/simulation/src/services.rs` — Transfer station: 20-cell radius, 2x2 footprint

## Test plan
- [ ] Unit test: transfer station serves buildings within 20 cells
- [ ] Unit test: collection at 80% capacity means 20% uncollected
- [ ] Unit test: placing a transfer station marks cells as covered
- [ ] Unit test: uncollected waste causes happiness penalty (>100 lbs threshold)
- [ ] Unit test: facility capacities match ticket spec (transfer station = 200 tons/day)
- [ ] Unit test: collection rate capped at 1.0 when capacity exceeds generation
- [ ] Unit test: uncollected waste capped at 10,000 lbs
- [ ] CI: cargo build, cargo test, cargo clippy, cargo fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)