### PR TITLE
Fix HeatMitigationState not persisting across save/load

### DIFF
--- a/crates/simulation/src/heat_mitigation.rs
+++ b/crates/simulation/src/heat_mitigation.rs
@@ -343,6 +343,12 @@ impl Plugin for HeatMitigationPlugin {
             FixedUpdate,
             update_heat_mitigation.after(crate::heat_wave::update_heat_wave),
         );
+
+        // Register for save/load via the SaveableRegistry.
+        app.init_resource::<crate::SaveableRegistry>();
+        app.world_mut()
+            .resource_mut::<crate::SaveableRegistry>()
+            .register::<HeatMitigationState>();
     }
 }
 


### PR DESCRIPTION
## Summary
- `HeatMitigationState` implements `Saveable` but was never registered with `SaveableRegistry` in `HeatMitigationPlugin::build()`, causing player heat mitigation choices to silently fail to persist across save/load cycles.
- Added the missing `register::<HeatMitigationState>()` call, following the same pattern used by other simulation plugins (e.g., `climate_change`, `flood_protection`, `district_policies`).

Closes #1219

## Test plan
- [ ] Save a game with heat mitigation settings enabled (cooling centers, misting stations, etc.)
- [ ] Load the save and verify heat mitigation state is restored correctly
- [ ] Verify CI passes (build, test, clippy, fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)