### PR TITLE
UX-036: Resolve keybinding conflicts

### DIFF
--- a/crates/rendering/src/camera.rs
+++ b/crates/rendering/src/camera.rs
@@ -10,6 +10,7 @@ const MAX_DISTANCE: f32 = 4000.0;
 const MIN_PITCH: f32 = 5.0 * std::f32::consts::PI / 180.0; // 5 degrees (near street level)
 const MAX_PITCH: f32 = 80.0 * std::f32::consts::PI / 180.0; // 80 degrees
 const ORBIT_SENSITIVITY: f32 = 0.005;
+const KEYBOARD_ROTATE_SPEED: f32 = 2.0;
 
 /// Orbital camera model: camera orbits around a focus point on the ground.
 #[derive(Resource)]
@@ -258,6 +259,24 @@ pub fn camera_left_drag(
                 left_drag.last_pos = pos;
             }
         }
+    }
+}
+
+/// Q/E keys: rotate camera left/right around focus point.
+pub fn camera_rotate_keyboard(
+    keys: Res<ButtonInput<KeyCode>>,
+    time: Res<Time>,
+    mut orbit: ResMut<OrbitCamera>,
+) {
+    let mut yaw_delta = 0.0;
+    if keys.pressed(KeyCode::KeyQ) {
+        yaw_delta -= 1.0;
+    }
+    if keys.pressed(KeyCode::KeyE) {
+        yaw_delta += 1.0;
+    }
+    if yaw_delta != 0.0 {
+        orbit.yaw += yaw_delta * KEYBOARD_ROTATE_SPEED * time.delta_secs();
     }
 }
 

--- a/crates/rendering/src/input.rs
+++ b/crates/rendering/src/input.rs
@@ -1081,36 +1081,23 @@ pub fn toggle_grid_snap(keys: Res<ButtonInput<KeyCode>>, mut grid_snap: ResMut<G
     }
 }
 
+/// Quick-access tool shortcuts (R/Z/B/I/V).
+/// Digit keys 1-3 are reserved for simulation speed; overlays use Tab cycling.
 pub fn keyboard_tool_switch(keys: Res<ButtonInput<KeyCode>>, mut tool: ResMut<ActiveTool>) {
-    if keys.just_pressed(KeyCode::Digit1) {
+    if keys.just_pressed(KeyCode::KeyR) {
         *tool = ActiveTool::Road;
     }
-    if keys.just_pressed(KeyCode::Digit2) {
+    if keys.just_pressed(KeyCode::KeyZ) {
         *tool = ActiveTool::ZoneResidentialLow;
     }
-    if keys.just_pressed(KeyCode::Digit3) {
-        *tool = ActiveTool::ZoneCommercialLow;
-    }
-    if keys.just_pressed(KeyCode::Digit4) {
-        *tool = ActiveTool::ZoneIndustrial;
-    }
-    if keys.just_pressed(KeyCode::Digit5) {
+    if keys.just_pressed(KeyCode::KeyB) {
         *tool = ActiveTool::Bulldoze;
     }
-    if keys.just_pressed(KeyCode::Digit6) {
-        *tool = ActiveTool::ZoneResidentialHigh;
-    }
-    if keys.just_pressed(KeyCode::Digit7) {
-        *tool = ActiveTool::ZoneCommercialHigh;
-    }
-    if keys.just_pressed(KeyCode::Digit8) {
-        *tool = ActiveTool::ZoneOffice;
-    }
-    if keys.just_pressed(KeyCode::Digit9) {
+    if keys.just_pressed(KeyCode::KeyI) {
         *tool = ActiveTool::Inspect;
     }
-    if keys.just_pressed(KeyCode::Digit0) {
-        *tool = ActiveTool::ZoneMixedUse;
+    if keys.just_pressed(KeyCode::KeyV) {
+        *tool = ActiveTool::ZoneCommercialLow;
     }
 }
 

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -71,6 +71,7 @@ impl Plugin for RenderingPlugin {
                     camera::camera_orbit_drag,
                     camera::camera_zoom,
                     camera::camera_zoom_keyboard,
+                    camera::camera_rotate_keyboard,
                     camera::apply_orbit_camera,
                 ),
             )

--- a/crates/rendering/src/overlay.rs
+++ b/crates/rendering/src/overlay.rs
@@ -73,89 +73,16 @@ pub struct OverlayState {
     pub mode: OverlayMode,
 }
 
+/// Cycle overlays with Tab (forward) / Shift+Tab (backward).
+/// Individual letter-key shortcuts have been removed to resolve keybinding
+/// conflicts (see issue #905).  All overlays are reachable via Tab cycling.
 pub fn toggle_overlay_keys(keys: Res<ButtonInput<KeyCode>>, mut overlay: ResMut<OverlayState>) {
-    // Tab / Shift+Tab cycling through overlay modes
     if keys.just_pressed(KeyCode::Tab) {
         let shift = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
         overlay.mode = if shift {
             overlay.mode.prev()
         } else {
             overlay.mode.next()
-        };
-        return;
-    }
-
-    if keys.just_pressed(KeyCode::KeyP) {
-        overlay.mode = if overlay.mode == OverlayMode::Power {
-            OverlayMode::None
-        } else {
-            OverlayMode::Power
-        };
-    }
-    if keys.just_pressed(KeyCode::KeyO) {
-        overlay.mode = if overlay.mode == OverlayMode::Water {
-            OverlayMode::None
-        } else {
-            OverlayMode::Water
-        };
-    }
-    if keys.just_pressed(KeyCode::KeyT) {
-        overlay.mode = if overlay.mode == OverlayMode::Traffic {
-            OverlayMode::None
-        } else {
-            OverlayMode::Traffic
-        };
-    }
-    if keys.just_pressed(KeyCode::KeyN) {
-        overlay.mode = if overlay.mode == OverlayMode::Pollution {
-            OverlayMode::None
-        } else {
-            OverlayMode::Pollution
-        };
-    }
-    if keys.just_pressed(KeyCode::KeyL) {
-        overlay.mode = if overlay.mode == OverlayMode::LandValue {
-            OverlayMode::None
-        } else {
-            OverlayMode::LandValue
-        };
-    }
-    if keys.just_pressed(KeyCode::KeyE) {
-        overlay.mode = if overlay.mode == OverlayMode::Education {
-            OverlayMode::None
-        } else {
-            OverlayMode::Education
-        };
-    }
-    if keys.just_pressed(KeyCode::KeyG) {
-        overlay.mode = if overlay.mode == OverlayMode::Garbage {
-            OverlayMode::None
-        } else {
-            OverlayMode::Garbage
-        };
-    }
-    if keys.just_pressed(KeyCode::KeyM) {
-        overlay.mode = if overlay.mode == OverlayMode::Noise {
-            OverlayMode::None
-        } else {
-            OverlayMode::Noise
-        };
-    }
-    if keys.just_pressed(KeyCode::KeyU) {
-        overlay.mode = if overlay.mode == OverlayMode::WaterPollution {
-            OverlayMode::None
-        } else {
-            OverlayMode::WaterPollution
-        };
-    }
-    if keys.just_pressed(KeyCode::KeyW) {
-        // Toggle between groundwater level, quality, and wind sub-overlays:
-        // None -> Level -> Quality -> Wind -> None
-        overlay.mode = match overlay.mode {
-            OverlayMode::GroundwaterLevel => OverlayMode::GroundwaterQuality,
-            OverlayMode::GroundwaterQuality => OverlayMode::Wind,
-            OverlayMode::Wind => OverlayMode::None,
-            _ => OverlayMode::GroundwaterLevel,
         };
     }
 }

--- a/crates/ui/src/day_night_panel.rs
+++ b/crates/ui/src/day_night_panel.rs
@@ -23,20 +23,6 @@ pub struct DayNightPanelVisible(pub bool);
 // Systems
 // =============================================================================
 
-/// Toggles the day/night controls panel with the N key.
-pub fn day_night_panel_keybind(
-    keyboard: Res<ButtonInput<KeyCode>>,
-    mut visible: ResMut<DayNightPanelVisible>,
-    mut contexts: EguiContexts,
-) {
-    if contexts.ctx_mut().wants_keyboard_input() {
-        return;
-    }
-    if keyboard.just_pressed(KeyCode::KeyN) {
-        visible.0 = !visible.0;
-    }
-}
-
 /// Renders the day/night controls window.
 pub fn day_night_panel_ui(
     mut contexts: EguiContexts,

--- a/crates/ui/src/info_panel/budget.rs
+++ b/crates/ui/src/info_panel/budget.rs
@@ -35,7 +35,7 @@ pub fn budget_panel_ui(
         .default_open(true)
         .default_width(320.0)
         .show(contexts.ctx_mut(), |ui| {
-            ui.small("Press [B] to toggle");
+            ui.small("Budget panel");
             ui.separator();
 
             // Treasury

--- a/crates/ui/src/info_panel/keybinds.rs
+++ b/crates/ui/src/info_panel/keybinds.rs
@@ -1,10 +1,10 @@
 use bevy::prelude::*;
 use bevy_egui::EguiContexts;
 
-use super::{AdvisorVisible, BudgetPanelVisible, ChartsVisible, JournalVisible, PoliciesVisible};
+use super::{AdvisorVisible, ChartsVisible, JournalVisible, PoliciesVisible};
 
 /// Toggles UI panel visibility when keybinds are pressed.
-/// J = Event Journal, C = Charts, A = Advisors, P = Policies, B = Budget.
+/// J = Event Journal, C = Charts, A = Advisors, P = Policies.
 /// Keys are ignored when egui has keyboard focus (e.g. text input).
 pub fn panel_keybinds(
     keyboard: Res<ButtonInput<KeyCode>>,
@@ -12,7 +12,6 @@ pub fn panel_keybinds(
     mut charts: ResMut<ChartsVisible>,
     mut advisor: ResMut<AdvisorVisible>,
     mut policies: ResMut<PoliciesVisible>,
-    mut budget_panel: ResMut<BudgetPanelVisible>,
     mut contexts: EguiContexts,
 ) {
     // Don't toggle panels when a text field or other egui widget wants keyboard input
@@ -32,9 +31,8 @@ pub fn panel_keybinds(
     if keyboard.just_pressed(KeyCode::KeyP) {
         policies.0 = !policies.0;
     }
-    if keyboard.just_pressed(KeyCode::KeyB) {
-        budget_panel.0 = !budget_panel.0;
-    }
+    // B key is now used for the Bulldoze tool shortcut (issue #905).
+    // Budget panel is accessible via the toolbar UI.
 }
 
 /// Keyboard shortcuts for quick save (Ctrl+S), quick load (Ctrl+L), and new game (Ctrl+N).

--- a/crates/ui/src/info_panel/mod.rs
+++ b/crates/ui/src/info_panel/mod.rs
@@ -1334,23 +1334,19 @@ pub fn info_panel_ui(
 
             // Overlay info
             let overlay_text = match overlay.mode {
-                OverlayMode::None => "P=Pwr O=Wtr T=Trf N=Pol L=LV E=Edu G=Gar M=Noi U=WP W=GW",
-                OverlayMode::Power => "Power overlay active [P]",
-                OverlayMode::Water => "Water overlay active [O]",
-                OverlayMode::Traffic => "Traffic overlay active [T]",
-                OverlayMode::Pollution => "Pollution overlay active [N]",
-                OverlayMode::LandValue => "Land Value overlay active [L]",
-                OverlayMode::Education => "Education overlay active [E]",
-                OverlayMode::Garbage => "Garbage overlay active [G]",
-                OverlayMode::Noise => "Noise overlay active [M]",
-                OverlayMode::WaterPollution => "Water Pollution overlay active [U]",
-                OverlayMode::GroundwaterLevel => {
-                    "GW Level overlay active [W] (press W for Quality)"
-                }
-                OverlayMode::GroundwaterQuality => {
-                    "GW Quality overlay active [W] (press W for Wind)"
-                }
-                OverlayMode::Wind => "Wind overlay active [W] (press W to close)",
+                OverlayMode::None => "Tab to cycle overlays",
+                OverlayMode::Power => "Power overlay [Tab]",
+                OverlayMode::Water => "Water overlay [Tab]",
+                OverlayMode::Traffic => "Traffic overlay [Tab]",
+                OverlayMode::Pollution => "Pollution overlay [Tab]",
+                OverlayMode::LandValue => "Land Value overlay [Tab]",
+                OverlayMode::Education => "Education overlay [Tab]",
+                OverlayMode::Garbage => "Garbage overlay [Tab]",
+                OverlayMode::Noise => "Noise overlay [Tab]",
+                OverlayMode::WaterPollution => "Water Pollution overlay [Tab]",
+                OverlayMode::GroundwaterLevel => "GW Level overlay [Tab]",
+                OverlayMode::GroundwaterQuality => "GW Quality overlay [Tab]",
+                OverlayMode::Wind => "Wind overlay [Tab]",
             };
             ui.small(overlay_text);
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -76,9 +76,7 @@ impl Plugin for UiPlugin {
                     toolbar::speed_keybinds,
                     info_panel::groundwater_tooltip_ui,
                     water_dashboard::water_dashboard_ui,
-                    water_dashboard::water_dashboard_keybind,
                     tutorial::tutorial_ui,
-                    day_night_panel::day_night_panel_keybind,
                     day_night_panel::day_night_panel_ui,
                 ),
             );

--- a/crates/ui/src/service_coverage_panel.rs
+++ b/crates/ui/src/service_coverage_panel.rs
@@ -220,20 +220,6 @@ pub fn coverage_label(pct: f64) -> &'static str {
 // Keybind system
 // =============================================================================
 
-/// Toggles the service coverage panel when 'J' is pressed.
-pub fn service_coverage_keybind(
-    keyboard: Res<ButtonInput<KeyCode>>,
-    mut visible: ResMut<ServiceCoveragePanelVisible>,
-    mut contexts: EguiContexts,
-) {
-    if contexts.ctx_mut().wants_keyboard_input() {
-        return;
-    }
-    if keyboard.just_pressed(KeyCode::KeyJ) {
-        visible.0 = !visible.0;
-    }
-}
-
 // =============================================================================
 // Panel UI system
 // =============================================================================
@@ -257,7 +243,7 @@ pub fn service_coverage_panel_ui(
         .default_open(true)
         .default_width(380.0)
         .show(contexts.ctx_mut(), |ui| {
-            ui.small("Press [J] to toggle");
+            ui.small("Service coverage panel");
             ui.separator();
 
             // Compute overall stats
@@ -388,10 +374,7 @@ pub struct ServiceCoveragePanelPlugin;
 impl Plugin for ServiceCoveragePanelPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ServiceCoveragePanelVisible>()
-            .add_systems(
-                Update,
-                (service_coverage_keybind, service_coverage_panel_ui),
-            );
+            .add_systems(Update, service_coverage_panel_ui);
     }
 }
 

--- a/crates/ui/src/waste_dashboard.rs
+++ b/crates/ui/src/waste_dashboard.rs
@@ -31,21 +31,6 @@ pub struct WasteDashboardVisible(pub bool);
 // Keybind system
 // =============================================================================
 
-/// Toggles the waste dashboard visibility when 'G' is pressed (G for Garbage).
-/// Skipped when egui wants keyboard input (e.g. text field focused).
-pub fn waste_dashboard_keybind(
-    keyboard: Res<ButtonInput<KeyCode>>,
-    mut visible: ResMut<WasteDashboardVisible>,
-    mut contexts: EguiContexts,
-) {
-    if contexts.ctx_mut().wants_keyboard_input() {
-        return;
-    }
-    if keyboard.just_pressed(KeyCode::KeyG) {
-        visible.0 = !visible.0;
-    }
-}
-
 // =============================================================================
 // Helper: format tons for display
 // =============================================================================
@@ -162,7 +147,7 @@ pub fn waste_dashboard_ui(
         .default_open(true)
         .default_width(360.0)
         .show(contexts.ctx_mut(), |ui| {
-            ui.small("Press [G] to toggle");
+            ui.small("Waste dashboard");
             ui.separator();
 
             // === Warning indicators ===
@@ -491,7 +476,7 @@ pub struct WasteDashboardPlugin;
 impl Plugin for WasteDashboardPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<WasteDashboardVisible>()
-            .add_systems(Update, (waste_dashboard_keybind, waste_dashboard_ui));
+            .add_systems(Update, waste_dashboard_ui);
     }
 }
 

--- a/crates/ui/src/water_dashboard.rs
+++ b/crates/ui/src/water_dashboard.rs
@@ -28,21 +28,6 @@ pub struct WaterDashboardVisible(pub bool);
 /// Conversion constant: 1 MGD = 1,000,000 gallons per day.
 const MGD_TO_GPD: f32 = 1_000_000.0;
 
-/// Toggle the water dashboard with the 'W' key.
-/// Ignored when egui has keyboard focus (e.g. text input).
-pub fn water_dashboard_keybind(
-    keyboard: Res<ButtonInput<KeyCode>>,
-    mut visible: ResMut<WaterDashboardVisible>,
-    mut contexts: EguiContexts,
-) {
-    if contexts.ctx_mut().wants_keyboard_input() {
-        return;
-    }
-    if keyboard.just_pressed(KeyCode::KeyW) {
-        visible.0 = !visible.0;
-    }
-}
-
 /// Displays the water supply dashboard window.
 ///
 /// Shows demand/supply balance, source breakdown, groundwater status,
@@ -104,7 +89,7 @@ pub fn water_dashboard_ui(
         .default_open(true)
         .default_width(360.0)
         .show(contexts.ctx_mut(), |ui| {
-            ui.small("Press [W] to toggle");
+            ui.small("Water dashboard");
             ui.separator();
 
             // ---- Demand & Supply Overview ----


### PR DESCRIPTION
## Summary
- Remove individual overlay letter-key shortcuts (P/O/T/N/L/E/G/M/U/W); overlays now cycle exclusively via Tab / Shift+Tab
- Replace digit 1-9 tool shortcuts with R/Z/B/I/V for tool categories (1-3 reserved for simulation speed, Space for pause)
- Add Q/E keyboard camera rotation
- Free letter keys for UI panels: J=journal, C=charts, A=advisor, P=policies
- Remove conflicting standalone keybinds (waste G, water W, day/night N, service coverage J)
- Update all UI tooltip/hint text to reflect new keybindings

## Test plan
- [ ] Verify Tab cycles through all overlays; Shift+Tab cycles backward
- [ ] Verify 1/2/3 set simulation speed; Space toggles pause
- [ ] Verify R=Road, Z=Zone, B=Bulldoze, I=Inspect, V=Commercial zone tool shortcuts
- [ ] Verify Q/E rotate camera left/right
- [ ] Verify J/C/A/P toggle journal/charts/advisor/policies panels
- [ ] Verify no keybinding conflicts remain

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)