### PR TITLE
Register missing saveable resources

### DIFF
--- a/crates/simulation/src/localization.rs
+++ b/crates/simulation/src/localization.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-use crate::Saveable;
+use crate::{Saveable, SaveableRegistry};
 
 // =============================================================================
 // Constants
@@ -705,6 +705,10 @@ pub struct LocalizationPlugin;
 impl Plugin for LocalizationPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LocalizationState>();
+        app.init_resource::<SaveableRegistry>();
+        app.world_mut()
+            .resource_mut::<SaveableRegistry>()
+            .register::<LocalizationState>();
     }
 }
 

--- a/crates/simulation/src/nimby.rs
+++ b/crates/simulation/src/nimby.rs
@@ -37,8 +37,8 @@ use crate::policies::{Policies, Policy};
 use crate::time_of_day::GameClock;
 use crate::wealth::WealthTier;
 use crate::zones::ZoneDemand;
-use crate::Saveable;
 use crate::SlowTickTimer;
+use crate::{Saveable, SaveableRegistry};
 
 // =============================================================================
 // Constants
@@ -762,6 +762,10 @@ impl Plugin for NimbyPlugin {
                     .chain()
                     .after(crate::zones::update_zone_demand),
             );
+        app.init_resource::<SaveableRegistry>();
+        app.world_mut()
+            .resource_mut::<SaveableRegistry>()
+            .register::<NimbyState>();
     }
 }
 


### PR DESCRIPTION
## Summary
- Register `LocalizationState` as saveable in `LocalizationPlugin::build()` so it persists across save/load
- Register `NimbyState` as saveable in `NimbyPlugin::build()` so it persists across save/load
- Both types already implemented the `Saveable` trait but were never registered with `SaveableRegistry`

Closes #1155

## Test plan
- [ ] Save a game, modify localization settings, load the save — localization state should be restored
- [ ] Save a game with active NIMBY opinions, load the save — NIMBY state should be restored
- [ ] Verify no regression in existing save/load functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)