### PR TITLE
Add warning logs for extension-map decode failures

### DIFF
--- a/crates/simulation/src/climate_change.rs
+++ b/crates/simulation/src/climate_change.rs
@@ -129,7 +129,7 @@ impl Saveable for ClimateState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/cumulative_zoning.rs
+++ b/crates/simulation/src/cumulative_zoning.rs
@@ -176,7 +176,7 @@ impl crate::Saveable for CumulativeZoningState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/day_night_controls.rs
+++ b/crates/simulation/src/day_night_controls.rs
@@ -98,7 +98,7 @@ impl Saveable for DayNightControls {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/district_policies.rs
+++ b/crates/simulation/src/district_policies.rs
@@ -576,7 +576,7 @@ impl crate::Saveable for DistrictPolicyState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/far_transfer.rs
+++ b/crates/simulation/src/far_transfer.rs
@@ -455,7 +455,7 @@ impl crate::Saveable for FarTransferState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/flood_protection.rs
+++ b/crates/simulation/src/flood_protection.rs
@@ -213,7 +213,7 @@ impl Saveable for FloodProtectionState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/form_transect.rs
+++ b/crates/simulation/src/form_transect.rs
@@ -290,7 +290,7 @@ impl crate::Saveable for TransectGrid {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/heat_mitigation.rs
+++ b/crates/simulation/src/heat_mitigation.rs
@@ -158,6 +158,11 @@ impl crate::Saveable for HeatMitigationState {
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
         if bytes.len() < 30 {
+            warn!(
+                "Saveable {}: expected >= 30 bytes, got {}, falling back to default",
+                Self::SAVE_KEY,
+                bytes.len()
+            );
             return Self::default();
         }
         let cooling = bytes[0] != 0;

--- a/crates/simulation/src/historic_preservation.rs
+++ b/crates/simulation/src/historic_preservation.rs
@@ -209,7 +209,7 @@ impl crate::Saveable for HistoricPreservationState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/inclusionary_zoning.rs
+++ b/crates/simulation/src/inclusionary_zoning.rs
@@ -262,7 +262,7 @@ impl crate::Saveable for InclusionaryZoningState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/landfill.rs
+++ b/crates/simulation/src/landfill.rs
@@ -521,7 +521,7 @@ impl crate::Saveable for LandfillState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/localization.rs
+++ b/crates/simulation/src/localization.rs
@@ -158,7 +158,18 @@ impl Saveable for LocalizationState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        let locale = std::str::from_utf8(bytes).unwrap_or(DEFAULT_LOCALE);
+        let locale = match std::str::from_utf8(bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    "Saveable {}: failed to decode locale from {} bytes, using default: {}",
+                    Self::SAVE_KEY,
+                    bytes.len(),
+                    e
+                );
+                DEFAULT_LOCALE
+            }
+        };
         let mut state = Self::default();
         state.set_locale(locale);
         state

--- a/crates/simulation/src/multi_select.rs
+++ b/crates/simulation/src/multi_select.rs
@@ -154,7 +154,7 @@ impl Saveable for MultiSelectState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        let save: MultiSelectSave = bitcode::decode(bytes).unwrap_or_default();
+        let save: MultiSelectSave = crate::decode_or_warn(Self::SAVE_KEY, bytes);
         let mut state = MultiSelectState::default();
         for (x, y) in save.road_cells {
             state.add(SelectableItem::RoadCell {

--- a/crates/simulation/src/neighborhood_quality.rs
+++ b/crates/simulation/src/neighborhood_quality.rs
@@ -411,7 +411,7 @@ impl crate::Saveable for NeighborhoodQualityIndex {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/nimby.rs
+++ b/crates/simulation/src/nimby.rs
@@ -175,6 +175,11 @@ impl Saveable for NimbyState {
         let mut state = NimbyState::default();
 
         if bytes.len() < 16 {
+            warn!(
+                "Saveable {}: expected >= 16 bytes, got {}, falling back to default",
+                Self::SAVE_KEY,
+                bytes.len()
+            );
             return state;
         }
 

--- a/crates/simulation/src/oneway.rs
+++ b/crates/simulation/src/oneway.rs
@@ -221,6 +221,11 @@ impl Saveable for OneWayDirectionMap {
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
         if bytes.len() < 4 {
+            warn!(
+                "Saveable {}: expected >= 4 bytes, got {}, falling back to default",
+                Self::SAVE_KEY,
+                bytes.len()
+            );
             return Self::default();
         }
 

--- a/crates/simulation/src/parking.rs
+++ b/crates/simulation/src/parking.rs
@@ -256,7 +256,7 @@ impl crate::Saveable for ParkingPolicyState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/seasonal_rendering.rs
+++ b/crates/simulation/src/seasonal_rendering.rs
@@ -307,7 +307,7 @@ impl Saveable for SeasonalRenderingState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 
@@ -323,7 +323,7 @@ impl Saveable for SeasonalEffectsConfig {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/traffic_los.rs
+++ b/crates/simulation/src/traffic_los.rs
@@ -139,7 +139,7 @@ impl Saveable for TrafficLosGrid {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/tutorial.rs
+++ b/crates/simulation/src/tutorial.rs
@@ -253,7 +253,7 @@ impl Saveable for TutorialState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/uhi_mitigation.rs
+++ b/crates/simulation/src/uhi_mitigation.rs
@@ -355,7 +355,7 @@ impl crate::Saveable for UhiMitigationState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/walkability.rs
+++ b/crates/simulation/src/walkability.rs
@@ -328,7 +328,7 @@ impl crate::Saveable for WalkabilityGrid {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/waste_policies.rs
+++ b/crates/simulation/src/waste_policies.rs
@@ -324,7 +324,7 @@ impl crate::Saveable for WastePolicyState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 

--- a/crates/simulation/src/water_pressure.rs
+++ b/crates/simulation/src/water_pressure.rs
@@ -116,7 +116,7 @@ impl crate::Saveable for WaterPressureState {
     }
 
     fn load_from_bytes(bytes: &[u8]) -> Self {
-        bitcode::decode(bytes).unwrap_or_default()
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `decode_or_warn()` helper to `lib.rs` that wraps `bitcode::decode` with a `warn!()` log on failure before returning `Default`
- Replace all 21 silent `bitcode::decode(bytes).unwrap_or_default()` calls in `Saveable::load_from_bytes` implementations with `decode_or_warn(Self::SAVE_KEY, bytes)`
- Add explicit `warn!()` calls to manual byte-parsing implementations (`nimby`, `oneway`, `heat_mitigation`) at their early-return fallback points
- Add `warn!()` to `localization.rs` UTF-8 decode failure path

This ensures schema mismatches, save corruption, and migration issues surface in logs instead of silently resetting extension state to defaults.

Closes #1161

## Test plan
- [ ] Existing integration tests pass (no behavior change on valid data)
- [ ] Manually verify warnings appear when loading corrupted save data
- [ ] CI checks pass (build, test, clippy, fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)