### PR TITLE
Add road intersection snapping (UX-025)

### DIFF
--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -35,7 +35,10 @@ pub mod screenshot;
 
 use angle_snap::AngleSnapState;
 use camera::{CameraDrag, LeftClickDrag};
-use input::{ActiveTool, CursorGridPos, GridSnap, RoadDrawState, SelectedBuilding, StatusMessage};
+use input::{
+    ActiveTool, CursorGridPos, GridSnap, IntersectionSnap, RoadDrawState, SelectedBuilding,
+    StatusMessage,
+};
 use overlay::OverlayState;
 use props::PropsSpawned;
 
@@ -54,6 +57,7 @@ impl Plugin for RenderingPlugin {
             .init_resource::<RoadDrawState>()
             .init_resource::<GridSnap>()
             .init_resource::<AngleSnapState>()
+            .init_resource::<IntersectionSnap>()
             .add_systems(
                 Startup,
                 (
@@ -84,6 +88,7 @@ impl Plugin for RenderingPlugin {
                 (
                     input::update_cursor_grid_pos,
                     angle_snap::update_angle_snap,
+                    input::update_intersection_snap,
                     input::handle_tool_input,
                     input::handle_tree_tool,
                     input::keyboard_tool_switch,
@@ -102,6 +107,7 @@ impl Plugin for RenderingPlugin {
                     cursor_preview::update_cursor_preview,
                     cursor_preview::draw_bezier_preview,
                     angle_snap::draw_angle_snap_indicator,
+                    cursor_preview::draw_intersection_snap_indicator,
                     road_render::sync_road_segment_meshes,
                     lane_markings::sync_lane_marking_meshes,
                     road_grade::draw_road_grade_indicators,


### PR DESCRIPTION
## Summary
- When the cursor is within 1 cell distance of an existing road intersection (segment node), the road endpoint snaps to the exact intersection position
- Cyan highlight rings (outer + inner) indicate when snap is active, providing clear visual feedback
- Both start and end points of new roads snap to intersections, and bezier preview follows the snapped position
- Works for all road types: local, avenue, boulevard, highway, one-way, and path

## Implementation
- Added `IntersectionSnap` resource in `rendering/src/input.rs` that tracks the nearest node within `CELL_SIZE` (16 world units) snap radius
- Added `update_intersection_snap` system that runs each frame to detect nearby nodes
- Modified `handle_tool_input` to use snapped positions for both start and end clicks
- Modified `draw_bezier_preview` to show preview line going to snapped position
- Added `draw_intersection_snap_indicator` gizmo system for cyan highlight rings
- Unit tests verify snap detection logic (within radius, outside radius, closest node selection, boundary conditions)

## Test plan
- [ ] Place a road segment, then start a new road near the endpoint — verify it snaps to the exact intersection position
- [ ] Verify cyan highlight rings appear when cursor is within 1 cell of an intersection
- [ ] Verify snap works for both start point (first click) and end point (second click)
- [ ] Verify the bezier preview line follows the snapped position
- [ ] Verify no snap indicator when cursor is far from intersections
- [ ] Verify snap works with all road types (local, avenue, boulevard, highway, one-way, path)
- [ ] Verify unit tests pass: `cargo test --workspace`

Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)