### PR TITLE
UX-015: Add tool cost tooltips with maintenance, coverage, and descriptions

### DIFF
--- a/crates/ui/src/toolbar.rs
+++ b/crates/ui/src/toolbar.rs
@@ -1214,7 +1214,9 @@ pub fn toolbar_ui(
     let categories = build_categories();
 
     // Set tooltip delay to 300ms for tool tooltips
-    contexts.ctx_mut().style_mut().interaction.tooltip_delay = 0.3;
+    contexts
+        .ctx_mut()
+        .style_mut(|style| style.interaction.tooltip_delay = 0.3);
 
     // ---- Top info bar ----
     egui::TopBottomPanel::top("top_info_bar")


### PR DESCRIPTION
## Summary
- Hovering over any tool in the category popup now shows a rich tooltip after a 300ms delay
- Service buildings show: description, placement cost, monthly maintenance, coverage radius (cells), footprint size
- Utility buildings show: description, placement cost, monthly maintenance, coverage range (cells), capacity
- Overlay views show descriptive text
- Zones, roads, terrain tools, and environment tools show brief descriptions

## Implementation
- Added `show_tool_tooltip()` function that computes tooltip content from existing `ServiceBuilding` and `UtilityType` data
- Added `tool_description()` with descriptions for all 90+ tools
- Added `overlay_description()` for all overlay view modes
- Added utility metadata functions (`utility_maintenance`, `utility_range`, `utility_capacity`)
- Set `tooltip_delay` to 0.3s (300ms) on the egui context
- Used egui's `on_hover_ui()` on each selectable label in the category popup grid

Closes #884

## Test plan
- [ ] Hover over tools in each category popup and verify tooltip appears after ~300ms
- [ ] Verify service buildings show maintenance cost, coverage radius, and footprint
- [ ] Verify utility buildings show maintenance cost, coverage range, and capacity
- [ ] Verify overlay views show descriptive text
- [ ] Verify zones, roads, and other tools show brief descriptions
- [ ] Verify tooltip disappears when mouse leaves the tool button

🤖 Generated with [Claude Code](https://claude.com/claude-code)