### PR TITLE
Add traffic LOS grading with road color feedback (UX-073)

### DIFF
--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -16,6 +16,7 @@ pub mod terrain_render;
 pub mod road_render;
 pub mod selection_highlight;
 pub mod status_icons;
+pub mod traffic_los_render;
 
 use camera::{CameraDrag, LeftClickDrag};
 use input::{ActiveTool, CursorGridPos, GridSnap, RoadDrawState, SelectedBuilding, StatusMessage};
@@ -117,7 +118,8 @@ impl Plugin for RenderingPlugin {
                     selection_highlight::animate_selection_highlights,
                     selection_highlight::draw_connected_highlights,
                 ),
-            );
+            )
+            .add_plugins(traffic_los_render::TrafficLosRenderPlugin);
     }
 }
 

--- a/crates/rendering/src/traffic_los_render.rs
+++ b/crates/rendering/src/traffic_los_render.rs
@@ -1,0 +1,185 @@
+//! Traffic LOS road color feedback rendering.
+//!
+//! When the traffic overlay is active, this system tints road segment meshes
+//! with a green-to-red color ramp based on their Level of Service grade.
+//! Road segments are sampled at their midpoint to determine the dominant LOS
+//! for the segment, then the mesh material color is updated accordingly.
+//!
+//! Color ramp: green (A) -> yellow (C) -> orange (D) -> red (F).
+
+use bevy::prelude::*;
+
+use simulation::config::CELL_SIZE;
+use simulation::road_segments::RoadSegmentStore;
+use simulation::traffic_los::{LosGrade, TrafficLosGrid};
+
+use crate::overlay::OverlayMode;
+use crate::road_render::RoadSegmentMesh;
+
+/// LOS color ramp: green (free flow) -> yellow -> orange -> red (gridlock).
+/// Returns an sRGB [r, g, b, a] array for a given LOS grade.
+fn los_color(grade: LosGrade) -> Color {
+    match grade {
+        LosGrade::A => Color::srgb(0.20, 0.72, 0.20), // green
+        LosGrade::B => Color::srgb(0.55, 0.78, 0.22), // yellow-green
+        LosGrade::C => Color::srgb(0.90, 0.82, 0.15), // yellow
+        LosGrade::D => Color::srgb(0.95, 0.55, 0.10), // orange
+        LosGrade::E => Color::srgb(0.90, 0.25, 0.10), // red-orange
+        LosGrade::F => Color::srgb(0.75, 0.08, 0.08), // deep red
+    }
+}
+
+/// The default (neutral) road material color when no overlay is active.
+const ROAD_DEFAULT_COLOR: Color = Color::WHITE;
+
+/// System that updates road segment mesh materials based on traffic LOS.
+///
+/// When the traffic overlay is active, each road segment mesh is colored
+/// according to its LOS grade (sampled from the grid cells the segment covers).
+/// When the overlay is disabled, colors are reset to white (neutral).
+pub fn update_road_los_colors(
+    overlay: Res<crate::overlay::OverlayState>,
+    los_grid: Res<TrafficLosGrid>,
+    store: Res<RoadSegmentStore>,
+    segments_query: Query<(&RoadSegmentMesh, &MeshMaterial3d<StandardMaterial>)>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let is_traffic_overlay = overlay.mode == OverlayMode::Traffic;
+
+    // Only update when overlay state or LOS data changes
+    if !overlay.is_changed() && !los_grid.is_changed() {
+        return;
+    }
+
+    for (seg_mesh, material_handle) in &segments_query {
+        let Some(material) = materials.get_mut(&material_handle.0) else {
+            continue;
+        };
+
+        if !is_traffic_overlay {
+            // Reset to default color when overlay is off
+            material.base_color = ROAD_DEFAULT_COLOR;
+            continue;
+        }
+
+        // Find the segment in the store
+        let Some(segment) = store.get_segment(seg_mesh.segment_id) else {
+            material.base_color = ROAD_DEFAULT_COLOR;
+            continue;
+        };
+
+        // Determine LOS by sampling the rasterized cells of the segment.
+        // Use the worst (highest) LOS grade among all cells for conservative grading.
+        let grade = if segment.rasterized_cells.is_empty() {
+            // Fallback: sample the midpoint of the curve
+            let mid = segment.evaluate(0.5);
+            let gx = (mid.x / CELL_SIZE).clamp(0.0, (los_grid.width - 1) as f32) as usize;
+            let gy = (mid.y / CELL_SIZE).clamp(0.0, (los_grid.height - 1) as f32) as usize;
+            los_grid.get(gx, gy)
+        } else {
+            // Worst LOS across all rasterized cells
+            let mut worst = LosGrade::A;
+            for &(cx, cy) in &segment.rasterized_cells {
+                if cx < los_grid.width && cy < los_grid.height {
+                    let g = los_grid.get(cx, cy);
+                    if (g as u8) > (worst as u8) {
+                        worst = g;
+                    }
+                }
+            }
+            worst
+        };
+
+        material.base_color = los_color(grade);
+    }
+}
+
+pub struct TrafficLosRenderPlugin;
+
+impl Plugin for TrafficLosRenderPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, update_road_los_colors);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_los_color_green_to_red() {
+        let a = los_color(LosGrade::A).to_srgba();
+        let f = los_color(LosGrade::F).to_srgba();
+
+        // LOS A should be greenish (G > R)
+        assert!(
+            a.green > a.red,
+            "LOS A should be green: r={} g={}",
+            a.red,
+            a.green
+        );
+
+        // LOS F should be reddish (R > G)
+        assert!(
+            f.red > f.green,
+            "LOS F should be red: r={} g={}",
+            f.red,
+            f.green
+        );
+    }
+
+    #[test]
+    fn test_los_colors_distinct() {
+        let grades = [
+            LosGrade::A,
+            LosGrade::B,
+            LosGrade::C,
+            LosGrade::D,
+            LosGrade::E,
+            LosGrade::F,
+        ];
+
+        // Each grade should produce a distinct color
+        for i in 0..grades.len() {
+            for j in (i + 1)..grades.len() {
+                let ci = los_color(grades[i]).to_srgba();
+                let cj = los_color(grades[j]).to_srgba();
+                let diff = (ci.red - cj.red).abs()
+                    + (ci.green - cj.green).abs()
+                    + (ci.blue - cj.blue).abs();
+                assert!(
+                    diff > 0.05,
+                    "LOS {:?} and {:?} should have distinct colors",
+                    grades[i],
+                    grades[j]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_los_color_monotonic_red() {
+        // Red channel should generally increase from A to F
+        let a_red = los_color(LosGrade::A).to_srgba().red;
+        let f_red = los_color(LosGrade::F).to_srgba().red;
+        assert!(
+            f_red > a_red,
+            "LOS F should have more red than LOS A: A.r={} F.r={}",
+            a_red,
+            f_red
+        );
+    }
+
+    #[test]
+    fn test_los_color_monotonic_green() {
+        // Green channel should generally decrease from A to F
+        let a_green = los_color(LosGrade::A).to_srgba().green;
+        let f_green = los_color(LosGrade::F).to_srgba().green;
+        assert!(
+            a_green > f_green,
+            "LOS A should have more green than LOS F: A.g={} F.g={}",
+            a_green,
+            f_green
+        );
+    }
+}

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -90,6 +90,7 @@ pub mod time_of_day;
 pub mod tourism;
 pub mod traffic;
 pub mod traffic_accidents;
+pub mod traffic_los;
 pub mod trees;
 pub mod uhi_mitigation;
 pub mod unlocks;
@@ -302,6 +303,7 @@ impl Plugin for SimulationPlugin {
             recycling::RecyclingPlugin,
             road_maintenance::RoadMaintenancePlugin,
             traffic_accidents::TrafficAccidentsPlugin,
+            traffic_los::TrafficLosPlugin,
             loans::LoansPlugin,
         ));
 

--- a/crates/simulation/src/traffic_los.rs
+++ b/crates/simulation/src/traffic_los.rs
@@ -1,0 +1,316 @@
+//! Traffic Level of Service (LOS) grading system.
+//!
+//! Computes LOS grades A through F for each road cell based on traffic density
+//! relative to road capacity. LOS A represents free flow, while LOS F represents
+//! gridlock conditions.
+//!
+//! The grades follow the Highway Capacity Manual (HCM) convention:
+//! - A: Free flow (v/c ratio < 0.35)
+//! - B: Reasonably free flow (v/c ratio < 0.55)
+//! - C: Stable flow (v/c ratio < 0.70)
+//! - D: Approaching unstable (v/c ratio < 0.85)
+//! - E: Unstable flow (v/c ratio < 1.00)
+//! - F: Gridlock / forced flow (v/c ratio >= 1.00)
+
+use bevy::prelude::*;
+use bitcode::{Decode, Encode};
+
+use crate::config::{GRID_HEIGHT, GRID_WIDTH};
+use crate::grid::{CellType, RoadType, WorldGrid};
+use crate::traffic::TrafficGrid;
+use crate::Saveable;
+
+/// Level of Service grade from A (best) to F (worst).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Encode, Decode)]
+#[repr(u8)]
+pub enum LosGrade {
+    #[default]
+    A = 0,
+    B = 1,
+    C = 2,
+    D = 3,
+    E = 4,
+    F = 5,
+}
+
+impl LosGrade {
+    /// Convert a volume-to-capacity ratio to a LOS grade.
+    pub fn from_vc_ratio(vc: f32) -> Self {
+        if vc < 0.35 {
+            LosGrade::A
+        } else if vc < 0.55 {
+            LosGrade::B
+        } else if vc < 0.70 {
+            LosGrade::C
+        } else if vc < 0.85 {
+            LosGrade::D
+        } else if vc < 1.00 {
+            LosGrade::E
+        } else {
+            LosGrade::F
+        }
+    }
+
+    /// Return a normalized 0.0..1.0 value for use in color ramps.
+    /// A=0.0, F=1.0.
+    pub fn as_t(self) -> f32 {
+        self as u8 as f32 / 5.0
+    }
+
+    /// Human-readable label.
+    pub fn label(self) -> &'static str {
+        match self {
+            LosGrade::A => "LOS A (Free Flow)",
+            LosGrade::B => "LOS B (Reasonably Free)",
+            LosGrade::C => "LOS C (Stable Flow)",
+            LosGrade::D => "LOS D (Approaching Unstable)",
+            LosGrade::E => "LOS E (Unstable Flow)",
+            LosGrade::F => "LOS F (Gridlock)",
+        }
+    }
+}
+
+/// Returns the capacity (max vehicles per tick) for a given road type.
+/// Higher-capacity roads tolerate more traffic before degrading LOS.
+fn road_capacity(road_type: RoadType) -> f32 {
+    match road_type {
+        RoadType::Path => 3.0,
+        RoadType::OneWay => 8.0,
+        RoadType::Local => 10.0,
+        RoadType::Avenue => 18.0,
+        RoadType::Boulevard => 25.0,
+        RoadType::Highway => 35.0,
+    }
+}
+
+/// Per-cell LOS grade grid covering the entire map.
+#[derive(Resource, Encode, Decode)]
+pub struct TrafficLosGrid {
+    pub grades: Vec<u8>,
+    pub width: usize,
+    pub height: usize,
+}
+
+impl Default for TrafficLosGrid {
+    fn default() -> Self {
+        Self {
+            grades: vec![0; GRID_WIDTH * GRID_HEIGHT],
+            width: GRID_WIDTH,
+            height: GRID_HEIGHT,
+        }
+    }
+}
+
+impl TrafficLosGrid {
+    #[inline]
+    pub fn get(&self, x: usize, y: usize) -> LosGrade {
+        let raw = self.grades[y * self.width + x];
+        match raw {
+            0 => LosGrade::A,
+            1 => LosGrade::B,
+            2 => LosGrade::C,
+            3 => LosGrade::D,
+            4 => LosGrade::E,
+            _ => LosGrade::F,
+        }
+    }
+
+    #[inline]
+    pub fn set(&mut self, x: usize, y: usize, grade: LosGrade) {
+        self.grades[y * self.width + x] = grade as u8;
+    }
+
+    /// Return the LOS as a normalized float 0.0..1.0 for color mapping.
+    #[inline]
+    pub fn get_t(&self, x: usize, y: usize) -> f32 {
+        self.get(x, y).as_t()
+    }
+}
+
+impl Saveable for TrafficLosGrid {
+    const SAVE_KEY: &'static str = "traffic_los";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        // Skip saving if all grades are A (default)
+        if self.grades.iter().all(|&g| g == 0) {
+            return None;
+        }
+        Some(bitcode::encode(self))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        bitcode::decode(bytes).unwrap_or_default()
+    }
+}
+
+/// System that computes LOS grades for all road cells.
+/// Runs every 10 ticks, after traffic density is updated.
+pub fn update_traffic_los(
+    tick: Res<crate::TickCounter>,
+    grid: Res<WorldGrid>,
+    traffic: Res<TrafficGrid>,
+    mut los_grid: ResMut<TrafficLosGrid>,
+) {
+    // Run every 10 ticks (aligned with traffic updates which run every 5)
+    if !tick.0.is_multiple_of(10) {
+        return;
+    }
+
+    for y in 0..GRID_HEIGHT {
+        for x in 0..GRID_WIDTH {
+            let cell = grid.get(x, y);
+            if cell.cell_type != CellType::Road {
+                // Non-road cells default to A
+                los_grid.set(x, y, LosGrade::A);
+                continue;
+            }
+
+            let density = traffic.get(x, y) as f32;
+            let capacity = road_capacity(cell.road_type);
+            let vc_ratio = density / capacity;
+            let grade = LosGrade::from_vc_ratio(vc_ratio);
+            los_grid.set(x, y, grade);
+        }
+    }
+}
+
+pub struct TrafficLosPlugin;
+
+impl Plugin for TrafficLosPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<TrafficLosGrid>().add_systems(
+            FixedUpdate,
+            update_traffic_los.after(crate::traffic::update_traffic_density),
+        );
+
+        // Register for save/load
+        let mut registry = app
+            .world_mut()
+            .get_resource_or_insert_with(crate::SaveableRegistry::default);
+        registry.register::<TrafficLosGrid>();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_los_grade_from_vc_ratio() {
+        assert_eq!(LosGrade::from_vc_ratio(0.0), LosGrade::A);
+        assert_eq!(LosGrade::from_vc_ratio(0.20), LosGrade::A);
+        assert_eq!(LosGrade::from_vc_ratio(0.34), LosGrade::A);
+        assert_eq!(LosGrade::from_vc_ratio(0.35), LosGrade::B);
+        assert_eq!(LosGrade::from_vc_ratio(0.54), LosGrade::B);
+        assert_eq!(LosGrade::from_vc_ratio(0.55), LosGrade::C);
+        assert_eq!(LosGrade::from_vc_ratio(0.69), LosGrade::C);
+        assert_eq!(LosGrade::from_vc_ratio(0.70), LosGrade::D);
+        assert_eq!(LosGrade::from_vc_ratio(0.84), LosGrade::D);
+        assert_eq!(LosGrade::from_vc_ratio(0.85), LosGrade::E);
+        assert_eq!(LosGrade::from_vc_ratio(0.99), LosGrade::E);
+        assert_eq!(LosGrade::from_vc_ratio(1.00), LosGrade::F);
+        assert_eq!(LosGrade::from_vc_ratio(2.50), LosGrade::F);
+    }
+
+    #[test]
+    fn test_los_grade_as_t() {
+        assert!((LosGrade::A.as_t() - 0.0).abs() < f32::EPSILON);
+        assert!((LosGrade::B.as_t() - 0.2).abs() < f32::EPSILON);
+        assert!((LosGrade::C.as_t() - 0.4).abs() < f32::EPSILON);
+        assert!((LosGrade::D.as_t() - 0.6).abs() < f32::EPSILON);
+        assert!((LosGrade::E.as_t() - 0.8).abs() < f32::EPSILON);
+        assert!((LosGrade::F.as_t() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_los_grid_default() {
+        let grid = TrafficLosGrid::default();
+        assert_eq!(grid.grades.len(), GRID_WIDTH * GRID_HEIGHT);
+        for y in 0..3 {
+            for x in 0..3 {
+                assert_eq!(grid.get(x, y), LosGrade::A);
+            }
+        }
+    }
+
+    #[test]
+    fn test_los_grid_set_get() {
+        let mut grid = TrafficLosGrid::default();
+        grid.set(5, 5, LosGrade::C);
+        assert_eq!(grid.get(5, 5), LosGrade::C);
+        grid.set(5, 5, LosGrade::F);
+        assert_eq!(grid.get(5, 5), LosGrade::F);
+    }
+
+    #[test]
+    fn test_los_grid_get_t() {
+        let mut grid = TrafficLosGrid::default();
+        grid.set(0, 0, LosGrade::A);
+        assert!((grid.get_t(0, 0) - 0.0).abs() < f32::EPSILON);
+        grid.set(0, 0, LosGrade::F);
+        assert!((grid.get_t(0, 0) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_road_capacity_ordering() {
+        // Higher road types should have more capacity
+        assert!(road_capacity(RoadType::Path) < road_capacity(RoadType::Local));
+        assert!(road_capacity(RoadType::Local) < road_capacity(RoadType::Avenue));
+        assert!(road_capacity(RoadType::Avenue) < road_capacity(RoadType::Boulevard));
+        assert!(road_capacity(RoadType::Boulevard) < road_capacity(RoadType::Highway));
+    }
+
+    #[test]
+    fn test_los_label_non_empty() {
+        let grades = [
+            LosGrade::A,
+            LosGrade::B,
+            LosGrade::C,
+            LosGrade::D,
+            LosGrade::E,
+            LosGrade::F,
+        ];
+        for grade in &grades {
+            assert!(!grade.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn test_saveable_skip_default() {
+        let grid = TrafficLosGrid::default();
+        assert!(
+            grid.save_to_bytes().is_none(),
+            "Default state should skip saving"
+        );
+    }
+
+    #[test]
+    fn test_saveable_roundtrip() {
+        let mut grid = TrafficLosGrid::default();
+        grid.set(10, 10, LosGrade::D);
+        grid.set(20, 20, LosGrade::F);
+
+        let bytes = grid.save_to_bytes().expect("Non-default should save");
+        let restored = TrafficLosGrid::load_from_bytes(&bytes);
+
+        assert_eq!(restored.get(10, 10), LosGrade::D);
+        assert_eq!(restored.get(20, 20), LosGrade::F);
+        assert_eq!(restored.get(0, 0), LosGrade::A);
+    }
+
+    #[test]
+    fn test_highway_needs_more_traffic_for_congestion() {
+        // A highway with 15 vehicles should still be LOS A or B,
+        // while a local road with the same should be LOS F
+        let highway_vc = 15.0 / road_capacity(RoadType::Highway);
+        let local_vc = 15.0 / road_capacity(RoadType::Local);
+
+        let highway_grade = LosGrade::from_vc_ratio(highway_vc);
+        let local_grade = LosGrade::from_vc_ratio(local_vc);
+
+        assert!(
+            (highway_grade as u8) < (local_grade as u8),
+            "Highway should have better LOS than local road with same traffic"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add Level of Service (A-F) grading for road cells based on traffic volume-to-capacity ratios, following Highway Capacity Manual conventions
- Color-code road segment meshes with green-yellow-orange-red ramp when traffic overlay is active
- Per-road-type capacity thresholds ensure highways tolerate more traffic than local roads before degrading

## Details
**Simulation** (`crates/simulation/src/traffic_los.rs`):
- `LosGrade` enum (A-F) with v/c ratio thresholds: A(<0.35), B(<0.55), C(<0.70), D(<0.85), E(<1.00), F(>=1.00)
- `TrafficLosGrid` resource storing per-cell LOS grades, updated every 10 ticks
- Road capacity varies by type: Path(3), OneWay(8), Local(10), Avenue(18), Boulevard(25), Highway(35)
- Implements `Saveable` trait for save/load via bitcode serialization

**Rendering** (`crates/rendering/src/traffic_los_render.rs`):
- `update_road_los_colors` system tints road segment mesh materials based on LOS grade
- Color ramp: green (A) -> yellow-green (B) -> yellow (C) -> orange (D) -> red-orange (E) -> deep red (F)
- Samples worst LOS across all rasterized cells of each segment for conservative grading
- Only active during traffic overlay mode; resets to default white otherwise

## Test plan
- [ ] Unit tests for LOS grade thresholds and v/c ratio mapping
- [ ] Unit tests for LOS grid get/set and saveable roundtrip
- [ ] Unit tests for road capacity ordering
- [ ] Unit tests for LOS color distinctness and monotonic red/green channels
- [ ] CI: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy`, `cargo fmt --check`

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)