### PR TITLE
Add day/night cycle visual controls (UX-069)

### DIFF
--- a/crates/rendering/src/day_night.rs
+++ b/crates/rendering/src/day_night.rs
@@ -1,18 +1,21 @@
 use bevy::pbr::{DistanceFog, FogFalloff};
 use bevy::prelude::*;
+use simulation::day_night_controls::DayNightControls;
 use simulation::fog::FogState;
-use simulation::time_of_day::GameClock;
 use std::f32::consts::PI;
 
 /// Updates the directional light (sun), its transform, and the ambient light
 /// based on the current game hour to create a day/night cycle.
+///
+/// Uses `DayNightControls::effective_hour()` so that time-lock and cycle-speed
+/// settings are respected.
 pub fn update_day_night_cycle(
-    clock: Res<GameClock>,
+    controls: Res<DayNightControls>,
     mut sun_query: Query<&mut DirectionalLight>,
     mut sun_transform_query: Query<&mut Transform, With<DirectionalLight>>,
     mut ambient: ResMut<AmbientLight>,
 ) {
-    let hour = clock.hour;
+    let hour = controls.effective_hour();
 
     // --- Sun illuminance and color ---
     let (sun_illuminance, sun_color) = sun_light_for_hour(hour);

--- a/crates/simulation/src/day_night_controls.rs
+++ b/crates/simulation/src/day_night_controls.rs
@@ -1,0 +1,250 @@
+//! Day/Night cycle visual controls (UX-069).
+//!
+//! Exposes player controls for the day/night cycle rendering:
+//! - Time-of-day slider: set a specific hour for rendering
+//! - Lock time option: freeze the visual hour at a specific time (e.g. always daytime)
+//! - Cycle speed: normal, fast, or disabled
+//!
+//! These settings only affect the *visual* rendering of the day/night cycle.
+//! The simulation's `GameClock` continues to tick normally regardless of these settings.
+//! Settings persist across saves via the `Saveable` trait (bitcode serialization).
+
+use bevy::prelude::*;
+
+use crate::Saveable;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/// Controls the speed of the visual day/night cycle.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, bitcode::Encode, bitcode::Decode)]
+pub enum CycleSpeed {
+    /// Normal cycle speed (follows game clock 1:1).
+    #[default]
+    Normal,
+    /// Fast cycle speed (visual hour advances at 2x game clock rate).
+    Fast,
+    /// Visual cycle is disabled; hour stays fixed (equivalent to lock at current hour).
+    Disabled,
+}
+
+// =============================================================================
+// Resource
+// =============================================================================
+
+/// Player-facing controls for the day/night visual cycle.
+///
+/// This resource controls how the rendering layer interprets the game clock
+/// for lighting purposes. The simulation clock itself is unaffected.
+#[derive(Resource, Debug, Clone, bitcode::Encode, bitcode::Decode)]
+pub struct DayNightControls {
+    /// If `Some(hour)`, the visual hour is locked to this value (0.0..24.0).
+    /// The day/night rendering will use this hour instead of the game clock.
+    pub locked_hour: Option<f32>,
+
+    /// Speed multiplier for the visual day/night cycle.
+    pub cycle_speed: CycleSpeed,
+
+    /// The visual hour used by the rendering system.
+    /// Updated each frame based on locked_hour, cycle_speed, and the game clock.
+    /// When not locked, this tracks the game clock (possibly at a different speed).
+    pub visual_hour: f32,
+}
+
+impl Default for DayNightControls {
+    fn default() -> Self {
+        Self {
+            locked_hour: None,
+            cycle_speed: CycleSpeed::Normal,
+            visual_hour: 6.0, // default start: 6 AM
+        }
+    }
+}
+
+impl DayNightControls {
+    /// Returns the effective hour for rendering.
+    ///
+    /// If a locked hour is set, returns that. Otherwise returns `visual_hour`.
+    pub fn effective_hour(&self) -> f32 {
+        if let Some(locked) = self.locked_hour {
+            locked
+        } else {
+            self.visual_hour
+        }
+    }
+
+    /// Returns the visual cycle speed multiplier.
+    pub fn speed_multiplier(&self) -> f32 {
+        match self.cycle_speed {
+            CycleSpeed::Normal => 1.0,
+            CycleSpeed::Fast => 2.0,
+            CycleSpeed::Disabled => 0.0,
+        }
+    }
+}
+
+// =============================================================================
+// Saveable
+// =============================================================================
+
+impl Saveable for DayNightControls {
+    const SAVE_KEY: &'static str = "day_night_controls";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        // Always save: even default settings should persist so the player's
+        // choice of "normal" is explicit after loading.
+        Some(bitcode::encode(self))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        bitcode::decode(bytes).unwrap_or_default()
+    }
+}
+
+// =============================================================================
+// Systems
+// =============================================================================
+
+/// Updates the visual hour based on the game clock and day/night control settings.
+///
+/// - When locked, `visual_hour` stays at the locked value.
+/// - When in `Disabled` cycle speed, `visual_hour` freezes at its current value.
+/// - Otherwise, `visual_hour` follows the game clock hour (possibly at an altered rate).
+pub fn update_visual_hour(
+    clock: Res<crate::time_of_day::GameClock>,
+    mut controls: ResMut<DayNightControls>,
+) {
+    if controls.locked_hour.is_some() {
+        // Locked: visual hour is always the locked value
+        controls.visual_hour = controls.locked_hour.unwrap();
+        return;
+    }
+
+    match controls.cycle_speed {
+        CycleSpeed::Normal => {
+            // Follow game clock directly
+            controls.visual_hour = clock.hour;
+        }
+        CycleSpeed::Fast => {
+            // Visual hour advances at 2x the game clock rate.
+            // We compute a doubled-speed offset from the game clock.
+            controls.visual_hour = (clock.hour * 2.0) % 24.0;
+        }
+        CycleSpeed::Disabled => {
+            // Visual hour stays frozen at its current value -- no update needed.
+        }
+    }
+}
+
+// =============================================================================
+// Plugin
+// =============================================================================
+
+pub struct DayNightControlsPlugin;
+
+impl Plugin for DayNightControlsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<DayNightControls>()
+            .add_systems(Update, update_visual_hour);
+
+        // Register for save/load via the SaveableRegistry
+        app.init_resource::<crate::SaveableRegistry>();
+        app.world_mut()
+            .resource_mut::<crate::SaveableRegistry>()
+            .register::<DayNightControls>();
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_controls() {
+        let controls = DayNightControls::default();
+        assert_eq!(controls.locked_hour, None);
+        assert_eq!(controls.cycle_speed, CycleSpeed::Normal);
+        assert!((controls.visual_hour - 6.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_effective_hour_unlocked() {
+        let controls = DayNightControls {
+            locked_hour: None,
+            visual_hour: 14.5,
+            ..Default::default()
+        };
+        assert!((controls.effective_hour() - 14.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_effective_hour_locked() {
+        let controls = DayNightControls {
+            locked_hour: Some(12.0),
+            visual_hour: 20.0, // should be ignored
+            ..Default::default()
+        };
+        assert!((controls.effective_hour() - 12.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_speed_multiplier() {
+        assert!(
+            (DayNightControls {
+                cycle_speed: CycleSpeed::Normal,
+                ..Default::default()
+            }
+            .speed_multiplier()
+                - 1.0)
+                .abs()
+                < f32::EPSILON
+        );
+
+        assert!(
+            (DayNightControls {
+                cycle_speed: CycleSpeed::Fast,
+                ..Default::default()
+            }
+            .speed_multiplier()
+                - 2.0)
+                .abs()
+                < f32::EPSILON
+        );
+
+        assert!(
+            (DayNightControls {
+                cycle_speed: CycleSpeed::Disabled,
+                ..Default::default()
+            }
+            .speed_multiplier()
+                - 0.0)
+                .abs()
+                < f32::EPSILON
+        );
+    }
+
+    #[test]
+    fn test_saveable_roundtrip() {
+        let controls = DayNightControls {
+            locked_hour: Some(15.5),
+            cycle_speed: CycleSpeed::Fast,
+            visual_hour: 15.5,
+        };
+        let bytes = controls.save_to_bytes().unwrap();
+        let loaded = DayNightControls::load_from_bytes(&bytes);
+        assert!((loaded.locked_hour.unwrap() - 15.5).abs() < f32::EPSILON);
+        assert_eq!(loaded.cycle_speed, CycleSpeed::Fast);
+    }
+
+    #[test]
+    fn test_saveable_default_still_saves() {
+        let controls = DayNightControls::default();
+        // Even default state should save (player explicitly chose Normal)
+        assert!(controls.save_to_bytes().is_some());
+    }
+}

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -18,6 +18,7 @@ pub mod config;
 pub mod crime;
 pub mod cso;
 pub mod cumulative_zoning;
+pub mod day_night_controls;
 pub mod death_care;
 pub mod degree_days;
 pub mod disasters;
@@ -308,6 +309,9 @@ impl Plugin for SimulationPlugin {
             traffic_los::TrafficLosPlugin,
             loans::LoansPlugin,
         ));
+
+        // Day/night visual controls
+        app.add_plugins(day_night_controls::DayNightControlsPlugin);
 
         // Weather and environment
         app.add_plugins((

--- a/crates/ui/src/day_night_panel.rs
+++ b/crates/ui/src/day_night_panel.rs
@@ -1,0 +1,196 @@
+//! Day/Night cycle visual controls UI panel (UX-069).
+//!
+//! Provides an egui window with:
+//! - Time-of-day slider (0..24h)
+//! - Lock/unlock toggle to freeze the visual hour
+//! - Cycle speed selector (Normal / Fast / Disabled)
+//! - Keybind (N) to toggle the panel
+
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts};
+
+use simulation::day_night_controls::{CycleSpeed, DayNightControls};
+
+// =============================================================================
+// Resources
+// =============================================================================
+
+/// Whether the day/night controls panel is visible.
+#[derive(Resource, Default)]
+pub struct DayNightPanelVisible(pub bool);
+
+// =============================================================================
+// Systems
+// =============================================================================
+
+/// Toggles the day/night controls panel with the N key.
+pub fn day_night_panel_keybind(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut visible: ResMut<DayNightPanelVisible>,
+    mut contexts: EguiContexts,
+) {
+    if contexts.ctx_mut().wants_keyboard_input() {
+        return;
+    }
+    if keyboard.just_pressed(KeyCode::KeyN) {
+        visible.0 = !visible.0;
+    }
+}
+
+/// Renders the day/night controls window.
+pub fn day_night_panel_ui(
+    mut contexts: EguiContexts,
+    mut visible: ResMut<DayNightPanelVisible>,
+    mut controls: ResMut<DayNightControls>,
+) {
+    if !visible.0 {
+        return;
+    }
+
+    let mut open = true;
+    egui::Window::new("Day/Night Controls")
+        .open(&mut open)
+        .resizable(false)
+        .default_width(260.0)
+        .show(contexts.ctx_mut(), |ui| {
+            ui.spacing_mut().item_spacing.y = 8.0;
+
+            // --- Current visual hour display ---
+            let effective = controls.effective_hour();
+            let h = effective as u32;
+            let m = ((effective - h as f32) * 60.0) as u32;
+            let period = time_period_label(effective);
+            ui.heading(format!("{:02}:{:02} ({})", h, m, period));
+
+            ui.separator();
+
+            // --- Time-of-day slider ---
+            ui.label("Time of Day:");
+            let mut slider_hour = controls.effective_hour();
+            let slider_response = ui.add(
+                egui::Slider::new(&mut slider_hour, 0.0..=23.99)
+                    .text("hour")
+                    .custom_formatter(|v, _| {
+                        let hh = v as u32;
+                        let mm = ((v - hh as f64) * 60.0) as u32;
+                        format!("{:02}:{:02}", hh, mm)
+                    }),
+            );
+            if slider_response.changed() {
+                // When the player manually drags the slider, lock to that hour
+                controls.locked_hour = Some(slider_hour);
+                controls.visual_hour = slider_hour;
+            }
+
+            ui.separator();
+
+            // --- Lock time toggle ---
+            let is_locked = controls.locked_hour.is_some();
+            let lock_label = if is_locked {
+                "Locked (click to unlock)"
+            } else {
+                "Unlocked (click to lock at current time)"
+            };
+            if ui.selectable_label(is_locked, lock_label).clicked() {
+                if is_locked {
+                    controls.locked_hour = None;
+                } else {
+                    controls.locked_hour = Some(controls.visual_hour);
+                }
+            }
+
+            ui.separator();
+
+            // --- Cycle speed ---
+            ui.label("Cycle Speed:");
+            ui.horizontal(|ui| {
+                if ui
+                    .selectable_label(controls.cycle_speed == CycleSpeed::Normal, "Normal")
+                    .clicked()
+                {
+                    controls.cycle_speed = CycleSpeed::Normal;
+                    // Unlock when changing speed (user wants to see the cycle)
+                    if controls.locked_hour.is_some() {
+                        controls.locked_hour = None;
+                    }
+                }
+                if ui
+                    .selectable_label(controls.cycle_speed == CycleSpeed::Fast, "Fast")
+                    .clicked()
+                {
+                    controls.cycle_speed = CycleSpeed::Fast;
+                    if controls.locked_hour.is_some() {
+                        controls.locked_hour = None;
+                    }
+                }
+                if ui
+                    .selectable_label(controls.cycle_speed == CycleSpeed::Disabled, "Disabled")
+                    .clicked()
+                {
+                    controls.cycle_speed = CycleSpeed::Disabled;
+                }
+            });
+
+            // --- Quick presets ---
+            ui.separator();
+            ui.label("Quick Presets:");
+            ui.horizontal(|ui| {
+                if ui.button("Dawn (6:00)").clicked() {
+                    controls.locked_hour = Some(6.0);
+                    controls.visual_hour = 6.0;
+                }
+                if ui.button("Noon (12:00)").clicked() {
+                    controls.locked_hour = Some(12.0);
+                    controls.visual_hour = 12.0;
+                }
+                if ui.button("Dusk (18:00)").clicked() {
+                    controls.locked_hour = Some(18.0);
+                    controls.visual_hour = 18.0;
+                }
+                if ui.button("Night (0:00)").clicked() {
+                    controls.locked_hour = Some(0.0);
+                    controls.visual_hour = 0.0;
+                }
+            });
+        });
+
+    if !open {
+        visible.0 = false;
+    }
+}
+
+/// Returns a human-readable label for the time period.
+fn time_period_label(hour: f32) -> &'static str {
+    if (5.0..7.0).contains(&hour) {
+        "Dawn"
+    } else if (7.0..12.0).contains(&hour) {
+        "Morning"
+    } else if (12.0..14.0).contains(&hour) {
+        "Midday"
+    } else if (14.0..17.0).contains(&hour) {
+        "Afternoon"
+    } else if (17.0..19.0).contains(&hour) {
+        "Dusk"
+    } else if (19.0..22.0).contains(&hour) {
+        "Evening"
+    } else {
+        "Night"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_time_period_labels() {
+        assert_eq!(time_period_label(5.5), "Dawn");
+        assert_eq!(time_period_label(9.0), "Morning");
+        assert_eq!(time_period_label(12.5), "Midday");
+        assert_eq!(time_period_label(15.0), "Afternoon");
+        assert_eq!(time_period_label(18.0), "Dusk");
+        assert_eq!(time_period_label(20.0), "Evening");
+        assert_eq!(time_period_label(23.0), "Night");
+        assert_eq!(time_period_label(2.0), "Night");
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -3,6 +3,7 @@ use bevy_egui::EguiPlugin;
 
 pub mod cell_info_panel;
 pub mod citizen_info;
+pub mod day_night_panel;
 pub mod district_inspect;
 pub mod graphs;
 pub mod info_panel;
@@ -26,6 +27,7 @@ impl Plugin for UiPlugin {
             .add_plugins(road_segment_info::RoadSegmentInfoPlugin)
             .add_plugins(waste_dashboard::WasteDashboardPlugin)
             .add_plugins(localization::LocalizationUiPlugin)
+            .init_resource::<day_night_panel::DayNightPanelVisible>()
             .init_resource::<milestones::Milestones>()
             .init_resource::<graphs::HistoryData>()
             .init_resource::<toolbar::OpenCategory>()
@@ -62,6 +64,8 @@ impl Plugin for UiPlugin {
                     water_dashboard::water_dashboard_ui,
                     water_dashboard::water_dashboard_keybind,
                     tutorial::tutorial_ui,
+                    day_night_panel::day_night_panel_keybind,
+                    day_night_panel::day_night_panel_ui,
                 ),
             );
     }


### PR DESCRIPTION
## Summary
- Adds `DayNightControls` resource (simulation crate) with time-of-day slider, lock-time toggle, and cycle speed selector (Normal/Fast/Disabled)
- Adds egui panel (UI crate) toggled with N key, providing slider, lock toggle, cycle speed buttons, and quick presets (Dawn/Noon/Dusk/Night)
- Updates `update_day_night_cycle` (rendering crate) to use `DayNightControls::effective_hour()` instead of reading `GameClock.hour` directly
- Settings persist across saves via `Saveable` trait (bitcode serialization)

## Test plan
- [ ] Verify `cargo test --workspace` passes (unit tests for controls resource, saveable roundtrip, time period labels)
- [ ] Press N in-game to open the Day/Night Controls panel
- [ ] Drag the time-of-day slider and verify lighting changes in real-time
- [ ] Click "Lock" and verify the visual hour stays frozen while simulation continues
- [ ] Test cycle speed buttons: Normal follows game clock, Fast advances at 2x, Disabled freezes
- [ ] Quick presets (Dawn/Noon/Dusk/Night) should lock at the corresponding hour
- [ ] Save and load a game; verify day/night control settings persist

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)