### PR TITLE
Reject future save versions at runtime

### DIFF
--- a/crates/save/src/lib.rs
+++ b/crates/save/src/lib.rs
@@ -348,7 +348,13 @@ fn handle_load(
         };
 
         // Migrate older save formats to current version
-        let old_version = migrate_save(&mut save);
+        let old_version = match migrate_save(&mut save) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Save migration failed: {}", e);
+                continue;
+            }
+        };
         if old_version != CURRENT_SAVE_VERSION {
             println!(
                 "Migrated save from v{} to v{}",

--- a/crates/save/src/serialization.rs
+++ b/crates/save/src/serialization.rs
@@ -1396,7 +1396,7 @@ mod tests {
         );
         save.version = 0;
 
-        let old = migrate_save(&mut save);
+        let old = migrate_save(&mut save).expect("migration should succeed");
         assert_eq!(old, 0);
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
     }
@@ -1459,7 +1459,7 @@ mod tests {
         );
 
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
-        let old = migrate_save(&mut save);
+        let old = migrate_save(&mut save).expect("migration should succeed");
         assert_eq!(old, CURRENT_SAVE_VERSION);
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
     }
@@ -1584,7 +1584,7 @@ mod tests {
         );
         save.version = 1;
 
-        let old = migrate_save(&mut save);
+        let old = migrate_save(&mut save).expect("migration should succeed");
         assert_eq!(old, 1);
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
     }
@@ -1647,7 +1647,7 @@ mod tests {
         );
         save.version = 2;
 
-        let old = migrate_save(&mut save);
+        let old = migrate_save(&mut save).expect("migration should succeed");
         assert_eq!(old, 2);
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
     }
@@ -1966,7 +1966,7 @@ mod tests {
             activity_timer: 0,
         });
         save.version = 2;
-        let old = migrate_save(&mut save);
+        let old = migrate_save(&mut save).expect("migration should succeed");
         assert_eq!(old, 2);
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
         let c = &save.citizens[0];
@@ -2212,7 +2212,7 @@ mod tests {
         );
         save.version = 3;
 
-        let old = migrate_save(&mut save);
+        let old = migrate_save(&mut save).expect("migration should succeed");
         assert_eq!(old, 3);
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
     }
@@ -2520,7 +2520,7 @@ mod tests {
         );
         save.version = 4;
 
-        let old = migrate_save(&mut save);
+        let old = migrate_save(&mut save).expect("migration should succeed");
         assert_eq!(old, 4);
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
         // Vacancy fields should default to 0.0 for a migrated v4 save.
@@ -2588,7 +2588,7 @@ mod tests {
         );
         save.version = 5;
 
-        let old = migrate_save(&mut save);
+        let old = migrate_save(&mut save).expect("migration should succeed");
         assert_eq!(old, 5);
         assert_eq!(save.version, CURRENT_SAVE_VERSION);
     }


### PR DESCRIPTION
## Summary
- Replace `debug_assert_eq!` in `migrate_save` with an explicit runtime check that returns `Err(String)` when `save.version > CURRENT_SAVE_VERSION`
- Change return type from `u32` to `Result<u32, String>` with a user-facing error message telling the player to update the game
- Update all call sites (`lib.rs` load handler + test `.expect()` unwraps in `serialization.rs`)
- Add unit tests verifying future versions (current+1, current+100) are rejected and current version is accepted

## Test plan
- [ ] `test_migrate_save_rejects_future_version` -- version current+1 returns `Err` with descriptive message
- [ ] `test_migrate_save_rejects_far_future_version` -- version current+100 returns `Err`
- [ ] `test_migrate_save_accepts_current_version` -- current version passes through as `Ok`
- [ ] Existing migration tests continue to pass (v0, v1, v2, etc. all migrate successfully)

Closes #1241

🤖 Generated with [Claude Code](https://claude.com/claude-code)