### PR TITLE
Add floor area ratio (FAR) controls per zone (ZONE-005)

### DIFF
--- a/crates/simulation/src/building_upgrade.rs
+++ b/crates/simulation/src/building_upgrade.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use crate::buildings::{Building, MixedUseBuilding};
+use crate::buildings::{max_level_for_far, Building, MixedUseBuilding};
 use crate::stats::CityStats;
 
 const UPGRADE_INTERVAL: u32 = 30; // sim ticks between upgrade checks
@@ -33,7 +33,8 @@ pub fn upgrade_buildings(
             break;
         }
 
-        let max_level = building.zone_type.max_level().min(policy_max);
+        let far_cap = max_level_for_far(building.zone_type) as u8;
+        let max_level = building.zone_type.max_level().min(policy_max).min(far_cap);
         if building.level >= max_level {
             continue;
         }

--- a/crates/simulation/src/grid.rs
+++ b/crates/simulation/src/grid.rs
@@ -132,6 +132,22 @@ impl ZoneType {
             ZoneType::None => 0,
         }
     }
+
+    /// Returns the default Floor Area Ratio (FAR) limit for this zone type.
+    /// FAR = total floor area / lot area. Higher values allow denser buildings.
+    pub fn default_far(self) -> f32 {
+        match self {
+            ZoneType::ResidentialLow => 0.5,
+            ZoneType::ResidentialMedium => 1.5,
+            ZoneType::ResidentialHigh => 3.0,
+            ZoneType::CommercialLow => 1.5,
+            ZoneType::CommercialHigh => 3.0,
+            ZoneType::Industrial => 0.8,
+            ZoneType::Office => 1.5,
+            ZoneType::MixedUse => 3.0,
+            ZoneType::None => 0.0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -286,5 +302,23 @@ mod tests {
         assert!(mu.is_mixed_use());
         assert!(mu.is_job_zone());
         assert_eq!(mu.max_level(), 5);
+    }
+
+    #[test]
+    fn test_default_far_values() {
+        assert_eq!(ZoneType::ResidentialLow.default_far(), 0.5);
+        assert_eq!(ZoneType::ResidentialMedium.default_far(), 1.5);
+        assert_eq!(ZoneType::ResidentialHigh.default_far(), 3.0);
+        assert_eq!(ZoneType::CommercialLow.default_far(), 1.5);
+        assert_eq!(ZoneType::CommercialHigh.default_far(), 3.0);
+        assert_eq!(ZoneType::Industrial.default_far(), 0.8);
+        assert_eq!(ZoneType::Office.default_far(), 1.5);
+        assert_eq!(ZoneType::MixedUse.default_far(), 3.0);
+        assert_eq!(ZoneType::None.default_far(), 0.0);
+    }
+
+    #[test]
+    fn test_none_zone_far_is_zero() {
+        assert_eq!(ZoneType::None.default_far(), 0.0);
     }
 }


### PR DESCRIPTION
## Summary
- Add `default_far()` method to `ZoneType` with per-zone FAR limits (R-Low=0.5, R-Med=1.5, R-High=3.0, C-Low=1.5, C-High=3.0, Industrial=0.8, Office=1.5, MixedUse=3.0)
- Add `max_level_for_far()` function that constrains building levels based on FAR: computes `implied_far = (capacity * 20.0) / 256.0` for each level and returns the highest level within the FAR limit (minimum 1)
- Building spawner caps initial level at `max_level_for_far` limit
- Building upgrade system includes FAR cap alongside zone max_level and policy max

Closes #996

## Test plan
- [x] Unit test: `test_far_residential_low_limits_level` - ResidentialLow FAR limits building to low levels
- [x] Unit test: `test_far_residential_high_allows_higher_levels` - ResidentialHigh FAR allows higher levels than ResidentialLow
- [x] Unit test: `test_far_returns_at_least_one` - all zone types return at least level 1
- [x] Unit test: `test_far_respects_zone_max_level` - FAR limit never exceeds zone max_level
- [x] Unit test: `test_default_far_values` - all FAR values match spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)