### PR TITLE
UX-053: Seamless zoom-dependent LOD transitions

### DIFF
--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -103,12 +103,19 @@ impl Plugin for RenderingPlugin {
                     building_render::update_construction_visuals,
                     building_render::cleanup_orphan_building_meshes
                         .run_if(on_timer(std::time::Duration::from_secs(1))),
-                    citizen_render::spawn_citizen_sprites,
-                    citizen_render::update_citizen_sprites,
-                    citizen_render::despawn_abstract_sprites,
                     props::spawn_tree_props,
                     props::spawn_road_props,
                     props::spawn_parked_cars,
+                ),
+            )
+            .add_systems(
+                Update,
+                (
+                    citizen_render::spawn_citizen_sprites,
+                    citizen_render::trigger_lod_fade,
+                    citizen_render::update_citizen_sprites,
+                    citizen_render::update_lod_fade,
+                    citizen_render::despawn_abstract_sprites,
                 ),
             )
             .add_systems(


### PR DESCRIPTION
## Summary
- **Hysteresis in LOD tier assignment**: Different margin thresholds for upgrading (closer) vs downgrading (farther) to prevent rapid oscillation at LOD boundaries. WASM uses tighter margins.
- **Smooth fade transitions**: `LodFade` component provides 0.3s scale-based fade-in/fade-out when LOD tier changes, eliminating visual popping. No double-rendering — only one representation exists at a time.
- **Fade lifecycle**: `trigger_lod_fade` detects LOD changes and starts fades; `update_lod_fade` advances timers every frame and despawns sprites when fade-out completes.

## Test plan
- [ ] Verify hysteresis unit tests pass (boundary conditions for upgrade vs downgrade margins)
- [ ] Zoom in/out in-game and confirm citizens fade in/out smoothly instead of popping
- [ ] Verify no oscillation at LOD boundaries when camera is near a threshold
- [ ] Confirm Abstract-tier citizens are despawned after fade-out completes
- [ ] Check WASM build uses tighter margins

Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)