### PR TITLE
Add seasonal and weather tourism modifiers (WEATHER-004)

### DIFF
--- a/crates/simulation/src/tourism.rs
+++ b/crates/simulation/src/tourism.rs
@@ -187,8 +187,7 @@ mod tests {
     fn test_weather_multipliers() {
         assert!((weather_tourism_multiplier(WeatherCondition::Sunny) - 1.2).abs() < f32::EPSILON);
         assert!(
-            (weather_tourism_multiplier(WeatherCondition::PartlyCloudy) - 1.0).abs()
-                < f32::EPSILON
+            (weather_tourism_multiplier(WeatherCondition::PartlyCloudy) - 1.0).abs() < f32::EPSILON
         );
         assert!(
             (weather_tourism_multiplier(WeatherCondition::Overcast) - 0.8).abs() < f32::EPSILON


### PR DESCRIPTION
## Summary
- Add `tourism_seasonal_modifier(season, weather)` combining seasonal and weather condition multipliers
- Seasonal base: Summer=1.5x, Spring=1.2x, Autumn=1.1x, Winter=0.6x
- Weather condition: Sunny=1.2x, PartlyCloudy=1.0x, Overcast=0.8x, Rain/HeavyRain=0.5x, Snow=0.7x, Storm=0.2x
- Extreme temperature (>35C or <-5C) overrides weather multiplier to 0.1x
- Combined modifier applied to tourist arrival rate in `update_tourism` system
- Weather-related tourism events: Festival (sunny Spring/Summer) and Closure (storm/extreme)

Closes #975

## Test plan
- [x] Unit test: summer + sunny = 1.5 * 1.2 = 1.8x tourism
- [x] Unit test: winter + storm = 0.6 * 0.2 = 0.12x tourism
- [x] Unit test: extreme heat/cold applies 0.1x weather multiplier
- [x] Unit test: all seasonal and weather condition multiplier values
- [x] Unit test: tourism weather events (festival/closure logic)
- [x] Integration test: summer tourism modifier > winter tourism modifier
- [ ] Verify CI: cargo build/test/clippy/fmt all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)