### PR TITLE
Extend citizen save/load to preserve full state

### DIFF
--- a/crates/save/src/save_types.rs
+++ b/crates/save/src/save_types.rs
@@ -7,7 +7,9 @@ use std::collections::BTreeMap;
 use bitcode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-use simulation::citizen::{CitizenDetails, CitizenState, PathCache, Position, Velocity};
+use simulation::citizen::{
+    CitizenDetails, CitizenState, Needs, PathCache, Personality, Position, Velocity,
+};
 
 // ---------------------------------------------------------------------------
 // Version constants
@@ -268,6 +270,67 @@ pub struct SaveCitizen {
     pub pos_x: f32,
     #[serde(default)]
     pub pos_y: f32,
+    // V4 fields: Full citizen fidelity (backward-compatible via serde defaults)
+    /// Gender: 0 = Male, 1 = Female
+    #[serde(default)]
+    pub gender: u8,
+    #[serde(default = "default_citizen_health")]
+    pub health: f32,
+    #[serde(default)]
+    pub salary: f32,
+    #[serde(default)]
+    pub savings: f32,
+    // Personality traits
+    #[serde(default = "default_personality_trait")]
+    pub ambition: f32,
+    #[serde(default = "default_personality_trait")]
+    pub sociability: f32,
+    #[serde(default = "default_personality_trait")]
+    pub materialism: f32,
+    #[serde(default = "default_personality_trait")]
+    pub resilience: f32,
+    // Needs
+    #[serde(default = "default_need_hunger")]
+    pub need_hunger: f32,
+    #[serde(default = "default_need_energy")]
+    pub need_energy: f32,
+    #[serde(default = "default_need_social")]
+    pub need_social: f32,
+    #[serde(default = "default_need_fun")]
+    pub need_fun: f32,
+    #[serde(default = "default_need_comfort")]
+    pub need_comfort: f32,
+    // Activity timer
+    #[serde(default)]
+    pub activity_timer: u32,
+}
+
+fn default_citizen_health() -> f32 {
+    80.0
+}
+
+fn default_personality_trait() -> f32 {
+    0.5
+}
+
+fn default_need_hunger() -> f32 {
+    80.0
+}
+
+fn default_need_energy() -> f32 {
+    80.0
+}
+
+fn default_need_social() -> f32 {
+    70.0
+}
+
+fn default_need_fun() -> f32 {
+    70.0
+}
+
+fn default_need_comfort() -> f32 {
+    60.0
 }
 
 #[derive(Serialize, Deserialize, Encode, Decode)]
@@ -798,4 +861,7 @@ pub struct CitizenSaveInput {
     pub path: PathCache,
     pub velocity: Velocity,
     pub position: Position,
+    pub personality: Personality,
+    pub needs: Needs,
+    pub activity_timer: u32,
 }


### PR DESCRIPTION
## Summary
- Extended `SaveCitizen` struct with all missing citizen fields: gender, health, salary, savings, personality traits (ambition, sociability, materialism, resilience), needs (hunger, energy, social, fun, comfort), and activity timer
- Updated save logic to capture the full citizen state from `CitizenDetails`, `Personality`, `Needs`, and `ActivityTimer` components
- Updated load logic to restore all fields from saved data instead of using hardcoded defaults
- All new fields use `#[serde(default)]` with appropriate default values for backward compatibility with old saves
- Added comprehensive roundtrip test assertions for all new fields

## Problem
Previously, citizen serialization only stored age/happiness/education/state/path/velocity/position. On load, gender was reconstructed from age parity (`age % 2`), health was hardcoded to `80.0`, salary was derived from education, savings were `salary * 2.0`, personality traits were all `0.5`, needs used `Needs::default()`, and activity timer was `0`. This meant every save/load cycle lost significant citizen state.

## Fix
Extended `SaveCitizen` with 14 new fields that capture the full citizen state. The load logic now restores these values directly. For old saves that lack these fields, serde defaults provide the same fallback values that were previously hardcoded.

Closes #1154

## Test plan
- [ ] Existing roundtrip serialization test passes with new field assertions
- [ ] Backward compatibility test still passes (old saves without V4 fields get sensible defaults)
- [ ] All workspace tests pass
- [ ] No clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)