### PR TITLE
Fix citizen orbiting at low speeds

### DIFF
--- a/crates/simulation/src/movement.rs
+++ b/crates/simulation/src/movement.rs
@@ -407,7 +407,10 @@ pub fn move_citizens(
                 let (raw_tx, raw_ty) = WorldGrid::grid_to_world(target.0, target.1);
                 let raw_dist = ((raw_tx - pos.x).powi(2) + (raw_ty - pos.y).powi(2)).sqrt();
 
-                if raw_dist < speed_per_tick {
+                // Use a fixed minimum arrival threshold so that even at very low speeds
+                // (heavy snow/fog), citizens can still reach waypoints without orbiting.
+                let arrival_dist = speed_per_tick.max(2.0);
+                if raw_dist < arrival_dist {
                     pos.x = raw_tx;
                     pos.y = raw_ty;
                     vel.x = dx;
@@ -417,14 +420,18 @@ pub fn move_citizens(
                     let nx = dx / dist;
                     let ny = dy / dist;
 
-                    // Per-entity lane offset: shift perpendicular to travel direction
+                    // Per-entity lane offset: shift perpendicular to travel direction.
+                    // Scale the offset by (speed / raw_dist) clamped to [0, 1] so that
+                    // lateral drift diminishes as the citizen approaches the waypoint,
+                    // preventing orbiting at low speeds (issue #1163).
                     let lane = (entity.index() % 3) as f32 - 1.0;
                     let lane_offset = lane * 2.5;
                     let perp_x = -ny;
                     let perp_y = nx;
+                    let offset_scale = (speed_per_tick / raw_dist).min(1.0);
 
-                    pos.x += nx * speed_per_tick + perp_x * lane_offset * 0.02;
-                    pos.y += ny * speed_per_tick + perp_y * lane_offset * 0.02;
+                    pos.x += nx * speed_per_tick + perp_x * lane_offset * 0.02 * offset_scale;
+                    pos.y += ny * speed_per_tick + perp_y * lane_offset * 0.02 * offset_scale;
                     vel.x = nx * speed_per_tick;
                     vel.y = ny * speed_per_tick;
                 }


### PR DESCRIPTION
## Summary
- Fixed floating-point orbiting bug where citizens at very low speeds (heavy snow/fog) would orbit waypoints indefinitely instead of arriving
- Added a fixed minimum arrival threshold of 2.0 units (`speed_per_tick.max(2.0)`) so slow citizens can still reach waypoints
- Scaled perpendicular lane offset by `(speed / distance).min(1.0)` so lateral drift diminishes near waypoints, preventing orbit onset

## Root Cause
The arrival check `raw_dist < speed_per_tick` used the per-tick speed as the threshold. Under extreme weather (snow + fog), `speed_per_tick` could drop below 1.0, while the perpendicular lane offset (`perp * lane_offset * 0.02`) remained constant. This meant the lateral movement component overpowered forward progress, pushing citizens into a stable orbit around the waypoint that they could never escape.

## Test plan
- [ ] Verify citizens arrive at waypoints correctly under normal weather conditions
- [ ] Verify citizens still arrive under heavy snow + fog (speed multiplier ~0.2)
- [ ] Verify lane offset visual separation still works at normal speeds
- [ ] Check no traffic jams form at intersections due to orbiting citizens

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)