### PR TITLE
Move advisor dismiss persistence to simulation plugin

### DIFF
--- a/crates/simulation/src/advisors.rs
+++ b/crates/simulation/src/advisors.rs
@@ -1053,13 +1053,17 @@ pub struct AdvisorsPlugin;
 
 impl Plugin for AdvisorsPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<AdvisorPanel>()
+        app.init_resource::<crate::SaveableRegistry>()
+            .init_resource::<AdvisorPanel>()
             .init_resource::<DismissedAdvisorTips>()
             .add_event::<AdvisorJumpToLocation>()
             .add_systems(
                 FixedUpdate,
                 update_advisors.after(crate::stats::update_stats),
             );
+        app.world_mut()
+            .resource_mut::<crate::SaveableRegistry>()
+            .register::<DismissedAdvisorTips>();
     }
 }
 

--- a/crates/ui/src/advisor_tips.rs
+++ b/crates/ui/src/advisor_tips.rs
@@ -13,8 +13,6 @@ use rendering::camera::OrbitCamera;
 use simulation::advisors::{AdvisorJumpToLocation, AdvisorPanel, DismissedAdvisorTips};
 use simulation::config::CELL_SIZE;
 
-use save::SaveableAppExt;
-
 // ---------------------------------------------------------------------------
 // Resources
 // ---------------------------------------------------------------------------
@@ -233,7 +231,6 @@ pub struct AdvisorTipsPlugin;
 impl Plugin for AdvisorTipsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<AdvisorTipsPanelOpen>()
-            .add_systems(Update, (advisor_tips_ui, handle_advisor_jump))
-            .register_saveable::<DismissedAdvisorTips>();
+            .add_systems(Update, (advisor_tips_ui, handle_advisor_jump));
     }
 }


### PR DESCRIPTION
## Summary
- Moved `register_saveable::<DismissedAdvisorTips>()` from `AdvisorTipsPlugin` (UI crate) to `AdvisorsPlugin` (simulation crate)
- Removed unused `SaveableAppExt` import from UI advisor_tips module
- Follows the convention that each feature plugin owns its own saveable registration

## Test plan
- [ ] Verify `DismissedAdvisorTips` persistence works in full app mode (dismiss a tip, save, reload, confirm tip stays dismissed)
- [ ] Verify simulation-only contexts (e.g. headless/test) can persist dismissed tips without the UI crate

Closes #1221

🤖 Generated with [Claude Code](https://claude.com/claude-code)