### PR TITLE
Fix saveable key collisions with duplicate-key guard

### DIFF
--- a/crates/ui/src/localization.rs
+++ b/crates/ui/src/localization.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts};
 
-use save::SaveableAppExt;
 use simulation::localization::{LocalizationState, LOCALE_NAMES, SUPPORTED_LOCALES};
 
 // =============================================================================
@@ -87,7 +86,6 @@ pub struct LocalizationUiPlugin;
 impl Plugin for LocalizationUiPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LanguageSelectorVisible>()
-            .register_saveable::<LocalizationState>()
             .add_systems(Update, (language_selector_keybind, language_selector_ui));
     }
 }


### PR DESCRIPTION
## Summary
- Add duplicate-key guard to `SaveableRegistry::register()` that warns and returns early on collision (panics in debug builds via `debug_assert!`)
- Remove the duplicate `LocalizationState` registration from `crates/ui/src/localization.rs` (keep only the primary one in `crates/simulation/src/localization.rs`)
- Add test verifying duplicate registration is rejected

## Test plan
- [ ] `test_registry_duplicate_key_panics_in_debug` verifies the guard catches duplicates
- [ ] Existing saveable tests continue to pass (register, save, load, reset, unknown keys)
- [ ] CI: build, test, clippy, fmt all pass

Closes #1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)