### PR TITLE
Add Tab/Shift+Tab overlay cycling (UX-034)

### DIFF
--- a/crates/rendering/src/overlay.rs
+++ b/crates/rendering/src/overlay.rs
@@ -15,12 +15,67 @@ pub enum OverlayMode {
     WaterPollution,
 }
 
+/// Ordered list of all overlay modes for Tab/Shift+Tab cycling.
+const ALL_OVERLAYS: [OverlayMode; 10] = [
+    OverlayMode::None,
+    OverlayMode::Power,
+    OverlayMode::Water,
+    OverlayMode::Traffic,
+    OverlayMode::Pollution,
+    OverlayMode::LandValue,
+    OverlayMode::Education,
+    OverlayMode::Garbage,
+    OverlayMode::Noise,
+    OverlayMode::WaterPollution,
+];
+
+impl OverlayMode {
+    /// Returns the next overlay mode in the cycle (wraps around).
+    pub fn next(self) -> Self {
+        let idx = ALL_OVERLAYS.iter().position(|&m| m == self).unwrap_or(0);
+        ALL_OVERLAYS[(idx + 1) % ALL_OVERLAYS.len()]
+    }
+
+    /// Returns the previous overlay mode in the cycle (wraps around).
+    pub fn prev(self) -> Self {
+        let idx = ALL_OVERLAYS.iter().position(|&m| m == self).unwrap_or(0);
+        ALL_OVERLAYS[(idx + ALL_OVERLAYS.len() - 1) % ALL_OVERLAYS.len()]
+    }
+
+    /// Human-readable label for display in status bar.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::None => "None",
+            Self::Power => "Power",
+            Self::Water => "Water",
+            Self::Traffic => "Traffic",
+            Self::Pollution => "Pollution",
+            Self::LandValue => "Land Value",
+            Self::Education => "Education",
+            Self::Garbage => "Garbage",
+            Self::Noise => "Noise",
+            Self::WaterPollution => "Water Pollution",
+        }
+    }
+}
+
 #[derive(Resource, Default)]
 pub struct OverlayState {
     pub mode: OverlayMode,
 }
 
 pub fn toggle_overlay_keys(keys: Res<ButtonInput<KeyCode>>, mut overlay: ResMut<OverlayState>) {
+    // Tab / Shift+Tab cycling through overlay modes
+    if keys.just_pressed(KeyCode::Tab) {
+        let shift = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
+        overlay.mode = if shift {
+            overlay.mode.prev()
+        } else {
+            overlay.mode.next()
+        };
+        return;
+    }
+
     if keys.just_pressed(KeyCode::KeyP) {
         overlay.mode = if overlay.mode == OverlayMode::Power {
             OverlayMode::None
@@ -83,5 +138,67 @@ pub fn toggle_overlay_keys(keys: Res<ButtonInput<KeyCode>>, mut overlay: ResMut<
         } else {
             OverlayMode::WaterPollution
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_cycles_forward_through_all_overlays() {
+        let mut mode = OverlayMode::None;
+        let expected = [
+            OverlayMode::Power,
+            OverlayMode::Water,
+            OverlayMode::Traffic,
+            OverlayMode::Pollution,
+            OverlayMode::LandValue,
+            OverlayMode::Education,
+            OverlayMode::Garbage,
+            OverlayMode::Noise,
+            OverlayMode::WaterPollution,
+            OverlayMode::None, // wraps back
+        ];
+        for &exp in &expected {
+            mode = mode.next();
+            assert_eq!(mode, exp);
+        }
+    }
+
+    #[test]
+    fn prev_cycles_backward_through_all_overlays() {
+        let mut mode = OverlayMode::None;
+        let expected = [
+            OverlayMode::WaterPollution,
+            OverlayMode::Noise,
+            OverlayMode::Garbage,
+            OverlayMode::Education,
+            OverlayMode::LandValue,
+            OverlayMode::Pollution,
+            OverlayMode::Traffic,
+            OverlayMode::Water,
+            OverlayMode::Power,
+            OverlayMode::None, // wraps back
+        ];
+        for &exp in &expected {
+            mode = mode.prev();
+            assert_eq!(mode, exp);
+        }
+    }
+
+    #[test]
+    fn next_then_prev_returns_to_original() {
+        for &start in &ALL_OVERLAYS {
+            assert_eq!(start.next().prev(), start);
+            assert_eq!(start.prev().next(), start);
+        }
+    }
+
+    #[test]
+    fn label_returns_non_empty_for_all_variants() {
+        for &mode in &ALL_OVERLAYS {
+            assert!(!mode.label().is_empty());
+        }
     }
 }

--- a/crates/ui/src/toolbar.rs
+++ b/crates/ui/src/toolbar.rs
@@ -883,6 +883,15 @@ pub fn toolbar_ui(
                     load_events.send(LoadGameEvent);
                 }
 
+                // Current overlay
+                if overlay.mode != OverlayMode::None {
+                    ui.separator();
+                    ui.label(
+                        egui::RichText::new(format!("Overlay: {}", overlay.mode.label()))
+                            .color(egui::Color32::from_rgb(140, 220, 255)),
+                    );
+                }
+
                 // Active tool + cost
                 if let Some(cost) = tool.cost() {
                     ui.separator();


### PR DESCRIPTION
## Summary
- **Tab** cycles forward through data overlays (None -> Power -> Water -> Traffic -> Pollution -> Land Value -> Education -> Garbage -> Noise -> Water Pollution -> None)
- **Shift+Tab** cycles backward through the same sequence
- Current overlay name is displayed in the top status bar when an overlay is active
- Added `next()`, `prev()`, and `label()` methods to `OverlayMode`
- Includes unit tests for forward cycling, backward cycling, round-trip identity, and label coverage

Closes #903

## Test plan
- [ ] Press Tab repeatedly: overlays cycle forward through all 10 modes and wrap back to None
- [ ] Press Shift+Tab repeatedly: overlays cycle backward and wrap correctly
- [ ] When an overlay is active, the top status bar shows "Overlay: <name>" in blue text
- [ ] When overlay is None, no overlay label is shown in the status bar
- [ ] Existing letter-key overlay toggles (P, O, T, N, L, E, G, M, U) continue to work
- [ ] `cargo test --workspace` passes (4 new unit tests in `rendering::overlay::tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)