### PR TITLE
Fix extension-map load preserving stale state across saves

### DIFF
--- a/crates/save/src/lib.rs
+++ b/crates/save/src/lib.rs
@@ -879,9 +879,9 @@ fn handle_load(
         *v2.snow_stats = SnowStats::default();
 
         // Store extension map for the exclusive system to apply via SaveableRegistry.
-        if !save.extensions.is_empty() {
-            pending_ext.0 = Some(save.extensions.clone());
-        }
+        // Always enqueue -- even an empty map -- so that registered resources whose
+        // keys are absent get reset to defaults (prevents cross-save contamination).
+        pending_ext.0 = Some(save.extensions.clone());
 
         #[cfg(not(target_arch = "wasm32"))]
         println!("Loaded save from {}", save_file_path());

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -227,11 +227,18 @@ impl SaveableRegistry {
     }
 
     /// Load registered resources from an extension map.
-    /// Resources whose key is absent are left unchanged (they keep their init_resource default).
+    ///
+    /// Every registered resource is first reset to its default, then any
+    /// matching key from the extension map is applied on top. This ensures
+    /// that resources whose key is absent in the loaded save are returned to
+    /// defaults rather than silently retaining stale values from a previous
+    /// session (cross-save contamination).
     pub fn load_all(&self, world: &mut World, extensions: &BTreeMap<String, Vec<u8>>) {
         for entry in &self.entries {
             if let Some(bytes) = extensions.get(&entry.key) {
                 (entry.load_fn)(world, bytes);
+            } else {
+                (entry.reset_fn)(world);
             }
         }
     }
@@ -564,8 +571,33 @@ mod saveable_tests {
 
         registry.load_all(&mut world, &extensions);
 
-        // TestCounter should be unchanged since its key wasn't in extensions
+        // TestCounter key is absent from extensions, so it should be reset to default
         let counter = world.resource::<TestCounter>();
-        assert_eq!(counter.value, 5);
+        assert_eq!(counter.value, 0);
+    }
+
+    #[test]
+    fn test_registry_load_resets_missing_keys_to_default() {
+        // Simulates cross-save contamination: load save A (with extension data),
+        // then load save B (without that extension). The resource must reset to
+        // default, not retain save A's value.
+        let mut world = World::new();
+        world.insert_resource(TestCounter::default());
+
+        let mut registry = SaveableRegistry::default();
+        registry.register::<TestCounter>();
+
+        // "Load" save A -- has the extension key with value 42
+        let mut save_a = BTreeMap::new();
+        save_a.insert("test_counter".to_string(), 42u32.to_le_bytes().to_vec());
+        registry.load_all(&mut world, &save_a);
+        assert_eq!(world.resource::<TestCounter>().value, 42);
+
+        // "Load" save B -- empty extension map (older save without this feature)
+        let save_b = BTreeMap::new();
+        registry.load_all(&mut world, &save_b);
+
+        // Resource must be reset to default, NOT retain value 42 from save A
+        assert_eq!(world.resource::<TestCounter>().value, 0);
     }
 }


### PR DESCRIPTION
## Summary
- **Always enqueue extension processing** on load, even when the extension map is empty — previously `handle_load` skipped this entirely for empty maps
- **Reset registered Saveable resources to defaults** when their key is absent from the loaded extension map — previously `load_all()` left them unchanged, causing silent cross-save contamination
- **Add test** covering the exact cross-save contamination scenario (load save A with extension, load save B without, verify reset)

## Root Cause
`SaveableRegistry::load_all()` only applied data for keys present in the extension map and left all other registered resources untouched. Combined with `handle_load()` skipping extension processing entirely for empty maps, loading a save without certain extension keys would silently retain stale values from a previously loaded save.

## Changes
- `crates/save/src/lib.rs`: Remove `if !save.extensions.is_empty()` guard so extension processing always runs
- `crates/simulation/src/lib.rs`: Add `else { reset }` branch in `load_all()` for missing keys
- `crates/simulation/src/lib.rs`: Update existing test expectation + add new cross-save contamination test

Closes #1234

## Test plan
- [ ] Existing `test_registry_load_ignores_unknown_keys` updated to expect reset-to-default behavior
- [ ] New `test_registry_load_resets_missing_keys_to_default` verifies: load save A (value=42), load save B (empty), assert value=0
- [ ] All existing saveable tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)