### PR TITLE
Add Escape key cascade for cancel/deselect

### DIFF
--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -76,6 +76,7 @@ impl Plugin for RenderingPlugin {
                     input::handle_tree_tool,
                     input::keyboard_tool_switch,
                     input::toggle_grid_snap,
+                    input::handle_escape_key,
                     input::tick_status_message,
                     overlay::toggle_overlay_keys,
                 ),


### PR DESCRIPTION
## Summary
- Implements Escape key cascade that handles one level per press:
  1. Cancel active road drawing (if `RoadDrawState` is not Idle)
  2. Deselect selected building (if `SelectedBuilding` has a value)
  3. Reset active tool back to `Inspect`
- Removes the old single-purpose Escape handler from `handle_tool_input`
- Adds dedicated `handle_escape_key` system registered in the rendering plugin

## Test plan
- [ ] Start drawing a road, press Escape -- road drawing should cancel
- [ ] Select a building, press Escape -- building should deselect
- [ ] Switch to any non-Inspect tool, press Escape -- tool should reset to Inspect
- [ ] Verify cascade order: with road drawing active + building selected + non-Inspect tool, first Escape cancels drawing, second deselects building, third resets tool

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)