### PR TITLE
Fix tool popup positioning to reduce map obstruction (UX-013)

### DIFF
--- a/crates/ui/src/toolbar.rs
+++ b/crates/ui/src/toolbar.rs
@@ -78,6 +78,7 @@ impl Default for ToolCatalog {
 
 struct ToolItem {
     tool: Option<ActiveTool>,
+    #[allow(dead_code)]
     icon: &'static str,
     name: &'static str,
     cost: Option<f64>,


### PR DESCRIPTION
## Summary
- Replaced the large 3-column grid popup with a compact horizontal strip that spans the full screen width just above the bottom toolbar
- Uses smaller text (11-12px), tighter margins (8x4), and a single-row horizontal layout to minimize map obstruction
- Removed redundant icon prefixes from item labels for a cleaner, more compact appearance

## Test plan
- [ ] Open the game and click each category button (Roads, Zones, Utilities, etc.) in the bottom toolbar
- [ ] Verify the popup appears as a slim horizontal strip just above the toolbar, not a large vertical panel
- [ ] Verify all tool items are visible and clickable in the horizontal row
- [ ] Verify selecting a tool activates it and closes the popup
- [ ] Verify overlay items toggle correctly without closing the popup
- [ ] Verify the popup does not obstruct significant map area

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)