### PR TITLE
Add drought index and water restriction policies (WEATHER-010)

### DIFF
--- a/crates/save/src/lib.rs
+++ b/crates/save/src/lib.rs
@@ -11,11 +11,11 @@ pub mod serialization;
 use save_helpers::{V2ResourcesRead, V2ResourcesWrite};
 use serialization::{
     create_save_data, migrate_save, restore_climate_zone, restore_construction_modifiers,
-    restore_degree_days, restore_extended_budget, restore_life_sim_timer, restore_lifecycle_timer,
-    restore_loan_book, restore_policies, restore_road_segment_store, restore_stormwater_grid,
-    restore_unlock_state, restore_virtual_population, restore_water_source, restore_weather,
-    u8_to_road_type, u8_to_service_type, u8_to_utility_type, u8_to_zone_type, CitizenSaveInput,
-    SaveData, CURRENT_SAVE_VERSION,
+    restore_degree_days, restore_drought_state, restore_extended_budget, restore_life_sim_timer,
+    restore_lifecycle_timer, restore_loan_book, restore_policies, restore_road_segment_store,
+    restore_stormwater_grid, restore_unlock_state, restore_virtual_population,
+    restore_water_source, restore_weather, u8_to_road_type, u8_to_service_type,
+    u8_to_utility_type, u8_to_zone_type, CitizenSaveInput, SaveData, CURRENT_SAVE_VERSION,
 };
 use simulation::budget::ExtendedBudget;
 use simulation::buildings::{Building, MixedUseBuilding};
@@ -24,6 +24,7 @@ use simulation::citizen::{
     PathCache, Personality, Position, Velocity, WorkLocation,
 };
 use simulation::degree_days::DegreeDays;
+use simulation::drought::DroughtState;
 use simulation::economy::CityBudget;
 use simulation::grid::WorldGrid;
 use simulation::life_simulation::LifeSimTimer;
@@ -167,6 +168,7 @@ fn handle_save(
             Some(&v2.degree_days),
             Some(&v2.climate_zone),
             Some(&v2.construction_modifiers),
+            Some(&v2.drought_state),
         );
 
         let bytes = save.encode();
@@ -588,6 +590,13 @@ fn handle_load(
             *v2.construction_modifiers = ConstructionModifiers::default();
         }
 
+        // Restore drought state
+        if let Some(ref saved_ds) = save.drought_state {
+            *v2.drought_state = restore_drought_state(saved_ds);
+        } else {
+            *v2.drought_state = DroughtState::default();
+        }
+
         println!("Loaded save from {}", path);
     }
 }
@@ -665,6 +674,7 @@ fn handle_new_game(
         *v2.stormwater_grid = StormwaterGrid::default();
         *v2.degree_days = DegreeDays::default();
         *v2.construction_modifiers = ConstructionModifiers::default();
+        *v2.drought_state = DroughtState::default();
 
         // Generate a flat terrain with water on west edge (simple starter map)
         for y in 0..height {

--- a/crates/save/src/save_codec.rs
+++ b/crates/save/src/save_codec.rs
@@ -7,6 +7,7 @@ use simulation::policies::Policy;
 use simulation::services::ServiceType;
 use simulation::unlocks::UnlockNode;
 use simulation::utilities::UtilityType;
+use simulation::drought::DroughtTier;
 use simulation::water_sources::WaterSourceType;
 use simulation::weather::{ClimateZone, Season, WeatherCondition, WeatherEvent};
 
@@ -414,5 +415,24 @@ pub fn u8_to_unlock_node(v: u8) -> Option<UnlockNode> {
         36 => Some(UnlockNode::RegionalAirports),
         37 => Some(UnlockNode::InternationalAirports),
         _ => None,
+    }
+}
+
+pub fn drought_tier_to_u8(t: DroughtTier) -> u8 {
+    match t {
+        DroughtTier::Normal => 0,
+        DroughtTier::Moderate => 1,
+        DroughtTier::Severe => 2,
+        DroughtTier::Extreme => 3,
+    }
+}
+
+pub fn u8_to_drought_tier(v: u8) -> DroughtTier {
+    match v {
+        0 => DroughtTier::Normal,
+        1 => DroughtTier::Moderate,
+        2 => DroughtTier::Severe,
+        3 => DroughtTier::Extreme,
+        _ => DroughtTier::Normal, // fallback
     }
 }

--- a/crates/save/src/save_helpers.rs
+++ b/crates/save/src/save_helpers.rs
@@ -7,6 +7,7 @@ use bevy::prelude::*;
 
 use simulation::budget::ExtendedBudget;
 use simulation::degree_days::DegreeDays;
+use simulation::drought::DroughtState;
 use simulation::life_simulation::LifeSimTimer;
 use simulation::loans::LoanBook;
 use simulation::policies::Policies;
@@ -15,7 +16,7 @@ use simulation::unlocks::UnlockState;
 use simulation::virtual_population::VirtualPopulation;
 use simulation::weather::{ClimateZone, ConstructionModifiers, Weather};
 
-/// Read-only access to the V2+ resources (policies, weather, unlocks, ext budget, loans, virtual pop, life sim timer, stormwater, degree days, climate zone, construction modifiers).
+/// Read-only access to the V2+ resources (policies, weather, unlocks, ext budget, loans, virtual pop, life sim timer, stormwater, degree days, climate zone, construction modifiers, drought).
 #[derive(SystemParam)]
 pub(crate) struct V2ResourcesRead<'w> {
     pub policies: Res<'w, Policies>,
@@ -29,6 +30,7 @@ pub(crate) struct V2ResourcesRead<'w> {
     pub degree_days: Res<'w, DegreeDays>,
     pub climate_zone: Res<'w, ClimateZone>,
     pub construction_modifiers: Res<'w, ConstructionModifiers>,
+    pub drought_state: Res<'w, DroughtState>,
 }
 
 /// Mutable access to the V2+ resources.
@@ -45,4 +47,5 @@ pub(crate) struct V2ResourcesWrite<'w> {
     pub degree_days: ResMut<'w, DegreeDays>,
     pub climate_zone: ResMut<'w, ClimateZone>,
     pub construction_modifiers: ResMut<'w, ConstructionModifiers>,
+    pub drought_state: ResMut<'w, DroughtState>,
 }

--- a/crates/save/src/save_migrate.rs
+++ b/crates/save/src/save_migrate.rs
@@ -73,6 +73,12 @@ pub fn migrate_save(save: &mut SaveData) -> u32 {
         save.version = 9;
     }
 
+    // v9 -> v10: Added drought_state (DroughtState serialization).
+    // Uses `#[serde(default)]` so it deserializes as None from a v9 save.
+    if save.version == 9 {
+        save.version = 10;
+    }
+
     // Ensure version is at the current value (safety net for future additions).
     debug_assert_eq!(save.version, CURRENT_SAVE_VERSION);
 

--- a/crates/save/src/save_restore.rs
+++ b/crates/save/src/save_restore.rs
@@ -7,6 +7,7 @@ use crate::save_types::*;
 
 use simulation::budget::{ExtendedBudget, ServiceBudgets, ZoneTaxRates};
 use simulation::degree_days::DegreeDays;
+use simulation::drought::DroughtState;
 use simulation::life_simulation::LifeSimTimer;
 use simulation::lifecycle::LifecycleTimer;
 use simulation::loans::{self, LoanBook};
@@ -216,6 +217,21 @@ pub fn restore_construction_modifiers(save: &SaveConstructionModifiers) -> Const
     ConstructionModifiers {
         speed_factor: save.speed_factor,
         cost_factor: save.cost_factor,
+    }
+}
+
+/// Restore a `DroughtState` resource from saved data.
+pub fn restore_drought_state(save: &SaveDroughtState) -> DroughtState {
+    DroughtState {
+        rainfall_history: save.rainfall_history.clone(),
+        current_index: save.current_index,
+        current_tier: u8_to_drought_tier(save.current_tier),
+        expected_daily_rainfall: save.expected_daily_rainfall,
+        water_demand_modifier: save.water_demand_modifier,
+        agriculture_modifier: save.agriculture_modifier,
+        fire_risk_multiplier: save.fire_risk_multiplier,
+        happiness_modifier: save.happiness_modifier,
+        last_record_day: save.last_record_day,
     }
 }
 

--- a/crates/save/src/save_types.rs
+++ b/crates/save/src/save_types.rs
@@ -21,7 +21,8 @@ use simulation::citizen::{CitizenDetails, CitizenState, PathCache, Position, Vel
 /// v7 = degree_days (HDD/CDD tracking for HVAC energy demand)
 /// v8 = climate_zone in SaveWeather (ClimateZone resource)
 /// v9 = construction_modifiers (ConstructionModifiers serialization)
-pub const CURRENT_SAVE_VERSION: u32 = 9;
+/// v10 = drought_state (DroughtState serialization)
+pub const CURRENT_SAVE_VERSION: u32 = 10;
 
 // ---------------------------------------------------------------------------
 // Save structs
@@ -98,6 +99,8 @@ pub struct SaveData {
     pub degree_days: Option<SaveDegreeDays>,
     #[serde(default)]
     pub construction_modifiers: Option<SaveConstructionModifiers>,
+    #[serde(default)]
+    pub drought_state: Option<SaveDroughtState>,
 }
 
 #[derive(Serialize, Deserialize, Encode, Decode)]
@@ -360,6 +363,19 @@ pub struct SaveDegreeDays {
 pub struct SaveConstructionModifiers {
     pub speed_factor: f32,
     pub cost_factor: f32,
+}
+
+#[derive(Serialize, Deserialize, Encode, Decode, Default)]
+pub struct SaveDroughtState {
+    pub rainfall_history: Vec<f32>,
+    pub current_index: f32,
+    pub current_tier: u8,
+    pub expected_daily_rainfall: f32,
+    pub water_demand_modifier: f32,
+    pub agriculture_modifier: f32,
+    pub fire_risk_multiplier: f32,
+    pub happiness_modifier: f32,
+    pub last_record_day: u32,
 }
 
 #[derive(Serialize, Deserialize, Encode, Decode, Default)]

--- a/crates/save/src/serialization.rs
+++ b/crates/save/src/serialization.rs
@@ -10,6 +10,7 @@ pub use crate::save_types::*;
 
 use simulation::buildings::{Building, MixedUseBuilding};
 use simulation::citizen::CitizenState;
+use simulation::drought::DroughtState;
 use simulation::economy::CityBudget;
 use simulation::grid::WorldGrid;
 use simulation::life_simulation::LifeSimTimer;
@@ -56,6 +57,7 @@ pub fn create_save_data(
     degree_days: Option<&DegreeDays>,
     climate_zone: Option<&ClimateZone>,
     construction_modifiers: Option<&ConstructionModifiers>,
+    drought_state: Option<&DroughtState>,
 ) -> SaveData {
     let save_cells: Vec<SaveCell> = grid
         .cells
@@ -320,6 +322,17 @@ pub fn create_save_data(
             speed_factor: cm.speed_factor,
             cost_factor: cm.cost_factor,
         }),
+        drought_state: drought_state.map(|ds| SaveDroughtState {
+            rainfall_history: ds.rainfall_history.clone(),
+            current_index: ds.current_index,
+            current_tier: drought_tier_to_u8(ds.current_tier),
+            expected_daily_rainfall: ds.expected_daily_rainfall,
+            water_demand_modifier: ds.water_demand_modifier,
+            agriculture_modifier: ds.agriculture_modifier,
+            fire_risk_multiplier: ds.fire_risk_multiplier,
+            happiness_modifier: ds.happiness_modifier,
+            last_record_day: ds.last_record_day,
+        }),
     }
 }
 
@@ -389,6 +402,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let bytes = save.encode();
         let restored = SaveData::decode(&bytes).expect("decode should succeed");
@@ -422,6 +436,7 @@ mod tests {
         assert!(restored.degree_days.is_none());
         assert!(restored.water_sources.is_none());
         assert!(restored.construction_modifiers.is_none());
+        assert!(restored.drought_state.is_none());
     }
 
     #[test]
@@ -725,6 +740,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -801,6 +817,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let bytes = save.encode();
         let restored = SaveData::decode(&bytes).expect("decode v1 should succeed");
@@ -818,6 +835,7 @@ mod tests {
         assert!(restored.degree_days.is_none());
         assert!(restored.water_sources.is_none());
         assert!(restored.construction_modifiers.is_none());
+        assert!(restored.drought_state.is_none());
     }
 
     #[test]
@@ -874,6 +892,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
@@ -898,6 +917,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -953,6 +973,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
@@ -980,6 +1001,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1034,6 +1056,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         save.version = 1;
 
@@ -1061,6 +1084,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1205,6 +1229,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let bytes = save.encode();
         let restored = SaveData::decode(&bytes).expect("decode should succeed");
@@ -1247,6 +1272,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1365,6 +1391,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1417,6 +1444,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1443,6 +1471,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1534,6 +1563,7 @@ mod tests {
             None,
             None,
             Some(&water_sources),
+            None,
             None,
             None,
             None,
@@ -1658,6 +1688,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1685,6 +1716,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1731,6 +1763,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1792,6 +1825,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1831,6 +1865,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,
@@ -1929,6 +1964,7 @@ mod tests {
             None,
             Some(&climate_zone),
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -1981,6 +2017,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
         let bytes = save.encode();
@@ -2018,6 +2055,7 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
             None,
             None,
             None,

--- a/crates/simulation/src/drought.rs
+++ b/crates/simulation/src/drought.rs
@@ -1,0 +1,281 @@
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::weather::Weather;
+use crate::SlowTickTimer;
+
+/// Rolling history window size: 30 in-game days of rainfall data.
+const RAINFALL_HISTORY_SIZE: usize = 30;
+
+/// Drought severity tiers based on the drought index.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum DroughtTier {
+    /// Index > 0.8: no effects.
+    #[default]
+    Normal,
+    /// Index 0.5 to 0.8: lawn watering banned, moderate agriculture impact.
+    Moderate,
+    /// Index 0.25 to 0.5: mandatory rationing, severe agriculture impact.
+    Severe,
+    /// Index < 0.25: emergency water imports, agriculture failure.
+    Extreme,
+}
+
+/// Resource tracking drought conditions derived from rolling rainfall history.
+#[derive(Resource, Clone, Debug, Serialize, Deserialize)]
+pub struct DroughtState {
+    /// Rolling window of daily precipitation values (last 30 days).
+    pub rainfall_history: Vec<f32>,
+    /// Current drought index: `avg(rainfall_history) / expected_daily_rainfall`.
+    pub current_index: f32,
+    /// Current drought severity tier.
+    pub current_tier: DroughtTier,
+    /// Expected daily rainfall baseline (mm/day).
+    pub expected_daily_rainfall: f32,
+    /// Water demand modifier (1.0 = normal, lower = reduced demand).
+    pub water_demand_modifier: f32,
+    /// Agriculture output modifier (1.0 = normal, lower = reduced yield).
+    pub agriculture_modifier: f32,
+    /// Fire risk multiplier (1.0 = normal, higher = increased risk).
+    pub fire_risk_multiplier: f32,
+    /// Happiness modifier from drought (0.0 = no effect, negative = penalty).
+    pub happiness_modifier: f32,
+    /// Last game day that recorded rainfall into history.
+    pub last_record_day: u32,
+}
+
+impl Default for DroughtState {
+    fn default() -> Self {
+        Self {
+            rainfall_history: Vec::new(),
+            current_index: 1.0,
+            current_tier: DroughtTier::Normal,
+            expected_daily_rainfall: 2.5,
+            water_demand_modifier: 1.0,
+            agriculture_modifier: 1.0,
+            fire_risk_multiplier: 1.0,
+            happiness_modifier: 0.0,
+            last_record_day: 0,
+        }
+    }
+}
+
+/// Classify a drought index value into a severity tier.
+pub fn drought_tier_from_index(index: f32) -> DroughtTier {
+    if index > 0.8 {
+        DroughtTier::Normal
+    } else if index > 0.5 {
+        DroughtTier::Moderate
+    } else if index > 0.25 {
+        DroughtTier::Severe
+    } else {
+        DroughtTier::Extreme
+    }
+}
+
+/// Return effect modifiers for a given drought tier.
+///
+/// Returns `(water_demand_modifier, agriculture_modifier, fire_risk_multiplier, happiness_modifier)`.
+pub fn drought_effects(tier: DroughtTier) -> (f32, f32, f32, f32) {
+    match tier {
+        DroughtTier::Normal => (1.0, 1.0, 1.0, 0.0),
+        DroughtTier::Moderate => (0.8, 0.7, 2.0, 0.0),
+        DroughtTier::Severe => (0.6, 0.4, 4.0, -20.0),
+        DroughtTier::Extreme => (0.4, 0.0, 6.0, -40.0),
+    }
+}
+
+/// System that updates the drought index based on rolling 30-day rainfall average.
+///
+/// Runs on the slow tick timer (every ~100 ticks). Reads current precipitation
+/// from the `Weather` resource, records daily rainfall, and recomputes the
+/// drought index and associated modifiers.
+pub fn update_drought_index(
+    weather: Res<Weather>,
+    mut drought: ResMut<DroughtState>,
+    timer: Res<SlowTickTimer>,
+) {
+    if !timer.should_run() {
+        return;
+    }
+
+    // Record daily rainfall if the day changed since last record.
+    let current_day = weather.last_update_day;
+    if current_day > drought.last_record_day {
+        // precipitation_intensity is 0.0..1.0; scale to approximate mm/day.
+        // Expected baseline is 2.5mm, so a fully saturated day produces ~5mm.
+        let daily_rainfall = weather.precipitation_intensity * 5.0;
+        drought.rainfall_history.push(daily_rainfall);
+
+        // Trim to rolling 30-day window.
+        while drought.rainfall_history.len() > RAINFALL_HISTORY_SIZE {
+            drought.rainfall_history.remove(0);
+        }
+
+        drought.last_record_day = current_day;
+    }
+
+    // Calculate drought index.
+    if drought.rainfall_history.is_empty() || drought.expected_daily_rainfall <= 0.0 {
+        drought.current_index = 1.0;
+    } else {
+        let sum: f32 = drought.rainfall_history.iter().sum();
+        let avg = sum / drought.rainfall_history.len() as f32;
+        drought.current_index = (avg / drought.expected_daily_rainfall).min(2.0);
+    }
+
+    // Determine tier and apply effects.
+    drought.current_tier = drought_tier_from_index(drought.current_index);
+    let (water_mod, agri_mod, fire_mult, happy_mod) = drought_effects(drought.current_tier);
+    drought.water_demand_modifier = water_mod;
+    drought.agriculture_modifier = agri_mod;
+    drought.fire_risk_multiplier = fire_mult;
+    drought.happiness_modifier = happy_mod;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tier_normal() {
+        assert_eq!(drought_tier_from_index(1.0), DroughtTier::Normal);
+        assert_eq!(drought_tier_from_index(0.81), DroughtTier::Normal);
+    }
+
+    #[test]
+    fn test_tier_moderate() {
+        assert_eq!(drought_tier_from_index(0.8), DroughtTier::Moderate);
+        assert_eq!(drought_tier_from_index(0.51), DroughtTier::Moderate);
+    }
+
+    #[test]
+    fn test_tier_severe() {
+        assert_eq!(drought_tier_from_index(0.5), DroughtTier::Severe);
+        assert_eq!(drought_tier_from_index(0.26), DroughtTier::Severe);
+    }
+
+    #[test]
+    fn test_tier_extreme() {
+        assert_eq!(drought_tier_from_index(0.25), DroughtTier::Extreme);
+        assert_eq!(drought_tier_from_index(0.0), DroughtTier::Extreme);
+    }
+
+    #[test]
+    fn test_effects_normal() {
+        let (water, agri, fire, happy) = drought_effects(DroughtTier::Normal);
+        assert!((water - 1.0).abs() < f32::EPSILON);
+        assert!((agri - 1.0).abs() < f32::EPSILON);
+        assert!((fire - 1.0).abs() < f32::EPSILON);
+        assert!(happy.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_effects_moderate() {
+        let (water, agri, fire, happy) = drought_effects(DroughtTier::Moderate);
+        assert!((water - 0.8).abs() < f32::EPSILON);
+        assert!((agri - 0.7).abs() < f32::EPSILON);
+        assert!((fire - 2.0).abs() < f32::EPSILON);
+        assert!(happy.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_effects_severe() {
+        let (water, agri, fire, happy) = drought_effects(DroughtTier::Severe);
+        assert!((water - 0.6).abs() < f32::EPSILON);
+        assert!((agri - 0.4).abs() < f32::EPSILON);
+        assert!((fire - 4.0).abs() < f32::EPSILON);
+        assert!((happy - (-20.0)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_effects_extreme() {
+        let (water, agri, fire, happy) = drought_effects(DroughtTier::Extreme);
+        assert!((water - 0.4).abs() < f32::EPSILON);
+        assert!((agri - 0.0).abs() < f32::EPSILON);
+        assert!((fire - 6.0).abs() < f32::EPSILON);
+        assert!((happy - (-40.0)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_rolling_window_trimmed_to_30() {
+        let mut state = DroughtState::default();
+        // Push 35 entries
+        for i in 0..35 {
+            state.rainfall_history.push(i as f32);
+        }
+        // Trim manually as the system would
+        while state.rainfall_history.len() > 30 {
+            state.rainfall_history.remove(0);
+        }
+        assert_eq!(state.rainfall_history.len(), 30);
+        // First entry should be 5 (entries 0..4 were trimmed)
+        assert!((state.rainfall_history[0] - 5.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_index_calculation() {
+        let mut state = DroughtState::default();
+        state.expected_daily_rainfall = 2.5;
+        // Push 30 days with 1.25mm rainfall each
+        for _ in 0..30 {
+            state.rainfall_history.push(1.25);
+        }
+        let sum: f32 = state.rainfall_history.iter().sum();
+        let avg = sum / state.rainfall_history.len() as f32;
+        let index = avg / state.expected_daily_rainfall;
+        // 1.25 / 2.5 = 0.5 -> Severe drought
+        assert!((index - 0.5).abs() < f32::EPSILON);
+        assert_eq!(drought_tier_from_index(index), DroughtTier::Severe);
+    }
+
+    #[test]
+    fn test_index_with_no_rainfall() {
+        let mut state = DroughtState::default();
+        state.expected_daily_rainfall = 2.5;
+        for _ in 0..30 {
+            state.rainfall_history.push(0.0);
+        }
+        let sum: f32 = state.rainfall_history.iter().sum();
+        let avg = sum / state.rainfall_history.len() as f32;
+        let index = avg / state.expected_daily_rainfall;
+        assert!(index.abs() < f32::EPSILON);
+        assert_eq!(drought_tier_from_index(index), DroughtTier::Extreme);
+    }
+
+    #[test]
+    fn test_index_with_abundant_rainfall() {
+        let mut state = DroughtState::default();
+        state.expected_daily_rainfall = 2.5;
+        for _ in 0..30 {
+            state.rainfall_history.push(5.0);
+        }
+        let sum: f32 = state.rainfall_history.iter().sum();
+        let avg = sum / state.rainfall_history.len() as f32;
+        let index = avg / state.expected_daily_rainfall;
+        // 5.0 / 2.5 = 2.0 -> Normal
+        assert!((index - 2.0).abs() < f32::EPSILON);
+        assert_eq!(drought_tier_from_index(index), DroughtTier::Normal);
+    }
+
+    #[test]
+    fn test_default_state() {
+        let state = DroughtState::default();
+        assert!(state.rainfall_history.is_empty());
+        assert!((state.current_index - 1.0).abs() < f32::EPSILON);
+        assert_eq!(state.current_tier, DroughtTier::Normal);
+        assert!((state.expected_daily_rainfall - 2.5).abs() < f32::EPSILON);
+        assert!((state.water_demand_modifier - 1.0).abs() < f32::EPSILON);
+        assert!((state.agriculture_modifier - 1.0).abs() < f32::EPSILON);
+        assert!((state.fire_risk_multiplier - 1.0).abs() < f32::EPSILON);
+        assert!(state.happiness_modifier.abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_empty_history_gives_normal_index() {
+        let state = DroughtState::default();
+        // With empty history, index should be 1.0 (no drought)
+        assert!((state.current_index - 1.0).abs() < f32::EPSILON);
+        assert_eq!(drought_tier_from_index(state.current_index), DroughtTier::Normal);
+    }
+}

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -14,6 +14,7 @@ pub mod crime;
 pub mod death_care;
 pub mod degree_days;
 pub mod disasters;
+pub mod drought;
 pub mod districts;
 pub mod economy;
 pub mod education;
@@ -86,6 +87,7 @@ use crime::CrimeGrid;
 use death_care::{DeathCareGrid, DeathCareStats};
 use degree_days::DegreeDays;
 use disasters::ActiveDisaster;
+use drought::DroughtState;
 use districts::{DistrictMap, Districts};
 use economy::CityBudget;
 use education::EducationGrid;
@@ -242,6 +244,7 @@ impl Plugin for SimulationPlugin {
             .init_resource::<StormwaterGrid>()
             .init_resource::<DegreeDays>()
             .init_resource::<ConstructionModifiers>()
+            .init_resource::<DroughtState>()
             .init_resource::<WasteAccumulation>()
             .add_event::<BankruptcyEvent>()
             .add_event::<WeatherChangeEvent>()
@@ -352,6 +355,7 @@ impl Plugin for SimulationPlugin {
                     weather::update_weather,
                     degree_days::update_degree_days,
                     weather::update_construction_modifiers,
+                    drought::update_drought_index,
                     heating::update_heating,
                     wind::update_wind,
                     noise::update_noise_pollution,


### PR DESCRIPTION
## Summary
- Adds `DroughtState` resource with rolling 30-day rainfall tracking
- 4 drought tiers with water demand, agriculture, fire risk modifiers

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)