### PR TITLE
Fix citizen render pipeline ordering ambiguity

### DIFF
--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -137,7 +137,8 @@ impl Plugin for RenderingPlugin {
                     citizen_render::update_citizen_sprites,
                     citizen_render::update_lod_fade,
                     citizen_render::despawn_abstract_sprites,
-                ),
+                )
+                    .chain(),
             )
             .add_systems(
                 Update,


### PR DESCRIPTION
## Summary
- Added `.chain()` to citizen render systems in `crates/rendering/src/lib.rs` to enforce deterministic execution order: spawn → trigger_lod_fade → update_sprites → update_lod_fade → despawn
- Eliminates potential race conditions between spawn and despawn within the same frame
- Prevents visual glitches during LOD transitions caused by nondeterministic system ordering

## Test plan
- [ ] Verify citizen sprites appear and disappear correctly during LOD transitions
- [ ] Confirm no visual glitches when zooming in/out rapidly (LOD boundary crossings)
- [ ] Check that citizens smoothly fade between LOD tiers without flickering

Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)