### PR TITLE
Add road one-way direction toggle (UX-060)

### DIFF
--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -9,6 +9,7 @@ pub mod color_ramps;
 pub mod cursor_preview;
 pub mod day_night;
 pub mod input;
+pub mod oneway_arrows;
 pub mod overlay;
 pub mod props;
 pub mod terrain_render;
@@ -117,7 +118,8 @@ impl Plugin for RenderingPlugin {
                     selection_highlight::animate_selection_highlights,
                     selection_highlight::draw_connected_highlights,
                 ),
-            );
+            )
+            .add_systems(Update, oneway_arrows::draw_oneway_arrows);
     }
 }
 

--- a/crates/rendering/src/oneway_arrows.rs
+++ b/crates/rendering/src/oneway_arrows.rs
@@ -1,0 +1,82 @@
+use bevy::prelude::*;
+
+use simulation::oneway::{OneWayDirection, OneWayDirectionMap};
+use simulation::road_segments::RoadSegmentStore;
+
+/// Draw direction arrows on one-way road segments using gizmos.
+///
+/// Arrows are drawn along the segment at regular intervals, pointing
+/// in the allowed traffic direction.
+pub fn draw_oneway_arrows(
+    store: Res<RoadSegmentStore>,
+    oneway_map: Res<OneWayDirectionMap>,
+    mut gizmos: Gizmos,
+) {
+    if oneway_map.directions.is_empty() {
+        return;
+    }
+
+    let arrow_color = Color::srgba(0.1, 0.85, 0.3, 0.8);
+    let arrow_y = 0.15; // slightly above road surface
+
+    for segment in &store.segments {
+        let Some(direction) = oneway_map.get(segment.id) else {
+            continue;
+        };
+
+        // Place arrows every ~20 world units along the segment
+        let arrow_spacing = 20.0_f32;
+        let arrow_count = (segment.arc_length / arrow_spacing).ceil().max(1.0) as usize;
+
+        for i in 0..arrow_count {
+            // Parameter t for arrow center position
+            let t = if arrow_count == 1 {
+                0.5
+            } else {
+                (i as f32 + 0.5) / arrow_count as f32
+            };
+
+            let center = segment.evaluate(t);
+            let tangent = segment.tangent(t).normalize_or_zero();
+
+            // Flip tangent for reverse direction
+            let dir = match direction {
+                OneWayDirection::Forward => tangent,
+                OneWayDirection::Reverse => -tangent,
+            };
+
+            // Arrow dimensions
+            let arrow_len = 3.0_f32;
+            let arrow_head_len = 1.5_f32;
+            let arrow_half_width = 1.2_f32;
+
+            let tip = center + dir * arrow_len * 0.5;
+            let base = center - dir * arrow_len * 0.5;
+            let head_base = tip - dir * arrow_head_len;
+
+            // Perpendicular for arrow head wings
+            let perp = Vec2::new(-dir.y, dir.x);
+            let wing_l = head_base + perp * arrow_half_width;
+            let wing_r = head_base - perp * arrow_half_width;
+
+            // Draw arrow shaft
+            gizmos.line(
+                Vec3::new(base.x, arrow_y, base.y),
+                Vec3::new(head_base.x, arrow_y, head_base.y),
+                arrow_color,
+            );
+
+            // Draw arrow head (two lines from wings to tip)
+            gizmos.line(
+                Vec3::new(wing_l.x, arrow_y, wing_l.y),
+                Vec3::new(tip.x, arrow_y, tip.y),
+                arrow_color,
+            );
+            gizmos.line(
+                Vec3::new(wing_r.x, arrow_y, wing_r.y),
+                Vec3::new(tip.x, arrow_y, tip.y),
+                arrow_color,
+            );
+        }
+    }
+}

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -58,6 +58,7 @@ pub mod natural_resources;
 pub mod neighborhood_quality;
 pub mod nimby;
 pub mod noise;
+pub mod oneway;
 pub mod outside_connections;
 pub mod pathfinding_sys;
 pub mod policies;
@@ -248,7 +249,6 @@ impl Plugin for SimulationPlugin {
             .init_resource::<LodFrameCounter>()
             .add_systems(Startup, world_init::init_world)
             .add_systems(FixedUpdate, tick_slow_timer)
-            .add_systems(Update, rebuild_csr_on_road_change)
             .add_systems(Update, tick_lod_frame_counter);
 
         // Core simulation chain
@@ -290,6 +290,7 @@ impl Plugin for SimulationPlugin {
             waste_effects::WasteEffectsPlugin,
             recycling::RecyclingPlugin,
             road_maintenance::RoadMaintenancePlugin,
+            oneway::OneWayPlugin,
             traffic_accidents::TrafficAccidentsPlugin,
             loans::LoansPlugin,
         ));
@@ -404,13 +405,6 @@ fn tick_lod_frame_counter(mut counter: ResMut<LodFrameCounter>) {
 
 pub fn lod_frame_ready(counter: Res<LodFrameCounter>) -> bool {
     counter.0.is_multiple_of(6)
-}
-
-/// Rebuild the CSR graph whenever the road network changes.
-fn rebuild_csr_on_road_change(roads: Res<RoadNetwork>, mut csr: ResMut<CsrGraph>) {
-    if roads.is_changed() {
-        *csr = CsrGraph::from_road_network(&roads);
-    }
 }
 
 #[cfg(test)]

--- a/crates/simulation/src/oneway.rs
+++ b/crates/simulation/src/oneway.rs
@@ -1,0 +1,468 @@
+use bevy::prelude::*;
+use std::collections::HashMap;
+
+use crate::road_graph_csr::CsrGraph;
+use crate::road_segments::{RoadSegmentStore, SegmentId};
+use crate::roads::{RoadNetwork, RoadNode};
+use crate::Saveable;
+
+/// Direction of traffic flow on a one-way segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OneWayDirection {
+    /// Traffic flows from start_node to end_node.
+    Forward,
+    /// Traffic flows from end_node to start_node.
+    Reverse,
+}
+
+/// Stores one-way direction overrides for road segments.
+///
+/// By default, all segments are bidirectional. When a segment is added to this map,
+/// it becomes one-way in the specified direction.
+#[derive(Resource, Default, Debug)]
+pub struct OneWayDirectionMap {
+    /// Map from segment ID to one-way direction.
+    pub directions: HashMap<u32, OneWayDirection>,
+    /// Incremented every time the map changes, so systems can detect changes cheaply.
+    pub generation: u32,
+}
+
+impl OneWayDirectionMap {
+    /// Get the one-way direction for a segment, if any.
+    pub fn get(&self, id: SegmentId) -> Option<OneWayDirection> {
+        self.directions.get(&id.0).copied()
+    }
+
+    /// Set a segment to one-way in the given direction.
+    pub fn set(&mut self, id: SegmentId, direction: OneWayDirection) {
+        self.directions.insert(id.0, direction);
+        self.generation = self.generation.wrapping_add(1);
+    }
+
+    /// Remove one-way restriction (make bidirectional again).
+    pub fn remove(&mut self, id: SegmentId) {
+        self.directions.remove(&id.0);
+        self.generation = self.generation.wrapping_add(1);
+    }
+
+    /// Toggle through: None -> Forward -> Reverse -> None
+    pub fn toggle(&mut self, id: SegmentId) {
+        match self.get(id) {
+            None => self.set(id, OneWayDirection::Forward),
+            Some(OneWayDirection::Forward) => self.set(id, OneWayDirection::Reverse),
+            Some(OneWayDirection::Reverse) => self.remove(id),
+        }
+    }
+
+    /// Check if a segment is one-way.
+    pub fn is_oneway(&self, id: SegmentId) -> bool {
+        self.directions.contains_key(&id.0)
+    }
+}
+
+/// Event fired when user toggles one-way direction on a segment.
+#[derive(Event)]
+pub struct ToggleOneWayEvent {
+    pub segment_id: SegmentId,
+}
+
+/// Handle toggle events by cycling through direction states.
+fn handle_toggle_oneway(
+    mut events: EventReader<ToggleOneWayEvent>,
+    mut oneway_map: ResMut<OneWayDirectionMap>,
+) {
+    for event in events.read() {
+        oneway_map.toggle(event.segment_id);
+    }
+}
+
+/// Rebuild the CSR graph incorporating one-way direction constraints.
+///
+/// For bidirectional segments, edges go both ways (A->B and B->A).
+/// For one-way Forward segments, only start_node->end_node edges exist.
+/// For one-way Reverse segments, only end_node->start_node edges exist.
+///
+/// This replaces the default `rebuild_csr_on_road_change` when one-way
+/// directions are active.
+pub fn rebuild_csr_with_oneway(
+    roads: Res<RoadNetwork>,
+    segments: Res<RoadSegmentStore>,
+    oneway_map: Res<OneWayDirectionMap>,
+    mut csr: ResMut<CsrGraph>,
+    mut last_gen: Local<u32>,
+) {
+    // Only rebuild if something changed
+    if !roads.is_changed() && *last_gen == oneway_map.generation {
+        return;
+    }
+    *last_gen = oneway_map.generation;
+
+    // If no one-way directions exist, just use the standard builder
+    if oneway_map.directions.is_empty() {
+        *csr = CsrGraph::from_road_network(&roads);
+        return;
+    }
+
+    // Build a set of directed edge restrictions from segments
+    // For each one-way segment, identify which grid cells are rasterized and
+    // restrict edges between consecutive rasterized cells to the allowed direction.
+    let mut blocked_edges: std::collections::HashSet<(RoadNode, RoadNode)> =
+        std::collections::HashSet::new();
+
+    for segment in &segments.segments {
+        let Some(direction) = oneway_map.get(segment.id) else {
+            continue;
+        };
+
+        let cells = &segment.rasterized_cells;
+        if cells.len() < 2 {
+            continue;
+        }
+
+        // For each pair of consecutive rasterized cells, block the reverse direction
+        for window in cells.windows(2) {
+            let a = RoadNode(window[0].0, window[0].1);
+            let b = RoadNode(window[1].0, window[1].1);
+
+            match direction {
+                OneWayDirection::Forward => {
+                    // Allow A->B, block B->A
+                    blocked_edges.insert((b, a));
+                }
+                OneWayDirection::Reverse => {
+                    // Allow B->A, block A->B
+                    blocked_edges.insert((a, b));
+                }
+            }
+        }
+    }
+
+    // Build CSR graph from road network, filtering out blocked edges
+    *csr = CsrGraph::from_road_network_filtered(&roads, &blocked_edges);
+}
+
+impl CsrGraph {
+    /// Build CSR graph from road network, excluding blocked directed edges.
+    pub fn from_road_network_filtered(
+        network: &RoadNetwork,
+        blocked: &std::collections::HashSet<(RoadNode, RoadNode)>,
+    ) -> Self {
+        let mut nodes: Vec<RoadNode> = network.edges.keys().copied().collect();
+        nodes.sort_by(|a, b| (a.1, a.0).cmp(&(b.1, b.0)));
+
+        let node_index: std::collections::HashMap<RoadNode, u32> = nodes
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (*n, i as u32))
+            .collect();
+
+        let mut node_offsets = Vec::with_capacity(nodes.len() + 1);
+        let mut edges = Vec::new();
+        let mut weights = Vec::new();
+
+        for node in &nodes {
+            node_offsets.push(edges.len() as u32);
+            if let Some(neighbors) = network.edges.get(node) {
+                for neighbor in neighbors {
+                    // Skip blocked edges
+                    if blocked.contains(&(*node, *neighbor)) {
+                        continue;
+                    }
+                    if let Some(&idx) = node_index.get(neighbor) {
+                        edges.push(idx);
+                        weights.push(1);
+                    }
+                }
+            }
+        }
+        node_offsets.push(edges.len() as u32);
+
+        Self {
+            nodes,
+            node_offsets,
+            edges,
+            weights,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Save / Load
+// ---------------------------------------------------------------------------
+
+impl Saveable for OneWayDirectionMap {
+    const SAVE_KEY: &'static str = "oneway_direction_map";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.directions.is_empty() {
+            return None;
+        }
+
+        let mut buf = Vec::new();
+
+        // Entry count (4 bytes)
+        let count = self.directions.len() as u32;
+        buf.extend_from_slice(&count.to_le_bytes());
+
+        // Each entry: segment_id (4 bytes) + direction (1 byte)
+        for (&seg_id, &direction) in &self.directions {
+            buf.extend_from_slice(&seg_id.to_le_bytes());
+            buf.push(match direction {
+                OneWayDirection::Forward => 0,
+                OneWayDirection::Reverse => 1,
+            });
+        }
+
+        // Generation (4 bytes)
+        buf.extend_from_slice(&self.generation.to_le_bytes());
+
+        Some(buf)
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        if bytes.len() < 4 {
+            return Self::default();
+        }
+
+        let count = u32::from_le_bytes(bytes[0..4].try_into().unwrap_or([0; 4])) as usize;
+        let mut directions = HashMap::new();
+
+        let mut offset = 4;
+        for _ in 0..count {
+            if offset + 5 > bytes.len() {
+                break;
+            }
+            let seg_id =
+                u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap_or([0; 4]));
+            let dir_byte = bytes[offset + 4];
+            let direction = match dir_byte {
+                0 => OneWayDirection::Forward,
+                _ => OneWayDirection::Reverse,
+            };
+            directions.insert(seg_id, direction);
+            offset += 5;
+        }
+
+        let generation = if offset + 4 <= bytes.len() {
+            u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap_or([0; 4]))
+        } else {
+            0
+        };
+
+        Self {
+            directions,
+            generation,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+pub struct OneWayPlugin;
+
+impl Plugin for OneWayPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<OneWayDirectionMap>()
+            .add_event::<ToggleOneWayEvent>()
+            .add_systems(Update, handle_toggle_oneway)
+            .add_systems(
+                Update,
+                rebuild_csr_with_oneway.after(handle_toggle_oneway),
+            );
+
+        // Register for save/load via the SaveableRegistry.
+        app.init_resource::<crate::SaveableRegistry>();
+        app.world_mut()
+            .resource_mut::<crate::SaveableRegistry>()
+            .register::<OneWayDirectionMap>();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CELL_SIZE, GRID_HEIGHT, GRID_WIDTH};
+    use crate::grid::WorldGrid;
+    use crate::road_graph_csr::csr_find_path;
+    use crate::road_segments::RoadSegmentStore;
+    use crate::roads::RoadNetwork;
+
+    #[test]
+    fn test_toggle_cycles_directions() {
+        let mut map = OneWayDirectionMap::default();
+        let id = SegmentId(42);
+
+        assert_eq!(map.get(id), None);
+
+        map.toggle(id);
+        assert_eq!(map.get(id), Some(OneWayDirection::Forward));
+
+        map.toggle(id);
+        assert_eq!(map.get(id), Some(OneWayDirection::Reverse));
+
+        map.toggle(id);
+        assert_eq!(map.get(id), None);
+    }
+
+    #[test]
+    fn test_generation_increments_on_change() {
+        let mut map = OneWayDirectionMap::default();
+        let id = SegmentId(1);
+
+        assert_eq!(map.generation, 0);
+        map.set(id, OneWayDirection::Forward);
+        assert_eq!(map.generation, 1);
+        map.remove(id);
+        assert_eq!(map.generation, 2);
+    }
+
+    #[test]
+    fn test_saveable_roundtrip() {
+        let mut map = OneWayDirectionMap::default();
+        map.set(SegmentId(10), OneWayDirection::Forward);
+        map.set(SegmentId(20), OneWayDirection::Reverse);
+
+        let bytes = map.save_to_bytes().unwrap();
+        let loaded = OneWayDirectionMap::load_from_bytes(&bytes);
+
+        assert_eq!(loaded.get(SegmentId(10)), Some(OneWayDirection::Forward));
+        assert_eq!(loaded.get(SegmentId(20)), Some(OneWayDirection::Reverse));
+        assert_eq!(loaded.directions.len(), 2);
+    }
+
+    #[test]
+    fn test_saveable_empty_returns_none() {
+        let map = OneWayDirectionMap::default();
+        assert!(map.save_to_bytes().is_none());
+    }
+
+    #[test]
+    fn test_oneway_forward_blocks_reverse_path() {
+        let mut grid = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+        let mut roads = RoadNetwork::default();
+        let mut store = RoadSegmentStore::default();
+
+        // Build a straight road from (5,10) to (15,10) using segments
+        let from = Vec2::new(5.0 * CELL_SIZE + 8.0, 10.0 * CELL_SIZE + 8.0);
+        let to = Vec2::new(15.0 * CELL_SIZE + 8.0, 10.0 * CELL_SIZE + 8.0);
+        let (seg_id, _cells) =
+            store.add_straight_segment(from, to, crate::grid::RoadType::Local, 24.0, &mut grid, &mut roads);
+
+        // Without one-way: path should exist in both directions
+        let csr_bidir = CsrGraph::from_road_network(&roads);
+        let forward_path = csr_find_path(&csr_bidir, RoadNode(5, 10), RoadNode(15, 10));
+        let reverse_path = csr_find_path(&csr_bidir, RoadNode(15, 10), RoadNode(5, 10));
+        assert!(forward_path.is_some(), "Forward path should exist bidirectional");
+        assert!(reverse_path.is_some(), "Reverse path should exist bidirectional");
+
+        // Set one-way Forward (start -> end, i.e. 5,10 -> 15,10)
+        let mut oneway_map = OneWayDirectionMap::default();
+        oneway_map.set(seg_id, OneWayDirection::Forward);
+
+        // Build blocked edges
+        let mut blocked = std::collections::HashSet::new();
+        for segment in &store.segments {
+            if let Some(direction) = oneway_map.get(segment.id) {
+                let cells = &segment.rasterized_cells;
+                for window in cells.windows(2) {
+                    let a = RoadNode(window[0].0, window[0].1);
+                    let b = RoadNode(window[1].0, window[1].1);
+                    match direction {
+                        OneWayDirection::Forward => {
+                            blocked.insert((b, a));
+                        }
+                        OneWayDirection::Reverse => {
+                            blocked.insert((a, b));
+                        }
+                    }
+                }
+            }
+        }
+
+        let csr_oneway = CsrGraph::from_road_network_filtered(&roads, &blocked);
+
+        // Forward path should still exist
+        let forward_path = csr_find_path(&csr_oneway, RoadNode(5, 10), RoadNode(15, 10));
+        assert!(forward_path.is_some(), "Forward path should exist with one-way forward");
+
+        // Reverse path should be blocked
+        let reverse_path = csr_find_path(&csr_oneway, RoadNode(15, 10), RoadNode(5, 10));
+        assert!(reverse_path.is_none(), "Reverse path should be blocked with one-way forward");
+    }
+
+    #[test]
+    fn test_oneway_reverse_blocks_forward_path() {
+        let mut grid = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+        let mut roads = RoadNetwork::default();
+        let mut store = RoadSegmentStore::default();
+
+        let from = Vec2::new(5.0 * CELL_SIZE + 8.0, 10.0 * CELL_SIZE + 8.0);
+        let to = Vec2::new(15.0 * CELL_SIZE + 8.0, 10.0 * CELL_SIZE + 8.0);
+        let (seg_id, _cells) =
+            store.add_straight_segment(from, to, crate::grid::RoadType::Local, 24.0, &mut grid, &mut roads);
+
+        let mut oneway_map = OneWayDirectionMap::default();
+        oneway_map.set(seg_id, OneWayDirection::Reverse);
+
+        let mut blocked = std::collections::HashSet::new();
+        for segment in &store.segments {
+            if let Some(direction) = oneway_map.get(segment.id) {
+                let cells = &segment.rasterized_cells;
+                for window in cells.windows(2) {
+                    let a = RoadNode(window[0].0, window[0].1);
+                    let b = RoadNode(window[1].0, window[1].1);
+                    match direction {
+                        OneWayDirection::Forward => {
+                            blocked.insert((b, a));
+                        }
+                        OneWayDirection::Reverse => {
+                            blocked.insert((a, b));
+                        }
+                    }
+                }
+            }
+        }
+
+        let csr_oneway = CsrGraph::from_road_network_filtered(&roads, &blocked);
+
+        // Forward path should be blocked
+        let forward_path = csr_find_path(&csr_oneway, RoadNode(5, 10), RoadNode(15, 10));
+        assert!(forward_path.is_none(), "Forward path should be blocked with one-way reverse");
+
+        // Reverse path should exist
+        let reverse_path = csr_find_path(&csr_oneway, RoadNode(15, 10), RoadNode(5, 10));
+        assert!(reverse_path.is_some(), "Reverse path should exist with one-way reverse");
+    }
+
+    #[test]
+    fn test_removing_oneway_restores_bidirectional() {
+        let mut grid = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+        let mut roads = RoadNetwork::default();
+        let mut store = RoadSegmentStore::default();
+
+        let from = Vec2::new(5.0 * CELL_SIZE + 8.0, 10.0 * CELL_SIZE + 8.0);
+        let to = Vec2::new(15.0 * CELL_SIZE + 8.0, 10.0 * CELL_SIZE + 8.0);
+        let (seg_id, _cells) =
+            store.add_straight_segment(from, to, crate::grid::RoadType::Local, 24.0, &mut grid, &mut roads);
+
+        let mut oneway_map = OneWayDirectionMap::default();
+        oneway_map.set(seg_id, OneWayDirection::Forward);
+        oneway_map.remove(seg_id);
+
+        // No blocked edges since we removed the one-way
+        let blocked = std::collections::HashSet::new();
+        let csr = CsrGraph::from_road_network_filtered(&roads, &blocked);
+
+        let forward = csr_find_path(&csr, RoadNode(5, 10), RoadNode(15, 10));
+        let reverse = csr_find_path(&csr, RoadNode(15, 10), RoadNode(5, 10));
+        assert!(forward.is_some(), "Forward path should exist after removing one-way");
+        assert!(reverse.is_some(), "Reverse path should exist after removing one-way");
+    }
+}
+

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -4,6 +4,7 @@ use bevy_egui::EguiPlugin;
 pub mod graphs;
 pub mod info_panel;
 pub mod milestones;
+pub mod oneway_ui;
 pub mod theme;
 pub mod toolbar;
 
@@ -45,6 +46,7 @@ impl Plugin for UiPlugin {
                     toolbar::speed_keybinds,
                     info_panel::groundwater_tooltip_ui,
                 ),
-            );
+            )
+            .add_plugins(oneway_ui::OneWayUiPlugin);
     }
 }

--- a/crates/ui/src/oneway_ui.rs
+++ b/crates/ui/src/oneway_ui.rs
@@ -1,0 +1,131 @@
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts};
+
+use simulation::oneway::{OneWayDirection, OneWayDirectionMap, ToggleOneWayEvent};
+use simulation::road_segments::{RoadSegmentStore, SegmentId};
+
+/// Currently selected road segment for the context menu.
+#[derive(Resource, Default)]
+pub struct SelectedSegment(pub Option<SegmentId>);
+
+/// Road segment context menu UI.
+///
+/// When a segment is selected, shows a small window with one-way toggle controls.
+pub fn road_segment_context_menu(
+    mut contexts: EguiContexts,
+    mut selected: ResMut<SelectedSegment>,
+    store: Res<RoadSegmentStore>,
+    oneway_map: Res<OneWayDirectionMap>,
+    mut toggle_events: EventWriter<ToggleOneWayEvent>,
+) {
+    let Some(seg_id) = selected.0 else {
+        return;
+    };
+
+    let Some(segment) = store.get_segment(seg_id) else {
+        // Segment was removed, clear selection
+        selected.0 = None;
+        return;
+    };
+
+    let current_direction = oneway_map.get(seg_id);
+
+    let direction_label = match current_direction {
+        None => "Two-Way",
+        Some(OneWayDirection::Forward) => "One-Way \u{2192}",
+        Some(OneWayDirection::Reverse) => "One-Way \u{2190}",
+    };
+
+    let road_type = format!("{:?}", segment.road_type);
+    let arc_length = segment.arc_length;
+
+    let mut open = true;
+    egui::Window::new("Road Segment")
+        .open(&mut open)
+        .default_width(220.0)
+        .anchor(egui::Align2::RIGHT_TOP, egui::vec2(-8.0, 40.0))
+        .show(contexts.ctx_mut(), |ui| {
+            ui.heading("Road Properties");
+            ui.separator();
+
+            egui::Grid::new("road_segment_props")
+                .num_columns(2)
+                .show(ui, |ui| {
+                    ui.label("Type:");
+                    ui.label(&road_type);
+                    ui.end_row();
+
+                    ui.label("Length:");
+                    ui.label(format!("{:.0}m", arc_length));
+                    ui.end_row();
+
+                    ui.label("Direction:");
+                    ui.label(direction_label);
+                    ui.end_row();
+                });
+
+            ui.separator();
+
+            ui.horizontal(|ui| {
+                if ui
+                    .button("Toggle Direction")
+                    .on_hover_text(
+                        "Cycle: Two-Way \u{2192} One-Way Forward \u{2192} One-Way Reverse \u{2192} Two-Way",
+                    )
+                    .clicked()
+                {
+                    toggle_events.send(ToggleOneWayEvent {
+                        segment_id: seg_id,
+                    });
+                }
+
+                let status_color = if current_direction.is_some() {
+                    egui::Color32::from_rgb(50, 200, 100)
+                } else {
+                    egui::Color32::from_rgb(150, 150, 150)
+                };
+                ui.colored_label(status_color, direction_label);
+            });
+        });
+
+    if !open {
+        selected.0 = None;
+    }
+}
+
+/// Detect right-clicks on road segments to open the context menu.
+pub fn select_road_segment_on_click(
+    buttons: Res<ButtonInput<MouseButton>>,
+    cursor: Res<rendering::input::CursorGridPos>,
+    store: Res<RoadSegmentStore>,
+    mut selected: ResMut<SelectedSegment>,
+) {
+    if !buttons.just_pressed(MouseButton::Right) || !cursor.valid {
+        return;
+    }
+
+    // Find which segment the cursor is over by checking rasterized cells
+    let gx = cursor.grid_x as usize;
+    let gy = cursor.grid_y as usize;
+
+    for segment in &store.segments {
+        if segment.rasterized_cells.contains(&(gx, gy)) {
+            selected.0 = Some(segment.id);
+            return;
+        }
+    }
+
+    // No segment under cursor, clear selection
+    selected.0 = None;
+}
+
+pub struct OneWayUiPlugin;
+
+impl Plugin for OneWayUiPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<SelectedSegment>().add_systems(
+            Update,
+            (select_road_segment_on_click, road_segment_context_menu).chain(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `OneWayDirectionMap` resource to track per-segment one-way direction (Forward/Reverse/None)
- Toggle cycles through: Two-Way -> One-Way Forward -> One-Way Reverse -> Two-Way
- CSR pathfinding graph rebuilt with directed edge filtering for one-way segments
- Direction arrows rendered on one-way roads using Bevy gizmos
- Right-click road segment to open context menu with "Toggle Direction" button
- Full save/load support via `Saveable` trait and `SaveableRegistry`

## Test plan
- [x] Unit tests for direction toggle cycling (None -> Forward -> Reverse -> None)
- [x] Unit tests for generation counter increments
- [x] Unit tests for save/load roundtrip serialization
- [x] Unit tests for one-way forward blocking reverse pathfinding
- [x] Unit tests for one-way reverse blocking forward pathfinding
- [x] Unit tests for removing one-way restoring bidirectional pathfinding
- [ ] Manual: right-click road segment opens context menu
- [ ] Manual: toggle button cycles direction with visual arrows
- [ ] Manual: pathfinding avoids one-way roads in wrong direction

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)