### PR TITLE
Add multi-select for batch operations (UX-059)

### DIFF
--- a/crates/simulation/src/grid.rs
+++ b/crates/simulation/src/grid.rs
@@ -98,6 +98,26 @@ impl RoadType {
             RoadType::Path => 0,
         }
     }
+
+    /// Returns the next upgrade tier for this road type, or `None` if already at max tier.
+    /// Upgrade path: Path -> Local -> Avenue -> Boulevard, OneWay -> Avenue.
+    /// Highway and Boulevard have no further upgrade.
+    pub fn upgrade_tier(self) -> Option<RoadType> {
+        match self {
+            RoadType::Path => Some(RoadType::Local),
+            RoadType::Local => Some(RoadType::Avenue),
+            RoadType::Avenue => Some(RoadType::Boulevard),
+            RoadType::OneWay => Some(RoadType::Avenue),
+            RoadType::Boulevard | RoadType::Highway => None,
+        }
+    }
+
+    /// Returns the cost to upgrade this road type to its next tier.
+    /// The upgrade cost is the difference between the next tier cost and the current cost.
+    /// Returns `None` if no upgrade is available.
+    pub fn upgrade_cost(self) -> Option<f64> {
+        self.upgrade_tier().map(|next| next.cost() - self.cost())
+    }
 }
 
 impl ZoneType {

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -62,6 +62,7 @@ pub mod localization;
 pub mod lod;
 pub mod market;
 pub mod movement;
+pub mod multi_select;
 pub mod natural_resources;
 pub mod neighborhood_quality;
 pub mod nimby;
@@ -410,6 +411,7 @@ impl Plugin for SimulationPlugin {
             cumulative_zoning::CumulativeZoningPlugin,
             parking::ParkingPlugin,
             tutorial::TutorialPlugin,
+            multi_select::MultiSelectPlugin,
         ));
 
         // Localization infrastructure

--- a/crates/simulation/src/multi_select.rs
+++ b/crates/simulation/src/multi_select.rs
@@ -1,0 +1,343 @@
+//! Multi-Select for Batch Operations (UX-059).
+//!
+//! Provides a `MultiSelectState` resource that tracks which entities (buildings
+//! or road cells) the player has Ctrl+Clicked to add to a batch selection.
+//!
+//! Supports two batch operations:
+//! - **Batch Bulldoze**: demolish all selected entities at once.
+//! - **Batch Road Upgrade**: upgrade all selected road cells to their next tier.
+//!
+//! The selection count and total cost for the pending batch operation are
+//! exposed for the UI status bar.
+
+use bevy::prelude::*;
+use bitcode::{Decode, Encode};
+
+use crate::Saveable;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/// Represents a selectable item in the multi-select system.
+/// Can be either a building entity or a road cell (by grid coordinates).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SelectableItem {
+    /// A building or service entity.
+    Building(Entity),
+    /// A road cell identified by grid coordinates.
+    RoadCell { x: usize, y: usize },
+}
+
+// =============================================================================
+// Resource
+// =============================================================================
+
+/// Resource tracking the current multi-select state.
+///
+/// Players add items via Ctrl+Click. The UI reads `selected_items` to display
+/// the count and compute batch operation costs.
+#[derive(Resource, Debug, Clone, Default)]
+pub struct MultiSelectState {
+    /// The set of currently selected items.
+    pub selected_items: Vec<SelectableItem>,
+}
+
+impl MultiSelectState {
+    /// Add an item to the selection if not already present.
+    pub fn add(&mut self, item: SelectableItem) {
+        if !self.selected_items.contains(&item) {
+            self.selected_items.push(item);
+        }
+    }
+
+    /// Remove an item from the selection (toggle off).
+    pub fn remove(&mut self, item: &SelectableItem) {
+        self.selected_items.retain(|i| i != item);
+    }
+
+    /// Toggle an item: add it if absent, remove it if present.
+    pub fn toggle(&mut self, item: SelectableItem) {
+        if self.selected_items.contains(&item) {
+            self.remove(&item);
+        } else {
+            self.add(item);
+        }
+    }
+
+    /// Returns the number of selected items.
+    pub fn count(&self) -> usize {
+        self.selected_items.len()
+    }
+
+    /// Check whether a specific item is selected.
+    pub fn contains(&self, item: &SelectableItem) -> bool {
+        self.selected_items.contains(item)
+    }
+
+    /// Clear the entire selection.
+    pub fn clear(&mut self) {
+        self.selected_items.clear();
+    }
+
+    /// Returns true if the selection is empty.
+    pub fn is_empty(&self) -> bool {
+        self.selected_items.is_empty()
+    }
+
+    /// Count of selected buildings.
+    pub fn building_count(&self) -> usize {
+        self.selected_items
+            .iter()
+            .filter(|i| matches!(i, SelectableItem::Building(_)))
+            .count()
+    }
+
+    /// Count of selected road cells.
+    pub fn road_count(&self) -> usize {
+        self.selected_items
+            .iter()
+            .filter(|i| matches!(i, SelectableItem::RoadCell { .. }))
+            .count()
+    }
+
+    /// Collect all building entities from the selection.
+    pub fn buildings(&self) -> Vec<Entity> {
+        self.selected_items
+            .iter()
+            .filter_map(|i| match i {
+                SelectableItem::Building(e) => Some(*e),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Collect all road cell coordinates from the selection.
+    pub fn road_cells(&self) -> Vec<(usize, usize)> {
+        self.selected_items
+            .iter()
+            .filter_map(|i| match i {
+                SelectableItem::RoadCell { x, y } => Some((*x, *y)),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+// =============================================================================
+// Saveable
+// =============================================================================
+
+/// Serializable form for save/load. We don't persist Entity references across
+/// saves (they're not stable), so we only save road cell selections.
+/// Building selections are cleared on save/load since entity IDs change.
+#[derive(Encode, Decode, Default)]
+struct MultiSelectSave {
+    road_cells: Vec<(u16, u16)>,
+}
+
+impl Saveable for MultiSelectState {
+    const SAVE_KEY: &'static str = "multi_select";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.is_empty() {
+            return None;
+        }
+        let save = MultiSelectSave {
+            road_cells: self
+                .road_cells()
+                .iter()
+                .map(|&(x, y)| (x as u16, y as u16))
+                .collect(),
+        };
+        Some(bitcode::encode(&save))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        let save: MultiSelectSave = bitcode::decode(bytes).unwrap_or_default();
+        let mut state = MultiSelectState::default();
+        for (x, y) in save.road_cells {
+            state.add(SelectableItem::RoadCell {
+                x: x as usize,
+                y: y as usize,
+            });
+        }
+        state
+    }
+}
+
+// =============================================================================
+// Events
+// =============================================================================
+
+/// Event fired to request a batch bulldoze of all selected items.
+#[derive(Event)]
+pub struct BatchBulldozeEvent;
+
+/// Event fired to request a batch road upgrade of all selected road cells.
+#[derive(Event)]
+pub struct BatchRoadUpgradeEvent;
+
+// =============================================================================
+// Plugin
+// =============================================================================
+
+pub struct MultiSelectPlugin;
+
+impl Plugin for MultiSelectPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<MultiSelectState>()
+            .add_event::<BatchBulldozeEvent>()
+            .add_event::<BatchRoadUpgradeEvent>();
+
+        // Register with save system
+        let mut registry = app.world_mut().resource_mut::<crate::SaveableRegistry>();
+        registry.register::<MultiSelectState>();
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_and_contains() {
+        let mut state = MultiSelectState::default();
+        let item = SelectableItem::RoadCell { x: 5, y: 10 };
+        state.add(item);
+        assert!(state.contains(&item));
+        assert_eq!(state.count(), 1);
+    }
+
+    #[test]
+    fn test_add_duplicate_is_noop() {
+        let mut state = MultiSelectState::default();
+        let item = SelectableItem::RoadCell { x: 5, y: 10 };
+        state.add(item);
+        state.add(item);
+        assert_eq!(state.count(), 1);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut state = MultiSelectState::default();
+        let item = SelectableItem::RoadCell { x: 5, y: 10 };
+        state.add(item);
+        state.remove(&item);
+        assert!(!state.contains(&item));
+        assert_eq!(state.count(), 0);
+    }
+
+    #[test]
+    fn test_toggle() {
+        let mut state = MultiSelectState::default();
+        let item = SelectableItem::RoadCell { x: 5, y: 10 };
+        state.toggle(item);
+        assert!(state.contains(&item));
+        state.toggle(item);
+        assert!(!state.contains(&item));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut state = MultiSelectState::default();
+        state.add(SelectableItem::RoadCell { x: 1, y: 2 });
+        state.add(SelectableItem::RoadCell { x: 3, y: 4 });
+        assert_eq!(state.count(), 2);
+        state.clear();
+        assert!(state.is_empty());
+    }
+
+    #[test]
+    fn test_building_and_road_counts() {
+        let mut state = MultiSelectState::default();
+        state.add(SelectableItem::RoadCell { x: 1, y: 2 });
+        state.add(SelectableItem::RoadCell { x: 3, y: 4 });
+        state.add(SelectableItem::Building(Entity::from_raw(42)));
+        assert_eq!(state.building_count(), 1);
+        assert_eq!(state.road_count(), 2);
+        assert_eq!(state.count(), 3);
+    }
+
+    #[test]
+    fn test_buildings_collection() {
+        let mut state = MultiSelectState::default();
+        let e1 = Entity::from_raw(1);
+        let e2 = Entity::from_raw(2);
+        state.add(SelectableItem::Building(e1));
+        state.add(SelectableItem::Building(e2));
+        state.add(SelectableItem::RoadCell { x: 0, y: 0 });
+        let buildings = state.buildings();
+        assert_eq!(buildings.len(), 2);
+        assert!(buildings.contains(&e1));
+        assert!(buildings.contains(&e2));
+    }
+
+    #[test]
+    fn test_road_cells_collection() {
+        let mut state = MultiSelectState::default();
+        state.add(SelectableItem::RoadCell { x: 5, y: 10 });
+        state.add(SelectableItem::RoadCell { x: 15, y: 20 });
+        state.add(SelectableItem::Building(Entity::from_raw(1)));
+        let roads = state.road_cells();
+        assert_eq!(roads.len(), 2);
+        assert!(roads.contains(&(5, 10)));
+        assert!(roads.contains(&(15, 20)));
+    }
+
+    #[test]
+    fn test_save_load_round_trip() {
+        let mut state = MultiSelectState::default();
+        state.add(SelectableItem::RoadCell { x: 10, y: 20 });
+        state.add(SelectableItem::RoadCell { x: 30, y: 40 });
+        // Building entities are NOT persisted
+        state.add(SelectableItem::Building(Entity::from_raw(99)));
+
+        let bytes = state.save_to_bytes().expect("should save non-empty state");
+        let loaded = MultiSelectState::load_from_bytes(&bytes);
+
+        // Only road cells survive save/load
+        assert_eq!(loaded.road_count(), 2);
+        assert_eq!(loaded.building_count(), 0);
+        assert!(loaded.contains(&SelectableItem::RoadCell { x: 10, y: 20 }));
+        assert!(loaded.contains(&SelectableItem::RoadCell { x: 30, y: 40 }));
+    }
+
+    #[test]
+    fn test_save_empty_returns_none() {
+        let state = MultiSelectState::default();
+        assert!(state.save_to_bytes().is_none());
+    }
+
+    #[test]
+    fn test_road_type_upgrade_tier() {
+        use crate::grid::RoadType;
+        assert_eq!(RoadType::Path.upgrade_tier(), Some(RoadType::Local));
+        assert_eq!(RoadType::Local.upgrade_tier(), Some(RoadType::Avenue));
+        assert_eq!(RoadType::Avenue.upgrade_tier(), Some(RoadType::Boulevard));
+        assert_eq!(RoadType::OneWay.upgrade_tier(), Some(RoadType::Avenue));
+        assert_eq!(RoadType::Boulevard.upgrade_tier(), None);
+        assert_eq!(RoadType::Highway.upgrade_tier(), None);
+    }
+
+    #[test]
+    fn test_road_type_upgrade_cost() {
+        use crate::grid::RoadType;
+        // Local ($10) -> Avenue ($20) = $10 upgrade cost
+        assert_eq!(RoadType::Local.upgrade_cost(), Some(10.0));
+        // Avenue ($20) -> Boulevard ($30) = $10 upgrade cost
+        assert_eq!(RoadType::Avenue.upgrade_cost(), Some(10.0));
+        // Path ($5) -> Local ($10) = $5 upgrade cost
+        assert_eq!(RoadType::Path.upgrade_cost(), Some(5.0));
+        // OneWay ($15) -> Avenue ($20) = $5 upgrade cost
+        assert_eq!(RoadType::OneWay.upgrade_cost(), Some(5.0));
+        // Boulevard has no upgrade
+        assert_eq!(RoadType::Boulevard.upgrade_cost(), None);
+        // Highway has no upgrade
+        assert_eq!(RoadType::Highway.upgrade_cost(), None);
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -9,6 +9,7 @@ pub mod graphs;
 pub mod info_panel;
 pub mod localization;
 pub mod milestones;
+pub mod multi_select;
 pub mod road_segment_info;
 pub mod theme;
 pub mod toolbar;
@@ -27,6 +28,7 @@ impl Plugin for UiPlugin {
             .add_plugins(road_segment_info::RoadSegmentInfoPlugin)
             .add_plugins(waste_dashboard::WasteDashboardPlugin)
             .add_plugins(localization::LocalizationUiPlugin)
+            .add_plugins(multi_select::MultiSelectUiPlugin)
             .init_resource::<day_night_panel::DayNightPanelVisible>()
             .init_resource::<milestones::Milestones>()
             .init_resource::<graphs::HistoryData>()

--- a/crates/ui/src/multi_select.rs
+++ b/crates/ui/src/multi_select.rs
@@ -1,0 +1,420 @@
+//! Multi-Select UI Panel (UX-059).
+//!
+//! Handles Ctrl+Click input for adding entities to the multi-selection,
+//! displays the selection count in a status bar, and provides batch
+//! operation buttons (bulldoze all, upgrade all roads) with total cost.
+
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts};
+
+use rendering::input::{ActiveTool, CursorGridPos, StatusMessage};
+use simulation::economy::CityBudget;
+use simulation::grid::{CellType, RoadType, WorldGrid, ZoneType};
+use simulation::multi_select::{
+    BatchBulldozeEvent, BatchRoadUpgradeEvent, MultiSelectState, SelectableItem,
+};
+use simulation::roads::RoadNetwork;
+use simulation::services::ServiceBuilding;
+
+// =============================================================================
+// Systems
+// =============================================================================
+
+/// Handle Ctrl+Click to toggle entities in/out of the multi-selection.
+///
+/// When Ctrl is held and the player left-clicks:
+/// - On a building: toggle that building entity in the selection.
+/// - On a road cell: toggle that road cell in the selection.
+/// - On empty terrain: no-op.
+///
+/// When clicking without Ctrl, the multi-selection is cleared (normal click
+/// behaviour takes over via the existing input system).
+#[allow(clippy::too_many_arguments)]
+pub fn handle_multi_select_input(
+    buttons: Res<ButtonInput<MouseButton>>,
+    keys: Res<ButtonInput<KeyCode>>,
+    cursor: Res<CursorGridPos>,
+    tool: Res<ActiveTool>,
+    grid: Res<WorldGrid>,
+    mut multi_select: ResMut<MultiSelectState>,
+    mut status: ResMut<StatusMessage>,
+    left_drag: Res<rendering::camera::LeftClickDrag>,
+) {
+    // Only process on fresh left-click
+    if !buttons.just_pressed(MouseButton::Left) || !cursor.valid {
+        return;
+    }
+
+    // Don't interfere during camera drag
+    if left_drag.is_dragging {
+        return;
+    }
+
+    let ctrl_held = keys.pressed(KeyCode::ControlLeft) || keys.pressed(KeyCode::ControlRight);
+
+    // If Ctrl is not held, clear multi-selection on any click
+    // (the regular tool input system handles the normal action)
+    if !ctrl_held {
+        if !multi_select.is_empty() {
+            multi_select.clear();
+        }
+        return;
+    }
+
+    // Only allow multi-select with Inspect or Bulldoze tool
+    if !matches!(*tool, ActiveTool::Inspect | ActiveTool::Bulldoze) {
+        return;
+    }
+
+    let gx = cursor.grid_x as usize;
+    let gy = cursor.grid_y as usize;
+
+    if !grid.in_bounds(gx, gy) {
+        return;
+    }
+
+    let cell = grid.get(gx, gy);
+
+    if let Some(entity) = cell.building_id {
+        let item = SelectableItem::Building(entity);
+        multi_select.toggle(item);
+        let count = multi_select.count();
+        status.set(format!("{} item(s) selected", count), false);
+    } else if cell.cell_type == CellType::Road {
+        let item = SelectableItem::RoadCell { x: gx, y: gy };
+        multi_select.toggle(item);
+        let count = multi_select.count();
+        status.set(format!("{} item(s) selected", count), false);
+    }
+}
+
+/// Escape key clears multi-selection.
+pub fn multi_select_escape(
+    keys: Res<ButtonInput<KeyCode>>,
+    mut multi_select: ResMut<MultiSelectState>,
+    mut contexts: EguiContexts,
+) {
+    if contexts.ctx_mut().wants_keyboard_input() {
+        return;
+    }
+    if keys.just_pressed(KeyCode::Escape) && !multi_select.is_empty() {
+        multi_select.clear();
+    }
+}
+
+/// Calculate the total cost of upgrading all selected road cells.
+fn upgrade_cost(multi_select: &MultiSelectState, grid: &WorldGrid) -> f64 {
+    let mut total = 0.0;
+    for (x, y) in multi_select.road_cells() {
+        if grid.in_bounds(x, y) {
+            let cell = grid.get(x, y);
+            if cell.cell_type == CellType::Road {
+                if let Some(cost) = cell.road_type.upgrade_cost() {
+                    total += cost;
+                }
+            }
+        }
+    }
+    total
+}
+
+/// Count how many selected roads are actually upgradable.
+fn upgradable_road_count(multi_select: &MultiSelectState, grid: &WorldGrid) -> usize {
+    multi_select
+        .road_cells()
+        .iter()
+        .filter(|&&(x, y)| {
+            grid.in_bounds(x, y) && {
+                let cell = grid.get(x, y);
+                cell.cell_type == CellType::Road && cell.road_type.upgrade_tier().is_some()
+            }
+        })
+        .count()
+}
+
+/// Display the multi-select status bar and batch operation panel.
+///
+/// Shows:
+/// - Selection count
+/// - Batch Bulldoze button
+/// - Batch Upgrade button (for road cells) with total cost
+/// - Clear Selection button
+#[allow(clippy::too_many_arguments)]
+pub fn multi_select_panel_ui(
+    mut contexts: EguiContexts,
+    mut multi_select: ResMut<MultiSelectState>,
+    grid: Res<WorldGrid>,
+    budget: Res<CityBudget>,
+    mut bulldoze_events: EventWriter<BatchBulldozeEvent>,
+    mut upgrade_events: EventWriter<BatchRoadUpgradeEvent>,
+) {
+    if multi_select.is_empty() {
+        return;
+    }
+
+    let count = multi_select.count();
+    let building_count = multi_select.building_count();
+    let road_count = multi_select.road_count();
+    let total_upgrade_cost = upgrade_cost(&multi_select, &grid);
+    let upgradable_count = upgradable_road_count(&multi_select, &grid);
+
+    let mut should_clear = false;
+
+    egui::Window::new("Multi-Select")
+        .default_width(240.0)
+        .anchor(egui::Align2::RIGHT_BOTTOM, egui::vec2(-8.0, -8.0))
+        .collapsible(false)
+        .resizable(false)
+        .show(contexts.ctx_mut(), |ui| {
+            // Selection summary
+            ui.heading(format!("{} Selected", count));
+            ui.separator();
+
+            if building_count > 0 {
+                ui.label(format!("Buildings: {}", building_count));
+            }
+            if road_count > 0 {
+                ui.label(format!("Road cells: {}", road_count));
+            }
+
+            ui.separator();
+
+            // Batch Bulldoze (bulldozing is free)
+            let bulldoze_label = format!("Bulldoze All ({} items)", count);
+            if ui.button(bulldoze_label).clicked() {
+                bulldoze_events.send(BatchBulldozeEvent);
+            }
+
+            // Batch Road Upgrade (only shown when road cells are selected)
+            if road_count > 0 {
+                let can_afford = budget.treasury >= total_upgrade_cost;
+                let has_upgradable = upgradable_count > 0;
+
+                let upgrade_label = format!(
+                    "Upgrade Roads ({} upgradable, ${:.0})",
+                    upgradable_count, total_upgrade_cost
+                );
+
+                ui.add_enabled_ui(can_afford && has_upgradable, |ui| {
+                    if ui.button(upgrade_label).clicked() {
+                        upgrade_events.send(BatchRoadUpgradeEvent);
+                    }
+                });
+
+                if !can_afford && has_upgradable {
+                    ui.colored_label(
+                        egui::Color32::from_rgb(220, 50, 50),
+                        "Not enough money for upgrade",
+                    );
+                }
+                if !has_upgradable && road_count > 0 {
+                    ui.colored_label(
+                        egui::Color32::from_rgb(160, 160, 160),
+                        "No roads can be upgraded further",
+                    );
+                }
+            }
+
+            ui.separator();
+            if ui.button("Clear Selection (Esc)").clicked() {
+                should_clear = true;
+            }
+        });
+
+    if should_clear {
+        multi_select.clear();
+    }
+}
+
+/// Execute batch bulldoze when the event is received.
+#[allow(clippy::too_many_arguments)]
+pub fn execute_batch_bulldoze(
+    mut events: EventReader<BatchBulldozeEvent>,
+    mut multi_select: ResMut<MultiSelectState>,
+    mut grid: ResMut<WorldGrid>,
+    mut roads: ResMut<RoadNetwork>,
+    mut status: ResMut<StatusMessage>,
+    mut commands: Commands,
+    service_q: Query<&ServiceBuilding>,
+) {
+    for _event in events.read() {
+        let items: Vec<SelectableItem> = multi_select.selected_items.clone();
+        let mut demolished = 0usize;
+
+        for item in &items {
+            match item {
+                SelectableItem::Building(entity) => {
+                    // Check if it's a multi-cell service building
+                    if let Ok(service) = service_q.get(*entity) {
+                        let (fw, fh) = ServiceBuilding::footprint(service.service_type);
+                        let sx = service.grid_x;
+                        let sy = service.grid_y;
+                        for fy in sy..sy + fh {
+                            for fx in sx..sx + fw {
+                                if grid.in_bounds(fx, fy) {
+                                    grid.get_mut(fx, fy).building_id = None;
+                                    grid.get_mut(fx, fy).zone = ZoneType::None;
+                                }
+                            }
+                        }
+                    } else {
+                        // Regular building: scan grid for matching entity
+                        for y in 0..grid.height {
+                            for x in 0..grid.width {
+                                if grid.get(x, y).building_id == Some(*entity) {
+                                    grid.get_mut(x, y).building_id = None;
+                                    grid.get_mut(x, y).zone = ZoneType::None;
+                                }
+                            }
+                        }
+                    }
+                    commands.entity(*entity).despawn();
+                    demolished += 1;
+                }
+                SelectableItem::RoadCell { x, y } => {
+                    if grid.in_bounds(*x, *y) && grid.get(*x, *y).cell_type == CellType::Road {
+                        roads.remove_road(&mut grid, *x, *y);
+                        demolished += 1;
+                    }
+                }
+            }
+        }
+
+        multi_select.clear();
+        status.set(format!("Demolished {} items", demolished), false);
+    }
+}
+
+/// Execute batch road upgrade when the event is received.
+pub fn execute_batch_road_upgrade(
+    mut events: EventReader<BatchRoadUpgradeEvent>,
+    mut multi_select: ResMut<MultiSelectState>,
+    mut grid: ResMut<WorldGrid>,
+    mut budget: ResMut<CityBudget>,
+    mut status: ResMut<StatusMessage>,
+) {
+    for _event in events.read() {
+        let road_cells = multi_select.road_cells();
+
+        // Calculate total cost first
+        let mut total_cost = 0.0;
+        let mut upgradable: Vec<(usize, usize, RoadType)> = Vec::new();
+
+        for (x, y) in &road_cells {
+            if grid.in_bounds(*x, *y) {
+                let cell = grid.get(*x, *y);
+                if cell.cell_type == CellType::Road {
+                    if let Some(next_tier) = cell.road_type.upgrade_tier() {
+                        let cost = cell.road_type.upgrade_cost().unwrap_or(0.0);
+                        total_cost += cost;
+                        upgradable.push((*x, *y, next_tier));
+                    }
+                }
+            }
+        }
+
+        if budget.treasury < total_cost {
+            status.set("Not enough money for batch upgrade", true);
+            continue;
+        }
+
+        if upgradable.is_empty() {
+            status.set("No roads can be upgraded", true);
+            continue;
+        }
+
+        // Apply all upgrades
+        for (x, y, next_tier) in &upgradable {
+            grid.get_mut(*x, *y).road_type = *next_tier;
+        }
+
+        budget.treasury -= total_cost;
+        let count = upgradable.len();
+
+        multi_select.clear();
+        status.set(
+            format!("Upgraded {} roads (${:.0})", count, total_cost),
+            false,
+        );
+    }
+}
+
+// =============================================================================
+// Plugin
+// =============================================================================
+
+pub struct MultiSelectUiPlugin;
+
+impl Plugin for MultiSelectUiPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            (
+                handle_multi_select_input,
+                multi_select_escape,
+                multi_select_panel_ui,
+                execute_batch_bulldoze,
+                execute_batch_road_upgrade,
+            ),
+        );
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use simulation::grid::WorldGrid;
+
+    #[test]
+    fn test_upgrade_cost_calculation() {
+        let mut grid = WorldGrid::new(4, 4);
+        grid.get_mut(0, 0).cell_type = CellType::Road;
+        grid.get_mut(0, 0).road_type = RoadType::Local;
+        grid.get_mut(1, 0).cell_type = CellType::Road;
+        grid.get_mut(1, 0).road_type = RoadType::Avenue;
+        grid.get_mut(2, 0).cell_type = CellType::Road;
+        grid.get_mut(2, 0).road_type = RoadType::Boulevard; // max tier
+
+        let mut state = MultiSelectState::default();
+        state.add(SelectableItem::RoadCell { x: 0, y: 0 });
+        state.add(SelectableItem::RoadCell { x: 1, y: 0 });
+        state.add(SelectableItem::RoadCell { x: 2, y: 0 });
+
+        let cost = upgrade_cost(&state, &grid);
+        // Local->Avenue = $10, Avenue->Boulevard = $10, Boulevard = $0
+        assert!((cost - 20.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_upgradable_road_count() {
+        let mut grid = WorldGrid::new(4, 4);
+        grid.get_mut(0, 0).cell_type = CellType::Road;
+        grid.get_mut(0, 0).road_type = RoadType::Local;
+        grid.get_mut(1, 0).cell_type = CellType::Road;
+        grid.get_mut(1, 0).road_type = RoadType::Boulevard;
+
+        let mut state = MultiSelectState::default();
+        state.add(SelectableItem::RoadCell { x: 0, y: 0 });
+        state.add(SelectableItem::RoadCell { x: 1, y: 0 });
+
+        assert_eq!(upgradable_road_count(&state, &grid), 1);
+    }
+
+    #[test]
+    fn test_upgrade_cost_empty_selection() {
+        let grid = WorldGrid::new(4, 4);
+        let state = MultiSelectState::default();
+        assert!((upgrade_cost(&state, &grid)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_upgradable_count_empty_selection() {
+        let grid = WorldGrid::new(4, 4);
+        let state = MultiSelectState::default();
+        assert_eq!(upgradable_road_count(&state, &grid), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- **Ctrl+Click** adds buildings and road cells to a multi-selection (works with Inspect and Bulldoze tools)
- **Batch Bulldoze**: demolish all selected items at once via the Multi-Select panel
- **Batch Road Upgrade**: upgrade all selected road cells to their next tier (Path->Local->Avenue->Boulevard) with total cost displayed
- **Selection count** shown in a floating panel with building/road breakdown
- **Total cost** for batch road upgrade displayed, with affordability check
- Escape key or clicking without Ctrl clears the selection
- Save/load support via `SaveableRegistry` (road cell selections persist across saves)

## Implementation
- `crates/simulation/src/multi_select.rs` - `MultiSelectState` resource, `SelectableItem` enum, `BatchBulldozeEvent`/`BatchRoadUpgradeEvent`, `Saveable` impl
- `crates/ui/src/multi_select.rs` - Input handling (Ctrl+Click), egui panel UI, batch operation execution systems
- `crates/simulation/src/grid.rs` - Added `RoadType::upgrade_tier()` and `RoadType::upgrade_cost()` methods

## Test plan
- [x] Unit tests for `MultiSelectState` (add, remove, toggle, clear, counts, collections)
- [x] Unit tests for save/load round-trip (road cells persist, entities cleared)
- [x] Unit tests for `RoadType::upgrade_tier()` and `upgrade_cost()` 
- [x] Unit tests for upgrade cost calculation and upgradable road counting
- [ ] Manual: Ctrl+Click buildings and roads to build selection
- [ ] Manual: Verify selection panel shows correct counts
- [ ] Manual: Test Batch Bulldoze removes all selected items
- [ ] Manual: Test Batch Road Upgrade with sufficient/insufficient funds
- [ ] Manual: Verify Escape clears selection

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)