### PR TITLE
Add heat wave health, energy, and infrastructure effects (WEATHER-006)

### DIFF
--- a/crates/save/src/lib.rs
+++ b/crates/save/src/lib.rs
@@ -11,11 +11,12 @@ pub mod serialization;
 use save_helpers::{V2ResourcesRead, V2ResourcesWrite};
 use serialization::{
     create_save_data, migrate_save, restore_climate_zone, restore_construction_modifiers,
-    restore_degree_days, restore_extended_budget, restore_life_sim_timer, restore_lifecycle_timer,
-    restore_loan_book, restore_policies, restore_road_segment_store, restore_stormwater_grid,
-    restore_unlock_state, restore_virtual_population, restore_water_source, restore_weather,
-    u8_to_road_type, u8_to_service_type, u8_to_utility_type, u8_to_zone_type, CitizenSaveInput,
-    SaveData, CURRENT_SAVE_VERSION,
+    restore_degree_days, restore_extended_budget, restore_heat_wave_state,
+    restore_life_sim_timer, restore_lifecycle_timer, restore_loan_book, restore_policies,
+    restore_road_segment_store, restore_stormwater_grid, restore_unlock_state,
+    restore_virtual_population, restore_water_source, restore_weather, u8_to_road_type,
+    u8_to_service_type, u8_to_utility_type, u8_to_zone_type, CitizenSaveInput, SaveData,
+    CURRENT_SAVE_VERSION,
 };
 use simulation::budget::ExtendedBudget;
 use simulation::buildings::{Building, MixedUseBuilding};
@@ -41,6 +42,7 @@ use simulation::unlocks::UnlockState;
 use simulation::utilities::UtilitySource;
 use simulation::virtual_population::VirtualPopulation;
 use simulation::water_sources::WaterSource;
+use simulation::heat_wave::HeatWaveState;
 use simulation::weather::{ClimateZone, ConstructionModifiers, Weather};
 use simulation::zones::ZoneDemand;
 
@@ -167,6 +169,7 @@ fn handle_save(
             Some(&v2.degree_days),
             Some(&v2.climate_zone),
             Some(&v2.construction_modifiers),
+            Some(&v2.heat_wave_state),
         );
 
         let bytes = save.encode();
@@ -588,6 +591,13 @@ fn handle_load(
             *v2.construction_modifiers = ConstructionModifiers::default();
         }
 
+        // Restore heat wave state
+        if let Some(ref saved_hw) = save.heat_wave_state {
+            *v2.heat_wave_state = restore_heat_wave_state(saved_hw);
+        } else {
+            *v2.heat_wave_state = HeatWaveState::default();
+        }
+
         println!("Loaded save from {}", path);
     }
 }
@@ -665,6 +675,7 @@ fn handle_new_game(
         *v2.stormwater_grid = StormwaterGrid::default();
         *v2.degree_days = DegreeDays::default();
         *v2.construction_modifiers = ConstructionModifiers::default();
+        *v2.heat_wave_state = HeatWaveState::default();
 
         // Generate a flat terrain with water on west edge (simple starter map)
         for y in 0..height {

--- a/crates/save/src/save_codec.rs
+++ b/crates/save/src/save_codec.rs
@@ -7,6 +7,7 @@ use simulation::policies::Policy;
 use simulation::services::ServiceType;
 use simulation::unlocks::UnlockNode;
 use simulation::utilities::UtilityType;
+use simulation::heat_wave::HeatWaveSeverity;
 use simulation::water_sources::WaterSourceType;
 use simulation::weather::{ClimateZone, Season, WeatherCondition, WeatherEvent};
 
@@ -414,5 +415,24 @@ pub fn u8_to_unlock_node(v: u8) -> Option<UnlockNode> {
         36 => Some(UnlockNode::RegionalAirports),
         37 => Some(UnlockNode::InternationalAirports),
         _ => None,
+    }
+}
+
+pub fn heat_wave_severity_to_u8(s: HeatWaveSeverity) -> u8 {
+    match s {
+        HeatWaveSeverity::None => 0,
+        HeatWaveSeverity::Moderate => 1,
+        HeatWaveSeverity::Severe => 2,
+        HeatWaveSeverity::Extreme => 3,
+    }
+}
+
+pub fn u8_to_heat_wave_severity(v: u8) -> HeatWaveSeverity {
+    match v {
+        0 => HeatWaveSeverity::None,
+        1 => HeatWaveSeverity::Moderate,
+        2 => HeatWaveSeverity::Severe,
+        3 => HeatWaveSeverity::Extreme,
+        _ => HeatWaveSeverity::None, // fallback
     }
 }

--- a/crates/save/src/save_helpers.rs
+++ b/crates/save/src/save_helpers.rs
@@ -7,6 +7,7 @@ use bevy::prelude::*;
 
 use simulation::budget::ExtendedBudget;
 use simulation::degree_days::DegreeDays;
+use simulation::heat_wave::HeatWaveState;
 use simulation::life_simulation::LifeSimTimer;
 use simulation::loans::LoanBook;
 use simulation::policies::Policies;
@@ -15,7 +16,7 @@ use simulation::unlocks::UnlockState;
 use simulation::virtual_population::VirtualPopulation;
 use simulation::weather::{ClimateZone, ConstructionModifiers, Weather};
 
-/// Read-only access to the V2+ resources (policies, weather, unlocks, ext budget, loans, virtual pop, life sim timer, stormwater, degree days, climate zone, construction modifiers).
+/// Read-only access to the V2+ resources (policies, weather, unlocks, ext budget, loans, virtual pop, life sim timer, stormwater, degree days, climate zone, construction modifiers, heat wave state).
 #[derive(SystemParam)]
 pub(crate) struct V2ResourcesRead<'w> {
     pub policies: Res<'w, Policies>,
@@ -29,6 +30,7 @@ pub(crate) struct V2ResourcesRead<'w> {
     pub degree_days: Res<'w, DegreeDays>,
     pub climate_zone: Res<'w, ClimateZone>,
     pub construction_modifiers: Res<'w, ConstructionModifiers>,
+    pub heat_wave_state: Res<'w, HeatWaveState>,
 }
 
 /// Mutable access to the V2+ resources.
@@ -45,4 +47,5 @@ pub(crate) struct V2ResourcesWrite<'w> {
     pub degree_days: ResMut<'w, DegreeDays>,
     pub climate_zone: ResMut<'w, ClimateZone>,
     pub construction_modifiers: ResMut<'w, ConstructionModifiers>,
+    pub heat_wave_state: ResMut<'w, HeatWaveState>,
 }

--- a/crates/save/src/save_migrate.rs
+++ b/crates/save/src/save_migrate.rs
@@ -73,6 +73,12 @@ pub fn migrate_save(save: &mut SaveData) -> u32 {
         save.version = 9;
     }
 
+    // v9 -> v10: Added heat_wave_state (HeatWaveState serialization).
+    // Uses `#[serde(default)]` so it deserializes as None from a v9 save.
+    if save.version == 9 {
+        save.version = 10;
+    }
+
     // Ensure version is at the current value (safety net for future additions).
     debug_assert_eq!(save.version, CURRENT_SAVE_VERSION);
 

--- a/crates/save/src/save_restore.rs
+++ b/crates/save/src/save_restore.rs
@@ -7,6 +7,7 @@ use crate::save_types::*;
 
 use simulation::budget::{ExtendedBudget, ServiceBudgets, ZoneTaxRates};
 use simulation::degree_days::DegreeDays;
+use simulation::heat_wave::HeatWaveState;
 use simulation::life_simulation::LifeSimTimer;
 use simulation::lifecycle::LifecycleTimer;
 use simulation::loans::{self, LoanBook};
@@ -216,6 +217,23 @@ pub fn restore_construction_modifiers(save: &SaveConstructionModifiers) -> Const
     ConstructionModifiers {
         speed_factor: save.speed_factor,
         cost_factor: save.cost_factor,
+    }
+}
+
+/// Restore a `HeatWaveState` resource from saved data.
+pub fn restore_heat_wave_state(save: &SaveHeatWaveState) -> HeatWaveState {
+    HeatWaveState {
+        consecutive_hot_days: save.consecutive_hot_days,
+        severity: u8_to_heat_wave_severity(save.severity),
+        excess_mortality_per_100k: save.excess_mortality_per_100k,
+        energy_demand_multiplier: save.energy_demand_multiplier,
+        water_demand_multiplier: save.water_demand_multiplier,
+        road_damage_active: save.road_damage_active,
+        fire_risk_multiplier: save.fire_risk_multiplier,
+        blackout_risk: save.blackout_risk,
+        heat_threshold_c: save.heat_threshold_c,
+        consecutive_extreme_days: save.consecutive_extreme_days,
+        last_check_day: save.last_check_day,
     }
 }
 

--- a/crates/save/src/save_types.rs
+++ b/crates/save/src/save_types.rs
@@ -21,7 +21,8 @@ use simulation::citizen::{CitizenDetails, CitizenState, PathCache, Position, Vel
 /// v7 = degree_days (HDD/CDD tracking for HVAC energy demand)
 /// v8 = climate_zone in SaveWeather (ClimateZone resource)
 /// v9 = construction_modifiers (ConstructionModifiers serialization)
-pub const CURRENT_SAVE_VERSION: u32 = 9;
+/// v10 = heat_wave_state (HeatWaveState serialization)
+pub const CURRENT_SAVE_VERSION: u32 = 10;
 
 // ---------------------------------------------------------------------------
 // Save structs
@@ -98,6 +99,8 @@ pub struct SaveData {
     pub degree_days: Option<SaveDegreeDays>,
     #[serde(default)]
     pub construction_modifiers: Option<SaveConstructionModifiers>,
+    #[serde(default)]
+    pub heat_wave_state: Option<SaveHeatWaveState>,
 }
 
 #[derive(Serialize, Deserialize, Encode, Decode)]
@@ -360,6 +363,21 @@ pub struct SaveDegreeDays {
 pub struct SaveConstructionModifiers {
     pub speed_factor: f32,
     pub cost_factor: f32,
+}
+
+#[derive(Serialize, Deserialize, Encode, Decode, Default)]
+pub struct SaveHeatWaveState {
+    pub consecutive_hot_days: u32,
+    pub severity: u8,
+    pub excess_mortality_per_100k: f32,
+    pub energy_demand_multiplier: f32,
+    pub water_demand_multiplier: f32,
+    pub road_damage_active: bool,
+    pub fire_risk_multiplier: f32,
+    pub blackout_risk: f32,
+    pub heat_threshold_c: f32,
+    pub consecutive_extreme_days: u32,
+    pub last_check_day: u32,
 }
 
 #[derive(Serialize, Deserialize, Encode, Decode, Default)]

--- a/crates/simulation/src/heat_wave.rs
+++ b/crates/simulation/src/heat_wave.rs
@@ -1,0 +1,338 @@
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::weather::Weather;
+
+/// Heat wave severity levels based on consecutive hot days.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum HeatWaveSeverity {
+    #[default]
+    None,
+    Moderate,
+    Severe,
+    Extreme,
+}
+
+/// Resource tracking heat wave state and derived effects.
+#[derive(Resource, Clone, Debug, Serialize, Deserialize)]
+pub struct HeatWaveState {
+    /// Number of consecutive days with temperature above the heat threshold.
+    pub consecutive_hot_days: u32,
+    /// Current heat wave severity level.
+    pub severity: HeatWaveSeverity,
+    /// Excess deaths per 100,000 population from heat exposure.
+    pub excess_mortality_per_100k: f32,
+    /// Energy demand multiplier (1.0 = normal, 1.4-1.8 during heat wave).
+    pub energy_demand_multiplier: f32,
+    /// Water demand multiplier (1.0 = normal, up to 1.6 during heat wave).
+    pub water_demand_multiplier: f32,
+    /// True when sustained temperatures above 43C cause road buckling.
+    pub road_damage_active: bool,
+    /// Fire risk multiplier (increases during heat waves, especially with drought).
+    pub fire_risk_multiplier: f32,
+    /// Blackout probability (0.0-1.0) when AC demand exceeds grid capacity.
+    pub blackout_risk: f32,
+    /// Temperature threshold in Celsius for heat wave detection (default 38.0).
+    pub heat_threshold_c: f32,
+    /// Internal: number of consecutive days above 43C for road damage tracking.
+    pub consecutive_extreme_days: u32,
+    /// Internal: the last day we checked (to detect day changes).
+    pub last_check_day: u32,
+}
+
+impl Default for HeatWaveState {
+    fn default() -> Self {
+        Self {
+            consecutive_hot_days: 0,
+            severity: HeatWaveSeverity::None,
+            excess_mortality_per_100k: 0.0,
+            energy_demand_multiplier: 1.0,
+            water_demand_multiplier: 1.0,
+            road_damage_active: false,
+            fire_risk_multiplier: 1.0,
+            blackout_risk: 0.0,
+            heat_threshold_c: 38.0,
+            consecutive_extreme_days: 0,
+            last_check_day: 0,
+        }
+    }
+}
+
+/// Road buckling temperature threshold in Celsius.
+const ROAD_BUCKLING_THRESHOLD_C: f32 = 43.0;
+/// Number of consecutive days above 43C before road damage occurs.
+const ROAD_DAMAGE_DAYS: u32 = 3;
+
+/// Calculate excess deaths per 100k using exponential curve.
+///
+/// Formula: `0.5 * exp(0.15 * (temp - threshold))`
+/// Returns 0.0 when temperature is at or below the threshold.
+pub fn calculate_excess_mortality(temp_c: f32, threshold: f32) -> f32 {
+    if temp_c <= threshold {
+        return 0.0;
+    }
+    0.5 * (0.15 * (temp_c - threshold)).exp()
+}
+
+/// Determine heat wave severity from consecutive hot days.
+pub fn severity_from_days(days: u32) -> HeatWaveSeverity {
+    match days {
+        0..=2 => HeatWaveSeverity::None,
+        3..=5 => HeatWaveSeverity::Moderate,
+        6..=9 => HeatWaveSeverity::Severe,
+        _ => HeatWaveSeverity::Extreme,
+    }
+}
+
+/// System that updates the `HeatWaveState` resource based on current weather.
+///
+/// Runs on a timer (registered with `on_timer(Duration::from_secs(2))`).
+/// Reads the `Weather` resource for temperature and tracks consecutive hot days.
+pub fn update_heat_wave(weather: Res<Weather>, mut state: ResMut<HeatWaveState>) {
+    let current_day = weather.last_update_day;
+    let temp = weather.temperature;
+    let threshold = state.heat_threshold_c;
+
+    // Detect day change to update consecutive day counters
+    if current_day != state.last_check_day && current_day > 0 {
+        state.last_check_day = current_day;
+
+        // Track consecutive hot days (above heat threshold)
+        if temp >= threshold {
+            state.consecutive_hot_days += 1;
+        } else {
+            state.consecutive_hot_days = 0;
+        }
+
+        // Track consecutive extreme days (above road buckling threshold)
+        if temp >= ROAD_BUCKLING_THRESHOLD_C {
+            state.consecutive_extreme_days += 1;
+        } else {
+            state.consecutive_extreme_days = 0;
+        }
+    }
+
+    // Update severity
+    state.severity = severity_from_days(state.consecutive_hot_days);
+
+    // Calculate excess mortality
+    state.excess_mortality_per_100k = if state.severity != HeatWaveSeverity::None {
+        calculate_excess_mortality(temp, threshold)
+    } else {
+        0.0
+    };
+
+    // Energy demand multiplier: +40-80% from AC load based on severity
+    state.energy_demand_multiplier = match state.severity {
+        HeatWaveSeverity::None => 1.0,
+        HeatWaveSeverity::Moderate => 1.4,
+        HeatWaveSeverity::Severe => 1.6,
+        HeatWaveSeverity::Extreme => 1.8,
+    };
+
+    // Water demand multiplier: +60% during heat waves
+    state.water_demand_multiplier = match state.severity {
+        HeatWaveSeverity::None => 1.0,
+        HeatWaveSeverity::Moderate => 1.3,
+        HeatWaveSeverity::Severe => 1.45,
+        HeatWaveSeverity::Extreme => 1.6,
+    };
+
+    // Road damage: pavement buckling at sustained temps above 43C for 3+ days
+    state.road_damage_active = state.consecutive_extreme_days >= ROAD_DAMAGE_DAYS;
+
+    // Fire risk multiplier: increases with severity, +300% when combined with drought
+    // (low humidity acts as drought proxy)
+    let drought_factor = if weather.humidity < 0.2 { 3.0 } else { 1.0 };
+    state.fire_risk_multiplier = match state.severity {
+        HeatWaveSeverity::None => 1.0,
+        HeatWaveSeverity::Moderate => 1.5 * drought_factor,
+        HeatWaveSeverity::Severe => 2.0 * drought_factor,
+        HeatWaveSeverity::Extreme => 2.5 * drought_factor,
+    };
+
+    // Blackout risk: based on energy demand vs assumed capacity
+    // Higher severity = higher chance that AC demand exceeds grid capacity
+    state.blackout_risk = match state.severity {
+        HeatWaveSeverity::None => 0.0,
+        HeatWaveSeverity::Moderate => 0.05,
+        HeatWaveSeverity::Severe => 0.15,
+        HeatWaveSeverity::Extreme => 0.35,
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_severity_classification() {
+        assert_eq!(severity_from_days(0), HeatWaveSeverity::None);
+        assert_eq!(severity_from_days(1), HeatWaveSeverity::None);
+        assert_eq!(severity_from_days(2), HeatWaveSeverity::None);
+        assert_eq!(severity_from_days(3), HeatWaveSeverity::Moderate);
+        assert_eq!(severity_from_days(5), HeatWaveSeverity::Moderate);
+        assert_eq!(severity_from_days(6), HeatWaveSeverity::Severe);
+        assert_eq!(severity_from_days(9), HeatWaveSeverity::Severe);
+        assert_eq!(severity_from_days(10), HeatWaveSeverity::Extreme);
+        assert_eq!(severity_from_days(100), HeatWaveSeverity::Extreme);
+    }
+
+    #[test]
+    fn test_excess_mortality_at_threshold() {
+        // At or below threshold, mortality should be zero
+        let result = calculate_excess_mortality(38.0, 38.0);
+        assert!(result.abs() < f32::EPSILON, "Mortality at threshold should be 0, got {}", result);
+
+        let result_below = calculate_excess_mortality(35.0, 38.0);
+        assert!(result_below.abs() < f32::EPSILON, "Mortality below threshold should be 0");
+    }
+
+    #[test]
+    fn test_excess_mortality_above_threshold() {
+        // At 40C with 38C threshold: 0.5 * exp(0.15 * 2) = 0.5 * exp(0.3) ~ 0.675
+        let result = calculate_excess_mortality(40.0, 38.0);
+        let expected = 0.5 * (0.15_f32 * 2.0).exp();
+        assert!((result - expected).abs() < 0.001, "Expected ~{}, got {}", expected, result);
+    }
+
+    #[test]
+    fn test_excess_mortality_exponential_growth() {
+        // Verify the curve is exponential: mortality at 45C >> mortality at 40C
+        let m40 = calculate_excess_mortality(40.0, 38.0);
+        let m45 = calculate_excess_mortality(45.0, 38.0);
+        assert!(m45 > m40 * 2.0, "Mortality should grow exponentially: 45C={} vs 40C={}", m45, m40);
+    }
+
+    #[test]
+    fn test_excess_mortality_various_temperatures() {
+        // At 42C with 38C threshold: 0.5 * exp(0.15 * 4) = 0.5 * exp(0.6) ~ 0.911
+        let result = calculate_excess_mortality(42.0, 38.0);
+        let expected = 0.5 * (0.15_f32 * 4.0).exp();
+        assert!((result - expected).abs() < 0.01, "Expected ~{}, got {}", expected, result);
+
+        // At 50C with 38C threshold: 0.5 * exp(0.15 * 12) = 0.5 * exp(1.8) ~ 3.02
+        let result_high = calculate_excess_mortality(50.0, 38.0);
+        let expected_high = 0.5 * (0.15_f32 * 12.0).exp();
+        assert!((result_high - expected_high).abs() < 0.01, "Expected ~{}, got {}", expected_high, result_high);
+    }
+
+    #[test]
+    fn test_energy_multiplier_by_severity() {
+        // None: 1.0, Moderate: 1.4, Severe: 1.6, Extreme: 1.8
+        let expected = [
+            (HeatWaveSeverity::None, 1.0),
+            (HeatWaveSeverity::Moderate, 1.4),
+            (HeatWaveSeverity::Severe, 1.6),
+            (HeatWaveSeverity::Extreme, 1.8),
+        ];
+        for (severity, multiplier) in &expected {
+            let actual = match severity {
+                HeatWaveSeverity::None => 1.0_f32,
+                HeatWaveSeverity::Moderate => 1.4,
+                HeatWaveSeverity::Severe => 1.6,
+                HeatWaveSeverity::Extreme => 1.8,
+            };
+            assert!(
+                (actual - multiplier).abs() < f32::EPSILON,
+                "Energy multiplier for {:?} should be {}, got {}",
+                severity, multiplier, actual
+            );
+        }
+    }
+
+    #[test]
+    fn test_water_multiplier_by_severity() {
+        // None: 1.0, Moderate: 1.3, Severe: 1.45, Extreme: 1.6
+        let expected = [
+            (HeatWaveSeverity::None, 1.0),
+            (HeatWaveSeverity::Moderate, 1.3),
+            (HeatWaveSeverity::Severe, 1.45),
+            (HeatWaveSeverity::Extreme, 1.6),
+        ];
+        for (severity, multiplier) in &expected {
+            let actual = match severity {
+                HeatWaveSeverity::None => 1.0_f32,
+                HeatWaveSeverity::Moderate => 1.3,
+                HeatWaveSeverity::Severe => 1.45,
+                HeatWaveSeverity::Extreme => 1.6,
+            };
+            assert!(
+                (actual - multiplier).abs() < f32::EPSILON,
+                "Water multiplier for {:?} should be {}, got {}",
+                severity, multiplier, actual
+            );
+        }
+    }
+
+    #[test]
+    fn test_road_damage_threshold() {
+        let mut state = HeatWaveState::default();
+
+        // Less than 3 consecutive extreme days: no road damage
+        state.consecutive_extreme_days = 2;
+        state.road_damage_active = state.consecutive_extreme_days >= ROAD_DAMAGE_DAYS;
+        assert!(!state.road_damage_active);
+
+        // Exactly 3 consecutive extreme days: road damage active
+        state.consecutive_extreme_days = 3;
+        state.road_damage_active = state.consecutive_extreme_days >= ROAD_DAMAGE_DAYS;
+        assert!(state.road_damage_active);
+
+        // More than 3 consecutive extreme days: still active
+        state.consecutive_extreme_days = 10;
+        state.road_damage_active = state.consecutive_extreme_days >= ROAD_DAMAGE_DAYS;
+        assert!(state.road_damage_active);
+    }
+
+    #[test]
+    fn test_default_state() {
+        let state = HeatWaveState::default();
+        assert_eq!(state.consecutive_hot_days, 0);
+        assert_eq!(state.severity, HeatWaveSeverity::None);
+        assert!((state.excess_mortality_per_100k).abs() < f32::EPSILON);
+        assert!((state.energy_demand_multiplier - 1.0).abs() < f32::EPSILON);
+        assert!((state.water_demand_multiplier - 1.0).abs() < f32::EPSILON);
+        assert!(!state.road_damage_active);
+        assert!((state.fire_risk_multiplier - 1.0).abs() < f32::EPSILON);
+        assert!((state.blackout_risk).abs() < f32::EPSILON);
+        assert!((state.heat_threshold_c - 38.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_fire_risk_drought_multiplier() {
+        // With drought (humidity < 0.2) and extreme severity, fire risk should be very high
+        let drought_factor = 3.0_f32;
+        let extreme_base = 2.5_f32;
+        let expected = extreme_base * drought_factor; // 7.5
+        assert!((expected - 7.5).abs() < f32::EPSILON);
+
+        // Without drought, extreme severity fire risk = 2.5
+        let no_drought_factor = 1.0_f32;
+        let expected_no_drought = extreme_base * no_drought_factor;
+        assert!((expected_no_drought - 2.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_blackout_risk_by_severity() {
+        let expected = [
+            (HeatWaveSeverity::None, 0.0),
+            (HeatWaveSeverity::Moderate, 0.05),
+            (HeatWaveSeverity::Severe, 0.15),
+            (HeatWaveSeverity::Extreme, 0.35),
+        ];
+        for (severity, risk) in &expected {
+            let actual = match severity {
+                HeatWaveSeverity::None => 0.0_f32,
+                HeatWaveSeverity::Moderate => 0.05,
+                HeatWaveSeverity::Severe => 0.15,
+                HeatWaveSeverity::Extreme => 0.35,
+            };
+            assert!(
+                (actual - risk).abs() < f32::EPSILON,
+                "Blackout risk for {:?} should be {}, got {}",
+                severity, risk, actual
+            );
+        }
+    }
+}

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -26,6 +26,7 @@ pub mod grid;
 pub mod groundwater;
 pub mod happiness;
 pub mod health;
+pub mod heat_wave;
 pub mod heating;
 pub mod homelessness;
 pub mod immigration;
@@ -96,6 +97,7 @@ use forest_fire::{ForestFireGrid, ForestFireStats};
 use garbage::{GarbageGrid, WasteCollectionGrid, WasteSystem};
 use groundwater::{GroundwaterGrid, GroundwaterStats, WaterQualityGrid};
 use health::HealthGrid;
+use heat_wave::HeatWaveState;
 use heating::{HeatingGrid, HeatingStats};
 use imports_exports::TradeConnections;
 use land_value::LandValueGrid;
@@ -242,6 +244,7 @@ impl Plugin for SimulationPlugin {
             .init_resource::<StormwaterGrid>()
             .init_resource::<DegreeDays>()
             .init_resource::<ConstructionModifiers>()
+            .init_resource::<HeatWaveState>()
             .init_resource::<WasteAccumulation>()
             .add_event::<BankruptcyEvent>()
             .add_event::<WeatherChangeEvent>()
@@ -519,6 +522,9 @@ impl Plugin for SimulationPlugin {
                     rebuild_csr_on_road_change,
                     virtual_population::adjust_real_citizen_cap.run_if(
                         bevy::time::common_conditions::on_timer(std::time::Duration::from_secs(1)),
+                    ),
+                    heat_wave::update_heat_wave.run_if(
+                        bevy::time::common_conditions::on_timer(std::time::Duration::from_secs(2)),
                     ),
                 ),
             )


### PR DESCRIPTION
## Summary
- Adds `HeatWaveState` tracking consecutive hot days and severity
- Exponential mortality curve, energy/water demand surges, road damage

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)