### PR TITLE
UX-027: Real-time road cost display during placement

### DIFF
--- a/crates/rendering/src/input.rs
+++ b/crates/rendering/src/input.rs
@@ -268,6 +268,19 @@ impl ActiveTool {
             ActiveTool::TreeRemove => "Remove Tree",
         }
     }
+
+    /// Returns the `RoadType` for road tools, or `None` for non-road tools.
+    pub fn road_type(&self) -> Option<RoadType> {
+        match self {
+            ActiveTool::Road => Some(RoadType::Local),
+            ActiveTool::RoadAvenue => Some(RoadType::Avenue),
+            ActiveTool::RoadBoulevard => Some(RoadType::Boulevard),
+            ActiveTool::RoadHighway => Some(RoadType::Highway),
+            ActiveTool::RoadOneWay => Some(RoadType::OneWay),
+            ActiveTool::RoadPath => Some(RoadType::Path),
+            _ => None,
+        }
+    }
 }
 
 /// Grid snap mode: when enabled, cursor snaps to cell centers for precise placement.

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -13,6 +13,7 @@ pub mod milestones;
 pub mod multi_select;
 pub mod oneway_ui;
 pub mod progressive_disclosure;
+pub mod road_cost_display;
 pub mod road_segment_info;
 pub mod service_coverage_panel;
 pub mod settings_panel;
@@ -78,6 +79,7 @@ impl Plugin for UiPlugin {
                     tutorial::tutorial_ui,
                     day_night_panel::day_night_panel_keybind,
                     day_night_panel::day_night_panel_ui,
+                    road_cost_display::road_cost_display_ui,
                 ),
             );
     }

--- a/crates/ui/src/road_cost_display.rs
+++ b/crates/ui/src/road_cost_display.rs
@@ -1,0 +1,75 @@
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts};
+
+use rendering::input::{ActiveTool, CursorGridPos, DrawPhase, RoadDrawState};
+use simulation::config::CELL_SIZE;
+use simulation::economy::CityBudget;
+
+/// Shows estimated road cost near the cursor during road placement.
+/// Green text if affordable, red text if over budget.
+pub fn road_cost_display_ui(
+    mut contexts: EguiContexts,
+    tool: Res<ActiveTool>,
+    draw_state: Res<RoadDrawState>,
+    cursor: Res<CursorGridPos>,
+    budget: Res<CityBudget>,
+) {
+    // Only display when actively drawing a road (start placed, waiting for end)
+    if draw_state.phase != DrawPhase::PlacedStart {
+        return;
+    }
+
+    // Only for road tools
+    let Some(road_type) = tool.road_type() else {
+        return;
+    };
+
+    if !cursor.valid {
+        return;
+    }
+
+    // Calculate segment length and cost
+    let start = draw_state.start_pos;
+    let end = cursor.world_pos;
+    let length = (end - start).length();
+
+    // Minimum length check - don't show for very short segments
+    if length < CELL_SIZE * 0.5 {
+        return;
+    }
+
+    let approx_cells = (length / CELL_SIZE).ceil() as usize;
+    let cost_per_cell = road_type.cost();
+    let total_cost = cost_per_cell * approx_cells as f64;
+    let affordable = budget.treasury >= total_cost;
+
+    // Get cursor screen position from egui
+    let ctx = contexts.ctx_mut();
+    let Some(pointer_pos) = ctx.pointer_hover_pos() else {
+        return;
+    };
+
+    // Position the label slightly offset from cursor (below-right)
+    let offset = egui::vec2(16.0, 20.0);
+    let label_pos = pointer_pos + offset;
+
+    let color = if affordable {
+        egui::Color32::from_rgb(80, 220, 80) // green
+    } else {
+        egui::Color32::from_rgb(220, 60, 60) // red
+    };
+
+    let cost_text = format!("${:.0}", total_cost);
+
+    egui::Area::new(egui::Id::new("road_cost_display"))
+        .fixed_pos(egui::pos2(label_pos.x, label_pos.y))
+        .interactable(false)
+        .order(egui::Order::Tooltip)
+        .show(ctx, |ui| {
+            egui::Frame::popup(ui.style())
+                .fill(egui::Color32::from_rgba_premultiplied(20, 20, 20, 200))
+                .show(ui, |ui| {
+                    ui.colored_label(color, egui::RichText::new(cost_text).strong().size(14.0));
+                });
+        });
+}


### PR DESCRIPTION
## Summary
- Show estimated road cost near cursor in real-time during road segment drawing
- Cost is calculated from segment length (approx cells) and road type cost_per_cell
- Green text when budget is sufficient, red text when insufficient
- Display only appears after first click (start point placed), updating as cursor moves

## Implementation
- Added `ActiveTool::road_type()` helper to map road tools to `RoadType`
- Created `ui/src/road_cost_display.rs` with egui `Area` tooltip near cursor
- Uses `egui::Context::pointer_hover_pos()` for screen-space cursor position
- Calculates cost as `ceil(segment_length / CELL_SIZE) * cost_per_cell`

## Test plan
- [ ] Select any road tool, click to place start point, move cursor - cost should appear
- [ ] Verify cost updates as cursor moves farther from start
- [ ] Verify green text when treasury >= cost, red when treasury < cost
- [ ] Verify display disappears when not in road drawing mode (Idle phase)
- [ ] Verify all road types show correct per-cell cost

Closes #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)