### PR TITLE
Add Delete key to bulldoze selected entity

### DIFF
--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -77,6 +77,7 @@ impl Plugin for RenderingPlugin {
                     input::keyboard_tool_switch,
                     input::toggle_grid_snap,
                     input::handle_escape_key,
+                    input::delete_selected_building,
                     input::tick_status_message,
                     overlay::toggle_overlay_keys,
                 ),


### PR DESCRIPTION
## Summary
- When an entity is selected (via the Inspect tool), pressing **Delete** or **Backspace** now bulldozes it
- Handles both regular buildings (grid scan) and multi-cell service buildings (footprint-based clearing)
- Clears grid cells, marks chunks dirty for re-render, despawns the entity, and resets the selection
- No-op if nothing is currently selected

## Implementation
- Added `delete_selected_building` system in `crates/rendering/src/input.rs`
- Registered it in `RenderingPlugin::build()` alongside other input systems

## Test plan
- [ ] Select a residential building with Inspect tool, press Delete — building is demolished
- [ ] Select a service building (e.g., fire station), press Delete — all footprint cells cleared
- [ ] Press Delete with no selection — nothing happens
- [ ] Press Backspace with a selected building — building is demolished (macOS keyboard support)

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)