### PR TITLE
UX-024: Road angle snapping (15-degree increments)

### DIFF
--- a/crates/rendering/src/angle_snap.rs
+++ b/crates/rendering/src/angle_snap.rs
@@ -1,0 +1,166 @@
+//! Road angle snapping: when Shift is held during freeform road drawing,
+//! the end-point snaps to the nearest 15-degree increment from the start point.
+
+use bevy::prelude::*;
+
+use crate::input::{ActiveTool, CursorGridPos, DrawPhase, RoadDrawState};
+
+/// Snap increment in degrees.
+const SNAP_INCREMENT_DEG: f32 = 15.0;
+
+/// Resource tracking the angle-snap state each frame.
+#[derive(Resource, Default)]
+pub struct AngleSnapState {
+    /// Whether angle snapping is currently active (Shift held + road drawing).
+    pub active: bool,
+    /// The snapped world position (valid only when `active` is true).
+    pub snapped_pos: Vec2,
+    /// The snapped angle in degrees (0 = +X axis, counter-clockwise).
+    pub snapped_angle_deg: f32,
+}
+
+/// Snap `angle_rad` to the nearest `SNAP_INCREMENT_DEG`-degree increment.
+fn snap_angle(angle_rad: f32) -> f32 {
+    let deg = angle_rad.to_degrees();
+    let snapped_deg = (deg / SNAP_INCREMENT_DEG).round() * SNAP_INCREMENT_DEG;
+    snapped_deg.to_radians()
+}
+
+/// System that computes the angle-snapped cursor position each frame.
+/// Runs every frame; only activates when Shift is held during freeform road drawing.
+pub fn update_angle_snap(
+    keys: Res<ButtonInput<KeyCode>>,
+    cursor: Res<CursorGridPos>,
+    draw_state: Res<RoadDrawState>,
+    tool: Res<ActiveTool>,
+    mut snap: ResMut<AngleSnapState>,
+) {
+    let shift_held = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
+
+    let is_road_tool = matches!(
+        *tool,
+        ActiveTool::Road
+            | ActiveTool::RoadAvenue
+            | ActiveTool::RoadBoulevard
+            | ActiveTool::RoadHighway
+            | ActiveTool::RoadOneWay
+            | ActiveTool::RoadPath
+    );
+
+    // Only active when: shift held, road tool selected, start point placed, cursor valid
+    if !shift_held || !is_road_tool || draw_state.phase != DrawPhase::PlacedStart || !cursor.valid {
+        snap.active = false;
+        return;
+    }
+
+    let start = draw_state.start_pos;
+    let raw_end = cursor.world_pos;
+    let delta = raw_end - start;
+    let distance = delta.length();
+
+    if distance < 0.001 {
+        snap.active = false;
+        return;
+    }
+
+    // Compute angle from start to cursor (atan2 gives angle from +X axis)
+    let raw_angle = delta.y.atan2(delta.x);
+    let snapped_angle = snap_angle(raw_angle);
+
+    // Recompute end point at snapped angle, same distance
+    let snapped_end = start + Vec2::new(snapped_angle.cos(), snapped_angle.sin()) * distance;
+
+    snap.active = true;
+    snap.snapped_pos = snapped_end;
+    snap.snapped_angle_deg = snapped_angle.to_degrees();
+}
+
+/// Draw a visual indicator when angle snapping is active:
+/// - An arc from the start point showing the snapped angle
+/// - A label showing the angle in degrees
+pub fn draw_angle_snap_indicator(
+    snap: Res<AngleSnapState>,
+    draw_state: Res<RoadDrawState>,
+    mut gizmos: Gizmos,
+) {
+    if !snap.active || draw_state.phase != DrawPhase::PlacedStart {
+        return;
+    }
+
+    let start = draw_state.start_pos;
+    let end = snap.snapped_pos;
+    let y = 0.8; // slightly above ground and road preview
+
+    // Draw snapped guide line (dashed effect via segments)
+    let guide_color = Color::srgba(0.3, 1.0, 0.6, 0.6);
+    let delta = end - start;
+    let distance = delta.length();
+    let direction = delta / distance;
+
+    // Draw dashed guide line extending beyond the cursor
+    let dash_len = 8.0;
+    let gap_len = 6.0;
+    let total_len = distance + 80.0; // extend past cursor
+    let mut t = 0.0;
+    while t < total_len {
+        let seg_start = t;
+        let seg_end = (t + dash_len).min(total_len);
+        let p0 = start + direction * seg_start;
+        let p1 = start + direction * seg_end;
+        gizmos.line(
+            Vec3::new(p0.x, y, p0.y),
+            Vec3::new(p1.x, y, p1.y),
+            guide_color,
+        );
+        t += dash_len + gap_len;
+    }
+
+    // Draw a small arc near the start showing the snapped angle
+    let arc_radius = 24.0_f32.min(distance * 0.3);
+    let arc_color = Color::srgba(1.0, 1.0, 0.3, 0.8);
+    let arc_segments = 16;
+    let snapped_rad = snap.snapped_angle_deg.to_radians();
+
+    // Draw arc from 0 degrees to the snapped angle
+    let arc_start_angle = 0.0_f32;
+    let arc_end_angle = snapped_rad;
+    let (a0, a1) = if arc_start_angle <= arc_end_angle {
+        (arc_start_angle, arc_end_angle)
+    } else {
+        (arc_end_angle, arc_start_angle)
+    };
+
+    // Only draw arc if angle is non-zero
+    if (a1 - a0).abs() > 0.01 {
+        let mut prev_pt = Vec3::new(
+            start.x + arc_radius * a0.cos(),
+            y,
+            start.y + arc_radius * a0.sin(),
+        );
+        for i in 1..=arc_segments {
+            let frac = i as f32 / arc_segments as f32;
+            let angle = a0 + (a1 - a0) * frac;
+            let pt = Vec3::new(
+                start.x + arc_radius * angle.cos(),
+                y,
+                start.y + arc_radius * angle.sin(),
+            );
+            gizmos.line(prev_pt, pt, arc_color);
+            prev_pt = pt;
+        }
+    }
+
+    // Draw angle tick mark at the snapped position (small cross)
+    let tick_size = 4.0;
+    let end_3d = Vec3::new(end.x, y, end.y);
+    gizmos.line(
+        end_3d + Vec3::new(-tick_size, 0.0, -tick_size),
+        end_3d + Vec3::new(tick_size, 0.0, tick_size),
+        Color::srgba(1.0, 1.0, 0.3, 0.9),
+    );
+    gizmos.line(
+        end_3d + Vec3::new(-tick_size, 0.0, tick_size),
+        end_3d + Vec3::new(tick_size, 0.0, -tick_size),
+        Color::srgba(1.0, 1.0, 0.3, 0.9),
+    );
+}

--- a/crates/rendering/src/cursor_preview.rs
+++ b/crates/rendering/src/cursor_preview.rs
@@ -4,6 +4,7 @@ use simulation::config::CELL_SIZE;
 use simulation::grid::{CellType, WorldGrid, ZoneType};
 use simulation::services::ServiceBuilding;
 
+use crate::angle_snap::AngleSnapState;
 use crate::input::{ActiveTool, CursorGridPos, DrawPhase, RoadDrawState};
 
 /// Marker for the cursor ghost preview entity
@@ -144,6 +145,7 @@ pub fn draw_bezier_preview(
     draw_state: Res<RoadDrawState>,
     cursor: Res<CursorGridPos>,
     tool: Res<ActiveTool>,
+    angle_snap: Res<AngleSnapState>,
     mut gizmos: Gizmos,
 ) {
     if draw_state.phase != DrawPhase::PlacedStart || !cursor.valid {
@@ -165,7 +167,11 @@ pub fn draw_bezier_preview(
     }
 
     let start = draw_state.start_pos;
-    let end = cursor.world_pos;
+    let end = if angle_snap.active {
+        angle_snap.snapped_pos
+    } else {
+        cursor.world_pos
+    };
 
     // Draw preview as a series of line segments
     let segments = 32;

--- a/crates/rendering/src/input.rs
+++ b/crates/rendering/src/input.rs
@@ -9,6 +9,7 @@ use simulation::services::{self, ServiceBuilding, ServiceType};
 use simulation::urban_growth_boundary::UrbanGrowthBoundary;
 use simulation::utilities::UtilityType;
 
+use crate::angle_snap::AngleSnapState;
 use crate::terrain_render::{mark_chunk_dirty_at, ChunkDirty, TerrainChunk};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Resource)]
@@ -385,7 +386,11 @@ pub fn update_cursor_grid_pos(
 
 #[allow(clippy::too_many_arguments)]
 pub fn handle_tool_input(
-    input: (Res<ButtonInput<MouseButton>>, Res<ButtonInput<KeyCode>>),
+    input: (
+        Res<ButtonInput<MouseButton>>,
+        Res<ButtonInput<KeyCode>>,
+        Res<AngleSnapState>,
+    ),
     cursor: Res<CursorGridPos>,
     tool: Res<ActiveTool>,
     mut grid: ResMut<WorldGrid>,
@@ -402,7 +407,7 @@ pub fn handle_tool_input(
     mut district_map: ResMut<simulation::districts::DistrictMap>,
     ugb: Res<UrbanGrowthBoundary>,
 ) {
-    let (buttons, keys) = input;
+    let (buttons, keys, angle_snap) = input;
 
     // Suppress tool actions when left-click is being used for camera panning
     if left_drag.is_dragging {
@@ -453,11 +458,18 @@ pub fn handle_tool_input(
                     // First click: place start point
                     draw_state.start_pos = cursor.world_pos;
                     draw_state.phase = DrawPhase::PlacedStart;
-                    status.set("Click to place end point (Esc to cancel)", false);
+                    status.set(
+                        "Click to place end point (Shift=snap angle, Esc=cancel)",
+                        false,
+                    );
                 }
                 DrawPhase::PlacedStart => {
                     // Second click: place end point and commit segment
-                    let end_pos = cursor.world_pos;
+                    let end_pos = if angle_snap.active {
+                        angle_snap.snapped_pos
+                    } else {
+                        cursor.world_pos
+                    };
                     let start_pos = draw_state.start_pos;
 
                     // Minimum length check

--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use bevy::time::common_conditions::on_timer;
 
+pub mod angle_snap;
 pub mod building_mesh_variants;
 pub mod building_meshes;
 pub mod building_render;
@@ -31,6 +32,7 @@ pub mod wind_streamlines;
 
 pub mod screenshot;
 
+use angle_snap::AngleSnapState;
 use camera::{CameraDrag, LeftClickDrag};
 use input::{ActiveTool, CursorGridPos, GridSnap, RoadDrawState, SelectedBuilding, StatusMessage};
 use overlay::OverlayState;
@@ -50,6 +52,7 @@ impl Plugin for RenderingPlugin {
             .init_resource::<PropsSpawned>()
             .init_resource::<RoadDrawState>()
             .init_resource::<GridSnap>()
+            .init_resource::<AngleSnapState>()
             .add_systems(
                 Startup,
                 (
@@ -78,6 +81,7 @@ impl Plugin for RenderingPlugin {
                 Update,
                 (
                     input::update_cursor_grid_pos,
+                    angle_snap::update_angle_snap,
                     input::handle_tool_input,
                     input::handle_tree_tool,
                     input::keyboard_tool_switch,
@@ -95,6 +99,7 @@ impl Plugin for RenderingPlugin {
                     terrain_render::rebuild_dirty_chunks,
                     cursor_preview::update_cursor_preview,
                     cursor_preview::draw_bezier_preview,
+                    angle_snap::draw_angle_snap_indicator,
                     road_render::sync_road_segment_meshes,
                     lane_markings::sync_lane_marking_meshes,
                     road_grade::draw_road_grade_indicators,


### PR DESCRIPTION
## Summary
- When **Shift** is held during freeform road drawing, the end-point snaps to the nearest **15-degree increment** (0, 15, 30, 45, 60, 75, 90, ...) from the start point
- Visual indicators: dashed guide line along the snapped direction + arc showing snapped angle near the start point
- Releasing Shift returns to free-angle placement instantly
- Status message updated to hint at Shift for angle snapping

Closes #893

## Implementation
- New `angle_snap` module in the rendering crate (`crates/rendering/src/angle_snap.rs`)
- `AngleSnapState` resource tracks whether snapping is active, the snapped position, and the snapped angle
- `update_angle_snap` system computes the snap each frame (reads Shift key state, road draw state, cursor position)
- `draw_angle_snap_indicator` system renders the visual guide (dashed line + angle arc + endpoint cross)
- `handle_tool_input` and `draw_bezier_preview` use the snapped position when `AngleSnapState.active` is true

## Test plan
- [ ] Select a road tool and place start point
- [ ] Move cursor without Shift — free angle placement (existing behavior)
- [ ] Hold Shift — end point snaps to nearest 15-degree increment, dashed guide line and angle arc appear
- [ ] Release Shift — returns to free angle immediately
- [ ] Click while Shift held — road is placed at the snapped angle
- [ ] Verify road chaining still works (end becomes new start)
- [ ] Verify Ctrl still activates legacy grid-snap mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)