### PR TITLE
Add urban heat island (UHI) temperature grid (WEATHER-008)

### DIFF
--- a/crates/save/src/lib.rs
+++ b/crates/save/src/lib.rs
@@ -13,9 +13,9 @@ use serialization::{
     create_save_data, migrate_save, restore_climate_zone, restore_construction_modifiers,
     restore_degree_days, restore_extended_budget, restore_life_sim_timer, restore_lifecycle_timer,
     restore_loan_book, restore_policies, restore_road_segment_store, restore_stormwater_grid,
-    restore_unlock_state, restore_virtual_population, restore_water_source, restore_weather,
-    u8_to_road_type, u8_to_service_type, u8_to_utility_type, u8_to_zone_type, CitizenSaveInput,
-    SaveData, CURRENT_SAVE_VERSION,
+    restore_uhi_grid, restore_unlock_state, restore_virtual_population, restore_water_source,
+    restore_weather, u8_to_road_type, u8_to_service_type, u8_to_utility_type, u8_to_zone_type,
+    CitizenSaveInput, SaveData, CURRENT_SAVE_VERSION,
 };
 use simulation::budget::ExtendedBudget;
 use simulation::buildings::{Building, MixedUseBuilding};
@@ -38,6 +38,7 @@ use simulation::services::ServiceBuilding;
 use simulation::stormwater::StormwaterGrid;
 use simulation::time_of_day::GameClock;
 use simulation::unlocks::UnlockState;
+use simulation::urban_heat_island::UhiGrid;
 use simulation::utilities::UtilitySource;
 use simulation::virtual_population::VirtualPopulation;
 use simulation::water_sources::WaterSource;
@@ -167,6 +168,7 @@ fn handle_save(
             Some(&v2.degree_days),
             Some(&v2.climate_zone),
             Some(&v2.construction_modifiers),
+            Some(&v2.uhi_grid),
         );
 
         let bytes = save.encode();
@@ -588,6 +590,14 @@ fn handle_load(
             *v2.construction_modifiers = ConstructionModifiers::default();
         }
 
+        // Restore UHI grid (recomputed every 30 ticks, but persisting
+        // avoids a cold-start with all zeros after load).
+        if let Some(ref saved_uhi) = save.uhi_grid {
+            *v2.uhi_grid = restore_uhi_grid(saved_uhi);
+        } else {
+            *v2.uhi_grid = UhiGrid::default();
+        }
+
         println!("Loaded save from {}", path);
     }
 }
@@ -665,6 +675,7 @@ fn handle_new_game(
         *v2.stormwater_grid = StormwaterGrid::default();
         *v2.degree_days = DegreeDays::default();
         *v2.construction_modifiers = ConstructionModifiers::default();
+        *v2.uhi_grid = UhiGrid::default();
 
         // Generate a flat terrain with water on west edge (simple starter map)
         for y in 0..height {

--- a/crates/save/src/save_helpers.rs
+++ b/crates/save/src/save_helpers.rs
@@ -12,10 +12,11 @@ use simulation::loans::LoanBook;
 use simulation::policies::Policies;
 use simulation::stormwater::StormwaterGrid;
 use simulation::unlocks::UnlockState;
+use simulation::urban_heat_island::UhiGrid;
 use simulation::virtual_population::VirtualPopulation;
 use simulation::weather::{ClimateZone, ConstructionModifiers, Weather};
 
-/// Read-only access to the V2+ resources (policies, weather, unlocks, ext budget, loans, virtual pop, life sim timer, stormwater, degree days, climate zone, construction modifiers).
+/// Read-only access to the V2+ resources (policies, weather, unlocks, ext budget, loans, virtual pop, life sim timer, stormwater, degree days, climate zone, construction modifiers, uhi grid).
 #[derive(SystemParam)]
 pub(crate) struct V2ResourcesRead<'w> {
     pub policies: Res<'w, Policies>,
@@ -29,6 +30,7 @@ pub(crate) struct V2ResourcesRead<'w> {
     pub degree_days: Res<'w, DegreeDays>,
     pub climate_zone: Res<'w, ClimateZone>,
     pub construction_modifiers: Res<'w, ConstructionModifiers>,
+    pub uhi_grid: Res<'w, UhiGrid>,
 }
 
 /// Mutable access to the V2+ resources.
@@ -45,4 +47,5 @@ pub(crate) struct V2ResourcesWrite<'w> {
     pub degree_days: ResMut<'w, DegreeDays>,
     pub climate_zone: ResMut<'w, ClimateZone>,
     pub construction_modifiers: ResMut<'w, ConstructionModifiers>,
+    pub uhi_grid: ResMut<'w, UhiGrid>,
 }

--- a/crates/save/src/save_migrate.rs
+++ b/crates/save/src/save_migrate.rs
@@ -73,6 +73,12 @@ pub fn migrate_save(save: &mut SaveData) -> u32 {
         save.version = 9;
     }
 
+    // v9 -> v10: Added uhi_grid (Urban Heat Island grid serialization).
+    // Uses `#[serde(default)]` so it deserializes as None from a v9 save.
+    if save.version == 9 {
+        save.version = 10;
+    }
+
     // Ensure version is at the current value (safety net for future additions).
     debug_assert_eq!(save.version, CURRENT_SAVE_VERSION);
 

--- a/crates/save/src/save_restore.rs
+++ b/crates/save/src/save_restore.rs
@@ -16,6 +16,7 @@ use simulation::road_segments::{
 };
 use simulation::stormwater::StormwaterGrid;
 use simulation::unlocks::UnlockState;
+use simulation::urban_heat_island::UhiGrid;
 use simulation::virtual_population::{DistrictStats, VirtualPopulation};
 use simulation::water_sources::WaterSource;
 use simulation::weather::{ClimateZone, ConstructionModifiers, Weather};
@@ -216,6 +217,15 @@ pub fn restore_construction_modifiers(save: &SaveConstructionModifiers) -> Const
     ConstructionModifiers {
         speed_factor: save.speed_factor,
         cost_factor: save.cost_factor,
+    }
+}
+
+/// Restore a `UhiGrid` resource from saved data.
+pub fn restore_uhi_grid(save: &SaveUhiGrid) -> UhiGrid {
+    UhiGrid {
+        cells: save.cells.clone(),
+        width: save.width,
+        height: save.height,
     }
 }
 

--- a/crates/save/src/save_types.rs
+++ b/crates/save/src/save_types.rs
@@ -21,7 +21,8 @@ use simulation::citizen::{CitizenDetails, CitizenState, PathCache, Position, Vel
 /// v7 = degree_days (HDD/CDD tracking for HVAC energy demand)
 /// v8 = climate_zone in SaveWeather (ClimateZone resource)
 /// v9 = construction_modifiers (ConstructionModifiers serialization)
-pub const CURRENT_SAVE_VERSION: u32 = 9;
+/// v10 = uhi_grid (Urban Heat Island grid serialization)
+pub const CURRENT_SAVE_VERSION: u32 = 10;
 
 // ---------------------------------------------------------------------------
 // Save structs
@@ -98,6 +99,8 @@ pub struct SaveData {
     pub degree_days: Option<SaveDegreeDays>,
     #[serde(default)]
     pub construction_modifiers: Option<SaveConstructionModifiers>,
+    #[serde(default)]
+    pub uhi_grid: Option<SaveUhiGrid>,
 }
 
 #[derive(Serialize, Deserialize, Encode, Decode)]
@@ -360,6 +363,13 @@ pub struct SaveDegreeDays {
 pub struct SaveConstructionModifiers {
     pub speed_factor: f32,
     pub cost_factor: f32,
+}
+
+#[derive(Serialize, Deserialize, Encode, Decode, Default)]
+pub struct SaveUhiGrid {
+    pub cells: Vec<f32>,
+    pub width: usize,
+    pub height: usize,
 }
 
 #[derive(Serialize, Deserialize, Encode, Decode, Default)]

--- a/crates/save/src/serialization.rs
+++ b/crates/save/src/serialization.rs
@@ -22,6 +22,7 @@ use simulation::services::ServiceBuilding;
 use simulation::stormwater::StormwaterGrid;
 use simulation::time_of_day::GameClock;
 use simulation::unlocks::UnlockState;
+use simulation::urban_heat_island::UhiGrid;
 use simulation::utilities::UtilitySource;
 use simulation::virtual_population::VirtualPopulation;
 use simulation::water_sources::WaterSource;
@@ -56,6 +57,7 @@ pub fn create_save_data(
     degree_days: Option<&DegreeDays>,
     climate_zone: Option<&ClimateZone>,
     construction_modifiers: Option<&ConstructionModifiers>,
+    uhi_grid: Option<&UhiGrid>,
 ) -> SaveData {
     let save_cells: Vec<SaveCell> = grid
         .cells
@@ -320,6 +322,11 @@ pub fn create_save_data(
             speed_factor: cm.speed_factor,
             cost_factor: cm.cost_factor,
         }),
+        uhi_grid: uhi_grid.map(|u| SaveUhiGrid {
+            cells: u.cells.clone(),
+            width: u.width,
+            height: u.height,
+        }),
     }
 }
 
@@ -389,6 +396,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let bytes = save.encode();
         let restored = SaveData::decode(&bytes).expect("decode should succeed");
@@ -422,6 +430,7 @@ mod tests {
         assert!(restored.degree_days.is_none());
         assert!(restored.water_sources.is_none());
         assert!(restored.construction_modifiers.is_none());
+        assert!(restored.uhi_grid.is_none());
     }
 
     #[test]
@@ -725,6 +734,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -801,6 +811,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let bytes = save.encode();
         let restored = SaveData::decode(&bytes).expect("decode v1 should succeed");
@@ -818,6 +829,7 @@ mod tests {
         assert!(restored.degree_days.is_none());
         assert!(restored.water_sources.is_none());
         assert!(restored.construction_modifiers.is_none());
+        assert!(restored.uhi_grid.is_none());
     }
 
     #[test]
@@ -874,6 +886,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
@@ -898,6 +911,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -953,6 +967,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
@@ -980,6 +995,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1034,6 +1050,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         save.version = 1;
 
@@ -1061,6 +1078,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1205,6 +1223,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let bytes = save.encode();
         let restored = SaveData::decode(&bytes).expect("decode should succeed");
@@ -1247,6 +1266,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1365,6 +1385,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1417,6 +1438,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1443,6 +1465,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1534,6 +1557,7 @@ mod tests {
             None,
             None,
             Some(&water_sources),
+            None,
             None,
             None,
             None,
@@ -1658,6 +1682,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1685,6 +1710,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1731,6 +1757,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1792,6 +1819,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1831,6 +1859,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1929,6 +1958,7 @@ mod tests {
             None,
             Some(&climate_zone),
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1981,6 +2011,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1988,6 +2019,7 @@ mod tests {
         assert!(restored.stormwater_grid.is_none());
         // When construction_modifiers is None, the restore uses default
         assert!(restored.construction_modifiers.is_none());
+        assert!(restored.uhi_grid.is_none());
     }
 
     #[test]
@@ -2018,6 +2050,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -13,6 +13,7 @@ rand = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+serde_json = "1"
 
 [[bench]]
 name = "city_perf"

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -61,6 +61,7 @@ pub mod traffic;
 pub mod traffic_accidents;
 pub mod trees;
 pub mod unlocks;
+pub mod urban_heat_island;
 pub mod utilities;
 pub mod virtual_population;
 pub mod waste_composition;
@@ -123,6 +124,7 @@ use traffic::TrafficGrid;
 use traffic_accidents::AccidentTracker;
 use trees::TreeGrid;
 use unlocks::UnlockState;
+use urban_heat_island::UhiGrid;
 use virtual_population::VirtualPopulation;
 use waste_effects::{WasteAccumulation, WasteCrisisEvent};
 use water_demand::WaterSupply;
@@ -242,6 +244,7 @@ impl Plugin for SimulationPlugin {
             .init_resource::<StormwaterGrid>()
             .init_resource::<DegreeDays>()
             .init_resource::<ConstructionModifiers>()
+            .init_resource::<UhiGrid>()
             .init_resource::<WasteAccumulation>()
             .add_event::<BankruptcyEvent>()
             .add_event::<WeatherChangeEvent>()
@@ -363,6 +366,7 @@ impl Plugin for SimulationPlugin {
                     groundwater::update_groundwater,
                     groundwater::groundwater_health_penalty,
                     stormwater::update_stormwater,
+                    urban_heat_island::update_uhi_grid,
                     water_demand::calculate_building_water_demand,
                     water_demand::aggregate_water_supply,
                 )

--- a/crates/simulation/src/urban_heat_island.rs
+++ b/crates/simulation/src/urban_heat_island.rs
@@ -1,0 +1,645 @@
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::buildings::Building;
+// Urban Heat Island (UHI) temperature grid model
+use crate::config::{GRID_HEIGHT, GRID_WIDTH};
+use crate::grid::{CellType, WorldGrid, ZoneType};
+use crate::time_of_day::GameClock;
+use crate::trees::TreeGrid;
+use crate::weather::Weather;
+use crate::TickCounter;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// UHI update frequency in simulation ticks.
+const UHI_UPDATE_INTERVAL: u64 = 30;
+
+/// Rural baseline green fraction (fraction of cells that are vegetated in
+/// undeveloped areas).  The deficit between actual local green fraction and
+/// this baseline drives the vegetation-deficit UHI contribution.
+const RURAL_GREEN_BASELINE: f32 = 0.6;
+
+/// Maximum vegetation-deficit contribution in degrees Fahrenheit.
+const VEGETATION_DEFICIT_SCALE: f32 = 8.0;
+
+/// Canyon-effect scale: building levels (stories) above 4 contribute to UHI
+/// proportional to a height-to-width ratio approximation.
+const CANYON_STORIES_THRESHOLD: u8 = 4;
+const CANYON_EFFECT_SCALE: f32 = 1.5;
+
+/// Nighttime amplification factor (UHI is doubled at night).
+const NIGHTTIME_AMPLIFICATION: f32 = 2.0;
+
+/// Hours considered nighttime for UHI amplification.
+/// Night: 20:00 - 05:59 (inclusive).
+const NIGHT_START_HOUR: u32 = 20;
+const NIGHT_END_HOUR: u32 = 5;
+
+// ---------------------------------------------------------------------------
+// Surface heat factors (Fahrenheit)
+// ---------------------------------------------------------------------------
+
+/// Asphalt / dark roof surface heat factor.
+const SURFACE_ASPHALT: f32 = 2.0;
+/// Concrete surface heat factor.
+const SURFACE_CONCRETE: f32 = 1.5;
+/// Light roof surface heat factor.
+const SURFACE_LIGHT_ROOF: f32 = 0.5;
+/// Water surface heat factor (strong cooling).
+const SURFACE_WATER: f32 = -2.0;
+/// Vegetation surface heat factor (cooling).
+const SURFACE_VEGETATION: f32 = -1.5;
+
+// ---------------------------------------------------------------------------
+// UhiGrid resource
+// ---------------------------------------------------------------------------
+
+/// Per-cell temperature increment grid (in Fahrenheit). A positive value means
+/// the cell is warmer than the rural baseline; negative values indicate cooling
+/// (e.g. parks, water).
+///
+/// The final effective temperature for any cell is:
+///   `base_weather_temperature + uhi_grid.cells[idx]`
+#[derive(Resource, Serialize, Deserialize)]
+pub struct UhiGrid {
+    pub cells: Vec<f32>,
+    pub width: usize,
+    pub height: usize,
+}
+
+impl Default for UhiGrid {
+    fn default() -> Self {
+        Self {
+            cells: vec![0.0; GRID_WIDTH * GRID_HEIGHT],
+            width: GRID_WIDTH,
+            height: GRID_HEIGHT,
+        }
+    }
+}
+
+impl UhiGrid {
+    #[inline]
+    pub fn get(&self, x: usize, y: usize) -> f32 {
+        if x < self.width && y < self.height {
+            self.cells[y * self.width + x]
+        } else {
+            0.0
+        }
+    }
+
+    #[inline]
+    pub fn set(&mut self, x: usize, y: usize, val: f32) {
+        if x < self.width && y < self.height {
+            self.cells[y * self.width + x] = val;
+        }
+    }
+
+    /// Compute the effective temperature at a specific cell by adding the UHI
+    /// increment to the base weather temperature.
+    pub fn effective_temperature(&self, base_temp: f32, x: usize, y: usize) -> f32 {
+        base_temp + self.get(x, y)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: effective temperature (standalone for external callers)
+// ---------------------------------------------------------------------------
+
+/// Convenience function returning the final cell temperature given the base
+/// weather temperature and the UHI grid value at `(x, y)`.
+pub fn effective_temperature(uhi: &UhiGrid, base_temp: f32, x: usize, y: usize) -> f32 {
+    uhi.effective_temperature(base_temp, x, y)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when the given hour of day is considered nighttime for UHI
+/// amplification purposes.
+fn is_nighttime(hour: u32) -> bool {
+    hour >= NIGHT_START_HOUR || hour <= NIGHT_END_HOUR
+}
+
+/// Compute the surface heat factor for a cell based on its type, zone, and
+/// tree coverage.
+fn surface_heat_factor(cell_type: CellType, zone: ZoneType, has_tree: bool) -> f32 {
+    match cell_type {
+        CellType::Water => SURFACE_WATER,
+        CellType::Road => SURFACE_ASPHALT,
+        CellType::Grass => {
+            if has_tree {
+                SURFACE_VEGETATION
+            } else {
+                match zone {
+                    // Buildings with different roof types based on zone density.
+                    ZoneType::Industrial => SURFACE_ASPHALT, // dark roofs
+                    ZoneType::ResidentialHigh
+                    | ZoneType::CommercialHigh
+                    | ZoneType::Office
+                    | ZoneType::MixedUse => SURFACE_CONCRETE, // concrete/mixed
+                    ZoneType::ResidentialLow | ZoneType::CommercialLow => SURFACE_LIGHT_ROOF,
+                    ZoneType::ResidentialMedium => SURFACE_CONCRETE,
+                    ZoneType::None => {
+                        // Undeveloped grass -- slightly negative (vegetation)
+                        SURFACE_VEGETATION
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Compute the local green fraction in a 5x5 neighborhood centered on `(cx, cy)`.
+/// Green cells include trees and undeveloped grass (no building, no road).
+fn local_green_fraction(grid: &WorldGrid, tree_grid: &TreeGrid, cx: usize, cy: usize) -> f32 {
+    let mut green_count: u32 = 0;
+    let mut total: u32 = 0;
+
+    let radius = 2i32; // 5x5 neighbourhood
+    for dy in -radius..=radius {
+        for dx in -radius..=radius {
+            let nx = cx as i32 + dx;
+            let ny = cy as i32 + dy;
+            if nx < 0 || ny < 0 || (nx as usize) >= GRID_WIDTH || (ny as usize) >= GRID_HEIGHT {
+                continue;
+            }
+            let ux = nx as usize;
+            let uy = ny as usize;
+            total += 1;
+
+            let cell = grid.get(ux, uy);
+            if tree_grid.has_tree(ux, uy)
+                || (cell.cell_type == CellType::Grass
+                    && cell.zone == ZoneType::None
+                    && cell.building_id.is_none())
+                || cell.cell_type == CellType::Water
+            {
+                green_count += 1;
+            }
+        }
+    }
+
+    if total == 0 {
+        0.0
+    } else {
+        green_count as f32 / total as f32
+    }
+}
+
+// ---------------------------------------------------------------------------
+// System
+// ---------------------------------------------------------------------------
+
+/// Recomputes the UHI grid every `UHI_UPDATE_INTERVAL` ticks.
+///
+/// Contributions per cell:
+/// 1. **Surface type** -- roads=asphalt, industrial=dark roof, etc.
+/// 2. **Vegetation deficit** -- comparison of local green fraction to rural
+///    baseline; deficit * 8.0 F.
+/// 3. **Waste heat** -- proportional to building occupancy (energy demand proxy).
+/// 4. **Canyon effect** -- buildings > 4 stories add `(levels - 4) * 1.5 F`.
+/// 5. **Nighttime amplification** -- UHI *= 2.0 between 20:00 and 05:59.
+/// 6. **3x3 smoothing** -- averages each cell with its 3x3 neighbors.
+#[allow(clippy::too_many_arguments)]
+pub fn update_uhi_grid(
+    tick: Res<TickCounter>,
+    mut uhi: ResMut<UhiGrid>,
+    grid: Res<WorldGrid>,
+    tree_grid: Res<TreeGrid>,
+    clock: Res<GameClock>,
+    _weather: Res<Weather>,
+    buildings: Query<&Building>,
+) {
+    if !tick.0.is_multiple_of(UHI_UPDATE_INTERVAL) {
+        return;
+    }
+
+    let width = GRID_WIDTH;
+    let height = GRID_HEIGHT;
+    let total = width * height;
+
+    // --- Phase 0: Build a lookup of building levels per cell ---
+    // Also accumulate per-cell occupants for waste-heat contribution.
+    let mut building_levels: Vec<u8> = vec![0; total];
+    let mut building_occupants: Vec<u32> = vec![0; total];
+    for building in &buildings {
+        let bx = building.grid_x;
+        let by = building.grid_y;
+        if bx < width && by < height {
+            let idx = by * width + bx;
+            building_levels[idx] = building.level;
+            building_occupants[idx] = building.occupants;
+        }
+    }
+
+    // --- Phase 1: Raw UHI contribution per cell ---
+    let mut raw: Vec<f32> = vec![0.0; total];
+
+    for y in 0..height {
+        for x in 0..width {
+            let idx = y * width + x;
+            let cell = grid.get(x, y);
+            let has_tree = tree_grid.has_tree(x, y);
+
+            // 1. Surface heat factor
+            let surface = if cell.building_id.is_some() {
+                // Cell has a building -- use building zone for roof type
+                surface_heat_factor(CellType::Grass, cell.zone, has_tree)
+            } else {
+                surface_heat_factor(cell.cell_type, cell.zone, has_tree)
+            };
+
+            // 2. Vegetation deficit
+            let green_frac = local_green_fraction(&grid, &tree_grid, x, y);
+            let veg_deficit = (RURAL_GREEN_BASELINE - green_frac).max(0.0);
+            let veg_contribution = veg_deficit * VEGETATION_DEFICIT_SCALE;
+
+            // 3. Waste heat (proportional to occupancy as energy demand proxy)
+            // Each 100 occupants contributes ~0.5 F.
+            let waste_heat = building_occupants[idx] as f32 * 0.005;
+
+            // 4. Canyon effect
+            let levels = building_levels[idx];
+            let canyon = if levels > CANYON_STORIES_THRESHOLD {
+                (levels - CANYON_STORIES_THRESHOLD) as f32 * CANYON_EFFECT_SCALE
+            } else {
+                0.0
+            };
+
+            raw[idx] = surface + veg_contribution + waste_heat + canyon;
+        }
+    }
+
+    // --- Phase 2: Nighttime amplification ---
+    let hour = clock.hour_of_day();
+    if is_nighttime(hour) {
+        for val in raw.iter_mut() {
+            // Only amplify positive (warming) contributions; negative values
+            // (water, vegetation) stay as-is to preserve cooling at night.
+            if *val > 0.0 {
+                *val *= NIGHTTIME_AMPLIFICATION;
+            }
+        }
+    }
+
+    // --- Phase 3: 3x3 smoothing ---
+    let mut smoothed: Vec<f32> = vec![0.0; total];
+    for y in 0..height {
+        for x in 0..width {
+            let mut sum: f32 = 0.0;
+            let mut count: u32 = 0;
+            for dy in -1i32..=1 {
+                for dx in -1i32..=1 {
+                    let nx = x as i32 + dx;
+                    let ny = y as i32 + dy;
+                    if nx >= 0 && ny >= 0 && (nx as usize) < width && (ny as usize) < height {
+                        sum += raw[ny as usize * width + nx as usize];
+                        count += 1;
+                    }
+                }
+            }
+            smoothed[y * width + x] = sum / count as f32;
+        }
+    }
+
+    uhi.cells = smoothed;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grid::{Cell, CellType, WorldGrid, ZoneType};
+
+    #[test]
+    fn test_uhi_grid_default() {
+        let grid = UhiGrid::default();
+        assert_eq!(grid.cells.len(), GRID_WIDTH * GRID_HEIGHT);
+        assert!((grid.get(0, 0)).abs() < f32::EPSILON);
+        assert!((grid.get(128, 128)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_uhi_grid_get_set() {
+        let mut grid = UhiGrid::default();
+        grid.set(10, 20, 3.5);
+        assert!((grid.get(10, 20) - 3.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_uhi_grid_out_of_bounds() {
+        let grid = UhiGrid::default();
+        assert!((grid.get(9999, 9999)).abs() < f32::EPSILON);
+
+        let mut grid2 = UhiGrid::default();
+        grid2.set(9999, 9999, 10.0); // should not panic
+    }
+
+    #[test]
+    fn test_effective_temperature() {
+        let mut grid = UhiGrid::default();
+        grid.set(5, 5, 4.0);
+        let eff = grid.effective_temperature(70.0, 5, 5);
+        assert!((eff - 74.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_effective_temperature_standalone() {
+        let mut grid = UhiGrid::default();
+        grid.set(3, 3, -2.0);
+        let eff = effective_temperature(&grid, 70.0, 3, 3);
+        assert!((eff - 68.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_is_nighttime() {
+        assert!(is_nighttime(20));
+        assert!(is_nighttime(23));
+        assert!(is_nighttime(0));
+        assert!(is_nighttime(3));
+        assert!(is_nighttime(5));
+        assert!(!is_nighttime(6));
+        assert!(!is_nighttime(12));
+        assert!(!is_nighttime(19));
+    }
+
+    #[test]
+    fn test_surface_heat_factor_road() {
+        let factor = surface_heat_factor(CellType::Road, ZoneType::None, false);
+        assert!((factor - SURFACE_ASPHALT).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_surface_heat_factor_water() {
+        let factor = surface_heat_factor(CellType::Water, ZoneType::None, false);
+        assert!((factor - SURFACE_WATER).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_surface_heat_factor_vegetation() {
+        // Undeveloped grass with tree
+        let factor = surface_heat_factor(CellType::Grass, ZoneType::None, true);
+        assert!((factor - SURFACE_VEGETATION).abs() < f32::EPSILON);
+
+        // Undeveloped grass without tree (also vegetation)
+        let factor2 = surface_heat_factor(CellType::Grass, ZoneType::None, false);
+        assert!((factor2 - SURFACE_VEGETATION).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_surface_heat_factor_industrial_dark_roof() {
+        let factor = surface_heat_factor(CellType::Grass, ZoneType::Industrial, false);
+        assert!((factor - SURFACE_ASPHALT).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_surface_heat_factor_light_roof() {
+        let factor = surface_heat_factor(CellType::Grass, ZoneType::ResidentialLow, false);
+        assert!((factor - SURFACE_LIGHT_ROOF).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_surface_heat_factor_concrete_roof() {
+        let factor = surface_heat_factor(CellType::Grass, ZoneType::ResidentialHigh, false);
+        assert!((factor - SURFACE_CONCRETE).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_surface_heat_factor_tree_overrides_zone() {
+        // A tree on an industrial cell should still count as vegetation
+        let factor = surface_heat_factor(CellType::Grass, ZoneType::Industrial, true);
+        assert!((factor - SURFACE_VEGETATION).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_local_green_fraction_all_green() {
+        // An empty world grid with all grass, no buildings, no roads -> fully green
+        let world = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+        let trees = TreeGrid::default();
+        let frac = local_green_fraction(&world, &trees, 128, 128);
+        assert!(
+            (frac - 1.0).abs() < 0.01,
+            "fully undeveloped should be ~1.0 green, got {}",
+            frac
+        );
+    }
+
+    #[test]
+    fn test_local_green_fraction_all_road() {
+        let mut world = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+        // Fill a 5x5 area with roads
+        for dy in -2i32..=2 {
+            for dx in -2i32..=2 {
+                let nx = (50i32 + dx) as usize;
+                let ny = (50i32 + dy) as usize;
+                world.get_mut(nx, ny).cell_type = CellType::Road;
+            }
+        }
+        let trees = TreeGrid::default();
+        let frac = local_green_fraction(&world, &trees, 50, 50);
+        assert!(
+            frac < 0.01,
+            "all-road area should be ~0.0 green, got {}",
+            frac
+        );
+    }
+
+    #[test]
+    fn test_local_green_fraction_mixed() {
+        let mut world = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+        // Center cell (50, 50) and neighbors: half are roads
+        let mut count = 0;
+        for dy in -2i32..=2 {
+            for dx in -2i32..=2 {
+                let nx = (50i32 + dx) as usize;
+                let ny = (50i32 + dy) as usize;
+                if count % 2 == 0 {
+                    world.get_mut(nx, ny).cell_type = CellType::Road;
+                }
+                count += 1;
+            }
+        }
+        let trees = TreeGrid::default();
+        let frac = local_green_fraction(&world, &trees, 50, 50);
+        // About half should be green (undeveloped grass)
+        assert!(
+            frac > 0.3 && frac < 0.7,
+            "half-road area should be ~0.5 green, got {}",
+            frac
+        );
+    }
+
+    #[test]
+    fn test_vegetation_deficit_drives_uhi() {
+        // In a fully developed area (green_frac = 0.0):
+        //   deficit = 0.6 - 0.0 = 0.6
+        //   contribution = 0.6 * 8.0 = 4.8 F
+        let deficit = (RURAL_GREEN_BASELINE - 0.0).max(0.0);
+        let contribution = deficit * VEGETATION_DEFICIT_SCALE;
+        assert!((contribution - 4.8).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_vegetation_no_deficit_when_green() {
+        // In a fully green area (green_frac = 1.0):
+        //   deficit = (0.6 - 1.0).max(0.0) = 0.0
+        let deficit = (RURAL_GREEN_BASELINE - 1.0).max(0.0);
+        assert!(deficit.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_canyon_effect_low_building() {
+        // Building with 3 stories (below threshold): no canyon effect
+        let levels: u8 = 3;
+        let canyon = if levels > CANYON_STORIES_THRESHOLD {
+            (levels - CANYON_STORIES_THRESHOLD) as f32 * CANYON_EFFECT_SCALE
+        } else {
+            0.0
+        };
+        assert!(canyon.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_canyon_effect_tall_building() {
+        // Building with 5 stories: (5 - 4) * 1.5 = 1.5 F
+        let levels: u8 = 5;
+        let canyon = if levels > CANYON_STORIES_THRESHOLD {
+            (levels - CANYON_STORIES_THRESHOLD) as f32 * CANYON_EFFECT_SCALE
+        } else {
+            0.0
+        };
+        assert!((canyon - 1.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_nighttime_amplification_positive_only() {
+        // Positive value should be doubled at night
+        let mut val = 3.0_f32;
+        if val > 0.0 {
+            val *= NIGHTTIME_AMPLIFICATION;
+        }
+        assert!((val - 6.0).abs() < f32::EPSILON);
+
+        // Negative value should NOT be doubled
+        let mut neg = -1.5_f32;
+        if neg > 0.0 {
+            neg *= NIGHTTIME_AMPLIFICATION;
+        }
+        assert!((neg - (-1.5)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_smoothing_uniform_field() {
+        // If all raw values are the same, smoothing should not change them
+        let val = 5.0_f32;
+        let width = 4;
+        let height = 4;
+        let raw = vec![val; width * height];
+        let mut smoothed = vec![0.0_f32; width * height];
+        for y in 0..height {
+            for x in 0..width {
+                let mut sum: f32 = 0.0;
+                let mut count: u32 = 0;
+                for dy in -1i32..=1 {
+                    for dx in -1i32..=1 {
+                        let nx = x as i32 + dx;
+                        let ny = y as i32 + dy;
+                        if nx >= 0 && ny >= 0 && (nx as usize) < width && (ny as usize) < height {
+                            sum += raw[ny as usize * width + nx as usize];
+                            count += 1;
+                        }
+                    }
+                }
+                smoothed[y * width + x] = sum / count as f32;
+            }
+        }
+        for v in &smoothed {
+            assert!(
+                (*v - val).abs() < f32::EPSILON,
+                "uniform smoothing should preserve value"
+            );
+        }
+    }
+
+    #[test]
+    fn test_smoothing_reduces_spike() {
+        // A single spike at the center of a zero field should be reduced
+        let width = 5;
+        let height = 5;
+        let mut raw = vec![0.0_f32; width * height];
+        raw[2 * width + 2] = 9.0; // spike at center
+
+        let mut smoothed = vec![0.0_f32; width * height];
+        for y in 0..height {
+            for x in 0..width {
+                let mut sum: f32 = 0.0;
+                let mut count: u32 = 0;
+                for dy in -1i32..=1 {
+                    for dx in -1i32..=1 {
+                        let nx = x as i32 + dx;
+                        let ny = y as i32 + dy;
+                        if nx >= 0 && ny >= 0 && (nx as usize) < width && (ny as usize) < height {
+                            sum += raw[ny as usize * width + nx as usize];
+                            count += 1;
+                        }
+                    }
+                }
+                smoothed[y * width + x] = sum / count as f32;
+            }
+        }
+        // Center should be 9/9 = 1.0 (spike spread over 9 neighbors)
+        assert!(
+            (smoothed[2 * width + 2] - 1.0).abs() < f32::EPSILON,
+            "spike should be averaged: got {}",
+            smoothed[2 * width + 2]
+        );
+    }
+
+    #[test]
+    fn test_waste_heat_proportional_to_occupants() {
+        let occupants = 200u32;
+        let waste_heat = occupants as f32 * 0.005;
+        assert!((waste_heat - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_road_contributes_positive_uhi() {
+        // Road surface (asphalt=+2.0) in developed area with 0 green fraction:
+        //   surface=2.0, veg_deficit=0.6*8.0=4.8, waste=0, canyon=0
+        //   total = 6.8 before smoothing
+        let surface = SURFACE_ASPHALT;
+        let veg = RURAL_GREEN_BASELINE * VEGETATION_DEFICIT_SCALE;
+        let total = surface + veg;
+        assert!(
+            total > 0.0,
+            "roads in developed area should have positive UHI"
+        );
+    }
+
+    #[test]
+    fn test_water_contributes_negative_uhi() {
+        // Water surface: -2.0, and green fraction includes water so deficit should be low
+        let surface = SURFACE_WATER;
+        assert!(surface < 0.0, "water should have negative (cooling) UHI");
+    }
+
+    #[test]
+    fn test_uhi_grid_serialize_deserialize() {
+        let mut grid = UhiGrid::default();
+        grid.set(10, 10, 5.5);
+        grid.set(20, 20, -1.0);
+
+        // Round-trip through serde_json
+        let json = serde_json::to_string(&grid).expect("serialize");
+        let restored: UhiGrid = serde_json::from_str(&json).expect("deserialize");
+        assert!((restored.get(10, 10) - 5.5).abs() < f32::EPSILON);
+        assert!((restored.get(20, 20) - (-1.0)).abs() < f32::EPSILON);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `UhiGrid` resource: 256x256 per-cell temperature increment grid
- Surface heat, vegetation deficit, waste heat, canyon effect, nighttime amplification
- 3x3 Gaussian smoothing for realistic temperature gradients

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)