### PR TITLE
Fix O(n^2) road mesh sync with HashMap lookups

### DIFF
--- a/crates/rendering/src/road_render.rs
+++ b/crates/rendering/src/road_render.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy::render::mesh::Indices;
+use std::collections::{HashMap, HashSet};
 
 use simulation::grid::RoadType;
 use simulation::road_segments::{RoadSegmentStore, SegmentId, SegmentNodeId};
@@ -17,15 +18,18 @@ pub struct LastSyncedCount(usize);
 
 /// Marker component for intersection fill mesh entities.
 #[derive(Component)]
-pub struct RoadIntersectionMesh;
+pub struct RoadIntersectionMesh {
+    pub node_id: SegmentNodeId,
+}
 
 /// Synchronize road segment meshes with the RoadSegmentStore.
 /// Spawns meshes for new segments, despawns for removed ones.
 /// Also generates intersection fill discs where segments meet.
+#[allow(clippy::too_many_arguments)]
 pub fn sync_road_segment_meshes(
     store: Res<RoadSegmentStore>,
     existing: Query<(Entity, &RoadSegmentMesh)>,
-    existing_intersections: Query<Entity, With<RoadIntersectionMesh>>,
+    existing_intersections: Query<(Entity, &RoadIntersectionMesh)>,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
@@ -35,14 +39,28 @@ pub fn sync_road_segment_meshes(
         return;
     }
 
-    // Collect existing segment IDs
-    let existing_ids: Vec<(Entity, SegmentId)> =
-        existing.iter().map(|(e, m)| (e, m.segment_id)).collect();
+    // Build HashMap of existing segment meshes for O(1) lookup
+    let existing_map: HashMap<SegmentId, Entity> =
+        existing.iter().map(|(e, m)| (m.segment_id, e)).collect();
+
+    // Build HashSet of store segment IDs for O(1) membership checks
+    let store_ids: HashSet<SegmentId> = store.segments.iter().map(|s| s.id).collect();
+
+    // Track which node IDs need intersection mesh rebuilds
+    let mut dirty_nodes: HashSet<SegmentNodeId> = HashSet::new();
 
     // Despawn meshes for segments that no longer exist
-    for (entity, id) in &existing_ids {
-        if !store.segments.iter().any(|s| s.id == *id) {
-            commands.entity(*entity).despawn();
+    for (entity, seg_mesh) in &existing {
+        if !store_ids.contains(&seg_mesh.segment_id) {
+            // Mark connected nodes as dirty before despawning
+            // (the segment is gone from the store, so look up which nodes
+            // it *used* to connect by checking all nodes)
+            for node in &store.nodes {
+                if node.connected_segments.contains(&seg_mesh.segment_id) {
+                    dirty_nodes.insert(node.id);
+                }
+            }
+            commands.entity(entity).despawn();
         }
     }
 
@@ -56,10 +74,13 @@ pub fn sync_road_segment_meshes(
 
     // Spawn meshes for new segments
     for segment in &store.segments {
-        let already_exists = existing_ids.iter().any(|(_, id)| *id == segment.id);
-        if already_exists {
+        if existing_map.contains_key(&segment.id) {
             continue;
         }
+
+        // This is a new segment — mark its nodes as dirty
+        dirty_nodes.insert(segment.start_node);
+        dirty_nodes.insert(segment.end_node);
 
         // Compute trim distances based on junction status
         let road_half_w: f32 = match segment.road_type {
@@ -108,86 +129,95 @@ pub fn sync_road_segment_meshes(
         ));
     }
 
-    // Despawn old intersection meshes and regenerate
-    for entity in &existing_intersections {
-        commands.entity(entity).despawn();
-    }
-
-    // Generate intersection fill discs at junction nodes
-    let intersection_material = materials.add(StandardMaterial {
-        base_color: Color::WHITE,
-        perceptual_roughness: 0.9,
-        ..default()
-    });
-
-    for node in &store.nodes {
-        if node.connected_segments.len() < 2 {
-            continue;
-        }
-
-        // Find the max road dimensions of connected segments
-        let mut max_road_hw: f32 = 0.0;
-        let mut max_total_hw: f32 = 0.0;
-        let mut avg_asphalt = [0.0_f32; 4];
-        let mut count = 0.0_f32;
-
-        for &seg_id in &node.connected_segments {
-            if let Some(seg) = store.get_segment(seg_id) {
-                let rhw: f32 = match seg.road_type {
-                    RoadType::Path => 1.5,
-                    RoadType::OneWay => 3.0,
-                    RoadType::Local => 4.0,
-                    RoadType::Avenue => 6.0,
-                    RoadType::Boulevard => 8.0,
-                    RoadType::Highway => 10.0,
-                };
-                let sw: f32 = match seg.road_type {
-                    RoadType::Path => 0.5,
-                    RoadType::OneWay | RoadType::Local => 2.0,
-                    RoadType::Avenue => 3.0,
-                    RoadType::Boulevard => 4.0,
-                    RoadType::Highway => 1.5,
-                };
-                let asph: [f32; 4] = match seg.road_type {
-                    RoadType::Highway => [0.10, 0.10, 0.12, 1.0],
-                    RoadType::Boulevard => [0.16, 0.16, 0.20, 1.0],
-                    RoadType::Avenue => [0.22, 0.22, 0.25, 1.0],
-                    RoadType::Local | RoadType::OneWay => [0.32, 0.32, 0.34, 1.0],
-                    RoadType::Path => [0.52, 0.47, 0.36, 1.0],
-                };
-                max_road_hw = max_road_hw.max(rhw);
-                max_total_hw = max_total_hw.max(rhw + sw);
-                for j in 0..4 {
-                    avg_asphalt[j] += asph[j];
-                }
-                count += 1.0;
+    // Only rebuild intersection meshes for dirty nodes
+    if !dirty_nodes.is_empty() {
+        // Despawn only the intersection meshes for affected nodes
+        for (entity, intersection_mesh) in &existing_intersections {
+            if dirty_nodes.contains(&intersection_mesh.node_id) {
+                commands.entity(entity).despawn();
             }
         }
 
-        if count < 1.0 {
-            continue;
+        // Regenerate intersection fill discs only for dirty junction nodes
+        let intersection_material = materials.add(StandardMaterial {
+            base_color: Color::WHITE,
+            perceptual_roughness: 0.9,
+            ..default()
+        });
+
+        for node in &store.nodes {
+            if !dirty_nodes.contains(&node.id) {
+                continue;
+            }
+
+            if node.connected_segments.len() < 2 {
+                continue;
+            }
+
+            // Find the max road dimensions of connected segments
+            let mut max_road_hw: f32 = 0.0;
+            let mut max_total_hw: f32 = 0.0;
+            let mut avg_asphalt = [0.0_f32; 4];
+            let mut count = 0.0_f32;
+
+            for &seg_id in &node.connected_segments {
+                if let Some(seg) = store.get_segment(seg_id) {
+                    let rhw: f32 = match seg.road_type {
+                        RoadType::Path => 1.5,
+                        RoadType::OneWay => 3.0,
+                        RoadType::Local => 4.0,
+                        RoadType::Avenue => 6.0,
+                        RoadType::Boulevard => 8.0,
+                        RoadType::Highway => 10.0,
+                    };
+                    let sw: f32 = match seg.road_type {
+                        RoadType::Path => 0.5,
+                        RoadType::OneWay | RoadType::Local => 2.0,
+                        RoadType::Avenue => 3.0,
+                        RoadType::Boulevard => 4.0,
+                        RoadType::Highway => 1.5,
+                    };
+                    let asph: [f32; 4] = match seg.road_type {
+                        RoadType::Highway => [0.10, 0.10, 0.12, 1.0],
+                        RoadType::Boulevard => [0.16, 0.16, 0.20, 1.0],
+                        RoadType::Avenue => [0.22, 0.22, 0.25, 1.0],
+                        RoadType::Local | RoadType::OneWay => [0.32, 0.32, 0.34, 1.0],
+                        RoadType::Path => [0.52, 0.47, 0.36, 1.0],
+                    };
+                    max_road_hw = max_road_hw.max(rhw);
+                    max_total_hw = max_total_hw.max(rhw + sw);
+                    for j in 0..4 {
+                        avg_asphalt[j] += asph[j];
+                    }
+                    count += 1.0;
+                }
+            }
+
+            if count < 1.0 {
+                continue;
+            }
+            for val in &mut avg_asphalt {
+                *val /= count;
+            }
+
+            let sidewalk_color: [f32; 4] = [0.58, 0.56, 0.53, 1.0];
+
+            // Build a disc mesh: sidewalk disc + asphalt disc on top
+            let mesh = build_intersection_disc(
+                node.position,
+                max_total_hw,
+                max_road_hw,
+                sidewalk_color,
+                avg_asphalt,
+            );
+
+            commands.spawn((
+                RoadIntersectionMesh { node_id: node.id },
+                Mesh3d(meshes.add(mesh)),
+                MeshMaterial3d(intersection_material.clone()),
+                Transform::IDENTITY,
+            ));
         }
-        for val in &mut avg_asphalt {
-            *val /= count;
-        }
-
-        let sidewalk_color: [f32; 4] = [0.58, 0.56, 0.53, 1.0];
-
-        // Build a disc mesh: sidewalk disc + asphalt disc on top
-        let mesh = build_intersection_disc(
-            node.position,
-            max_total_hw,
-            max_road_hw,
-            sidewalk_color,
-            avg_asphalt,
-        );
-
-        commands.spawn((
-            RoadIntersectionMesh,
-            Mesh3d(meshes.add(mesh)),
-            MeshMaterial3d(intersection_material.clone()),
-            Transform::IDENTITY,
-        ));
     }
 
     local_count.0 = store.segments.len();


### PR DESCRIPTION
## Summary
- Replace linear `Vec` scans with `HashMap<SegmentId, Entity>` and `HashSet<SegmentId>` for O(1) existing mesh lookups and store membership checks in `sync_road_segment_meshes`
- Track dirty nodes (`HashSet<SegmentNodeId>`) to only rebuild intersection meshes for nodes connected to added/removed segments, instead of despawning and regenerating all intersection meshes on every store change
- Add `node_id` field to `RoadIntersectionMesh` component to enable targeted intersection tracking

Closes #1160

## Test plan
- [ ] Verify road meshes render correctly when placing new road segments
- [ ] Verify intersection discs appear at junctions and update when segments are added/removed
- [ ] Verify no visual regressions with existing road rendering
- [ ] CI checks pass (build, clippy, fmt, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)