### PR TITLE
Add service coverage detail panel (UI-002)

### DIFF
--- a/crates/ui/src/service_coverage_panel.rs
+++ b/crates/ui/src/service_coverage_panel.rs
@@ -1,11 +1,15 @@
-//! Service Coverage Detail Panel (UX-056).
+//! Service Coverage Detail Panel (UI-002).
 //!
 //! Displays a comprehensive overview of all service categories with:
 //! - Coverage percentage per category computed from `ServiceCoverageGrid`
 //! - Color coding: green (>80%), yellow (50-80%), red (<50%)
 //! - Clickable rows to activate the corresponding overlay mode
+//! - Per-service-type breakdown within each category (building count, maintenance)
 //! - Total capacity (number of service buildings) and current demand
 //!   (number of zoned/developed cells) for each category
+//! - Monthly maintenance cost per category
+//! - Additional "Other Services" section for services without coverage tracking
+//! - Keybind: K key to toggle visibility
 
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts};
@@ -110,6 +114,145 @@ impl ServiceCategory {
             Self::Transport => ServiceBuilding::is_transport(st),
         }
     }
+
+    /// Returns the list of service types that belong to this category.
+    pub fn service_types(self) -> &'static [ServiceType] {
+        match self {
+            Self::Health => &[
+                ServiceType::MedicalClinic,
+                ServiceType::Hospital,
+                ServiceType::MedicalCenter,
+            ],
+            Self::Education => &[
+                ServiceType::Kindergarten,
+                ServiceType::ElementarySchool,
+                ServiceType::HighSchool,
+                ServiceType::University,
+                ServiceType::Library,
+            ],
+            Self::Police => &[
+                ServiceType::PoliceKiosk,
+                ServiceType::PoliceStation,
+                ServiceType::PoliceHQ,
+                ServiceType::Prison,
+            ],
+            Self::Fire => &[
+                ServiceType::FireHouse,
+                ServiceType::FireStation,
+                ServiceType::FireHQ,
+            ],
+            Self::Parks => &[
+                ServiceType::SmallPark,
+                ServiceType::LargePark,
+                ServiceType::Playground,
+                ServiceType::SportsField,
+                ServiceType::Stadium,
+            ],
+            Self::Entertainment => &[
+                ServiceType::Plaza,
+                ServiceType::Museum,
+                ServiceType::Cathedral,
+                ServiceType::TVStation,
+            ],
+            Self::Telecom => &[ServiceType::CellTower, ServiceType::DataCenter],
+            Self::Transport => &[
+                ServiceType::BusDepot,
+                ServiceType::TrainStation,
+                ServiceType::SubwayStation,
+                ServiceType::TramDepot,
+                ServiceType::FerryPier,
+                ServiceType::SmallAirstrip,
+                ServiceType::RegionalAirport,
+                ServiceType::InternationalAirport,
+            ],
+        }
+    }
+}
+
+/// Service types that do not belong to any coverage-tracked category.
+/// These are shown in the "Other Services" section.
+pub const OTHER_SERVICE_TYPES: &[ServiceType] = &[
+    ServiceType::Landfill,
+    ServiceType::RecyclingCenter,
+    ServiceType::Incinerator,
+    ServiceType::TransferStation,
+    ServiceType::Cemetery,
+    ServiceType::Crematorium,
+    ServiceType::CityHall,
+    ServiceType::HomelessShelter,
+    ServiceType::WelfareOffice,
+    ServiceType::PostOffice,
+    ServiceType::MailSortingCenter,
+    ServiceType::WaterTreatmentPlant,
+    ServiceType::WellPump,
+    ServiceType::HeatingBoiler,
+    ServiceType::DistrictHeatingPlant,
+    ServiceType::GeothermalPlant,
+];
+
+/// Groups for "Other Services" display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtherServiceGroup {
+    Garbage,
+    DeathCare,
+    Governance,
+    Welfare,
+    Postal,
+    WaterService,
+    Heating,
+}
+
+impl OtherServiceGroup {
+    pub const ALL: [OtherServiceGroup; 7] = [
+        Self::Garbage,
+        Self::DeathCare,
+        Self::Governance,
+        Self::Welfare,
+        Self::Postal,
+        Self::WaterService,
+        Self::Heating,
+    ];
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Garbage => "Garbage",
+            Self::DeathCare => "Death Care",
+            Self::Governance => "Governance",
+            Self::Welfare => "Welfare",
+            Self::Postal => "Postal",
+            Self::WaterService => "Water Service",
+            Self::Heating => "Heating",
+        }
+    }
+
+    pub fn service_types(self) -> &'static [ServiceType] {
+        match self {
+            Self::Garbage => &[
+                ServiceType::Landfill,
+                ServiceType::RecyclingCenter,
+                ServiceType::Incinerator,
+                ServiceType::TransferStation,
+            ],
+            Self::DeathCare => &[ServiceType::Cemetery, ServiceType::Crematorium],
+            Self::Governance => &[ServiceType::CityHall],
+            Self::Welfare => &[ServiceType::HomelessShelter, ServiceType::WelfareOffice],
+            Self::Postal => &[ServiceType::PostOffice, ServiceType::MailSortingCenter],
+            Self::WaterService => &[ServiceType::WaterTreatmentPlant, ServiceType::WellPump],
+            Self::Heating => &[
+                ServiceType::HeatingBoiler,
+                ServiceType::DistrictHeatingPlant,
+                ServiceType::GeothermalPlant,
+            ],
+        }
+    }
+
+    pub fn overlay_mode(self) -> Option<OverlayMode> {
+        match self {
+            Self::Garbage => Some(OverlayMode::Garbage),
+            Self::WaterService => Some(OverlayMode::Water),
+            _ => None,
+        }
+    }
 }
 
 // =============================================================================
@@ -117,9 +260,20 @@ impl ServiceCategory {
 // =============================================================================
 
 /// Resource controlling whether the service coverage panel is visible.
-/// Toggle with 'J' key.
+/// Toggle with 'K' key.
 #[derive(Resource, Default)]
 pub struct ServiceCoveragePanelVisible(pub bool);
+
+// =============================================================================
+// Expanded rows state
+// =============================================================================
+
+/// Resource tracking which categories are expanded to show per-service-type detail.
+#[derive(Resource, Default)]
+pub struct ExpandedCategories {
+    pub expanded: std::collections::HashSet<u8>,
+    pub other_expanded: std::collections::HashSet<u8>,
+}
 
 // =============================================================================
 // Computed coverage data (updated each frame the panel is visible)
@@ -136,6 +290,15 @@ pub struct CategoryStats {
     pub demand_cells: u32,
     /// Number of those demand cells that are covered.
     pub covered_cells: u32,
+    /// Total monthly maintenance cost for this category.
+    pub monthly_maintenance: f64,
+}
+
+/// Per-service-type statistics within a category.
+#[derive(Debug, Clone, Default)]
+pub struct ServiceTypeStats {
+    pub count: u32,
+    pub monthly_maintenance: f64,
 }
 
 // =============================================================================
@@ -176,16 +339,40 @@ pub fn compute_category_stats(
         0.0
     };
 
-    let building_count = services
-        .iter()
-        .filter(|s| category.matches_service(s.service_type))
-        .count() as u32;
+    let mut building_count = 0u32;
+    let mut monthly_maintenance = 0.0f64;
+    for s in services {
+        if category.matches_service(s.service_type) {
+            building_count += 1;
+            monthly_maintenance += ServiceBuilding::monthly_maintenance(s.service_type);
+        }
+    }
 
     CategoryStats {
         coverage_pct,
         building_count,
         demand_cells,
         covered_cells,
+        monthly_maintenance,
+    }
+}
+
+/// Computes per-service-type stats within a list of services.
+pub fn compute_service_type_stats(
+    service_type: ServiceType,
+    services: &[&ServiceBuilding],
+) -> ServiceTypeStats {
+    let mut count = 0u32;
+    let mut monthly_maintenance = 0.0f64;
+    for s in services {
+        if s.service_type == service_type {
+            count += 1;
+            monthly_maintenance += ServiceBuilding::monthly_maintenance(s.service_type);
+        }
+    }
+    ServiceTypeStats {
+        count,
+        monthly_maintenance,
     }
 }
 
@@ -220,11 +407,26 @@ pub fn coverage_label(pct: f64) -> &'static str {
 // Keybind system
 // =============================================================================
 
+/// Toggles service coverage panel with K key.
+pub fn service_coverage_keybind(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut visible: ResMut<ServiceCoveragePanelVisible>,
+    mut contexts: EguiContexts,
+) {
+    if contexts.ctx_mut().wants_keyboard_input() {
+        return;
+    }
+    if keyboard.just_pressed(KeyCode::KeyK) {
+        visible.0 = !visible.0;
+    }
+}
+
 // =============================================================================
 // Panel UI system
 // =============================================================================
 
 /// Renders the service coverage detail panel.
+#[allow(clippy::too_many_arguments)]
 pub fn service_coverage_panel_ui(
     mut contexts: EguiContexts,
     visible: Res<ServiceCoveragePanelVisible>,
@@ -232,6 +434,7 @@ pub fn service_coverage_panel_ui(
     coverage: Res<ServiceCoverageGrid>,
     services: Query<&ServiceBuilding>,
     mut overlay: ResMut<OverlayState>,
+    mut expanded: ResMut<ExpandedCategories>,
 ) {
     if !visible.0 {
         return;
@@ -241,16 +444,12 @@ pub fn service_coverage_panel_ui(
 
     egui::Window::new("Service Coverage")
         .default_open(true)
-        .default_width(380.0)
+        .default_width(400.0)
         .show(contexts.ctx_mut(), |ui| {
-            ui.small("Service coverage panel");
+            ui.small("Per-service coverage and utilization (K to toggle)");
             ui.separator();
 
-            // Compute overall stats
-            let mut total_demand: u32 = 0;
-            let mut total_covered_all: u32 = 0;
-
-            // We need demand cells count (computed once since it's same for all categories)
+            // Compute demand cells count (same for all categories)
             let mut demand_count: u32 = 0;
             for y in 0..GRID_HEIGHT {
                 for x in 0..GRID_WIDTH {
@@ -260,76 +459,232 @@ pub fn service_coverage_panel_ui(
                 }
             }
 
-            // Header row
+            // Header
             ui.heading("Coverage by Service Type");
             ui.small(format!("{} zoned cells in city", demand_count));
             ui.separator();
 
-            // Table header
-            egui::Grid::new("service_coverage_grid")
-                .num_columns(5)
-                .striped(true)
-                .min_col_width(60.0)
-                .show(ui, |ui| {
-                    ui.strong("Service");
-                    ui.strong("Coverage");
-                    ui.strong("Status");
-                    ui.strong("Buildings");
-                    ui.strong("Covered/Demand");
-                    ui.end_row();
+            let mut total_maintenance = 0.0f64;
+            let mut total_covered_all: u32 = 0;
+            let mut total_demand: u32 = 0;
 
-                    for category in ServiceCategory::ALL {
-                        let stats =
-                            compute_category_stats(category, &grid, &coverage, &service_list);
+            // --- Coverage-tracked categories ---
+            for (cat_idx, category) in ServiceCategory::ALL.iter().enumerate() {
+                let stats = compute_category_stats(*category, &grid, &coverage, &service_list);
 
-                        total_demand += stats.demand_cells;
-                        total_covered_all += stats.covered_cells;
+                total_demand += stats.demand_cells;
+                total_covered_all += stats.covered_cells;
+                total_maintenance += stats.monthly_maintenance;
 
-                        let color = coverage_color(stats.coverage_pct);
-                        let pct_str = format!("{:.1}%", stats.coverage_pct * 100.0);
-                        let label = coverage_label(stats.coverage_pct);
+                let color = coverage_color(stats.coverage_pct);
+                let pct_str = format!("{:.1}%", stats.coverage_pct * 100.0);
+                let label = coverage_label(stats.coverage_pct);
+                let is_expanded = expanded.expanded.contains(&(cat_idx as u8));
 
-                        // Clickable service name to activate overlay
-                        let name_response = ui.add(
-                            egui::Label::new(egui::RichText::new(category.name()).strong())
-                                .sense(egui::Sense::click()),
-                        );
+                // Category header row
+                ui.horizontal(|ui| {
+                    let arrow = if is_expanded { "\u{25BC}" } else { "\u{25B6}" };
+                    let header_text = format!(
+                        "{} {}  {}  {}  ({} bldgs, ${:.0}/mo)",
+                        arrow,
+                        category.name(),
+                        pct_str,
+                        label,
+                        stats.building_count,
+                        stats.monthly_maintenance
+                    );
 
-                        if name_response.clicked() {
-                            if let Some(mode) = category.overlay_mode() {
-                                if overlay.mode == mode {
-                                    overlay.mode = OverlayMode::None;
-                                } else {
-                                    overlay.mode = mode;
-                                }
+                    let resp = ui.add(
+                        egui::Label::new(egui::RichText::new(header_text).strong().color(color))
+                            .sense(egui::Sense::click()),
+                    );
+
+                    if resp.clicked() {
+                        if is_expanded {
+                            expanded.expanded.remove(&(cat_idx as u8));
+                        } else {
+                            expanded.expanded.insert(cat_idx as u8);
+                        }
+                    }
+
+                    // Overlay toggle on right-click
+                    if resp.secondary_clicked() {
+                        if let Some(mode) = category.overlay_mode() {
+                            if overlay.mode == mode {
+                                overlay.mode = OverlayMode::None;
+                            } else {
+                                overlay.mode = mode;
                             }
                         }
-                        if name_response.hovered() {
-                            name_response.on_hover_text(match category.overlay_mode() {
-                                Some(_) => "Click to toggle overlay",
-                                None => "No overlay available",
+                    }
+
+                    resp.on_hover_text(format!(
+                        "Covered: {} / {} cells\nClick to expand, right-click to toggle overlay",
+                        stats.covered_cells, stats.demand_cells
+                    ));
+                });
+
+                // Coverage bar
+                ui.horizontal(|ui| {
+                    ui.add_space(16.0);
+                    let bar_width = 200.0;
+                    let bar_height = 6.0;
+                    let desired = egui::vec2(bar_width, bar_height);
+                    let (rect, _) = ui.allocate_exact_size(desired, egui::Sense::hover());
+                    let painter = ui.painter();
+                    painter.rect_filled(rect, 2.0, egui::Color32::from_gray(40));
+                    let fraction = stats.coverage_pct as f32;
+                    let mut fill_rect = rect;
+                    fill_rect.set_right(rect.left() + rect.width() * fraction.clamp(0.0, 1.0));
+                    painter.rect_filled(fill_rect, 2.0, color);
+                });
+
+                // Expanded per-service-type detail
+                if is_expanded {
+                    for &st in category.service_types() {
+                        let type_stats = compute_service_type_stats(st, &service_list);
+                        if type_stats.count > 0 {
+                            ui.horizontal(|ui| {
+                                ui.add_space(24.0);
+                                ui.label(
+                                    egui::RichText::new(format!(
+                                        "{}: {} bldg(s), ${:.0}/mo",
+                                        st.name(),
+                                        type_stats.count,
+                                        type_stats.monthly_maintenance
+                                    ))
+                                    .small(),
+                                );
                             });
                         }
-
-                        // Coverage percentage with color
-                        ui.colored_label(color, &pct_str);
-
-                        // Status label
-                        ui.colored_label(color, label);
-
-                        // Building count (capacity)
-                        ui.label(format!("{}", stats.building_count));
-
-                        // Covered / demand
-                        ui.label(format!("{} / {}", stats.covered_cells, stats.demand_cells));
-
-                        ui.end_row();
                     }
-                });
+
+                    // Show types with 0 count dimmed
+                    let has_zero = category
+                        .service_types()
+                        .iter()
+                        .any(|st| compute_service_type_stats(*st, &service_list).count == 0);
+                    if has_zero {
+                        ui.horizontal(|ui| {
+                            ui.add_space(24.0);
+                            let missing: Vec<&str> = category
+                                .service_types()
+                                .iter()
+                                .filter(|st| {
+                                    compute_service_type_stats(**st, &service_list).count == 0
+                                })
+                                .map(|st| st.name())
+                                .collect();
+                            ui.label(
+                                egui::RichText::new(format!("Not built: {}", missing.join(", ")))
+                                    .small()
+                                    .weak(),
+                            );
+                        });
+                    }
+                }
+
+                ui.add_space(2.0);
+            }
 
             ui.separator();
 
-            // Overall summary
+            // --- Other Services (no coverage tracking) ---
+            ui.heading("Other Services");
+            ui.small("Services without area coverage tracking");
+            ui.add_space(4.0);
+
+            let mut other_maintenance = 0.0f64;
+
+            for (group_idx, group) in OtherServiceGroup::ALL.iter().enumerate() {
+                let mut group_count = 0u32;
+                let mut group_maintenance = 0.0f64;
+
+                for &st in group.service_types() {
+                    let type_stats = compute_service_type_stats(st, &service_list);
+                    group_count += type_stats.count;
+                    group_maintenance += type_stats.monthly_maintenance;
+                }
+
+                other_maintenance += group_maintenance;
+
+                if group_count == 0 {
+                    // Show dimmed row for empty groups
+                    ui.horizontal(|ui| {
+                        ui.label(egui::RichText::new(format!("{}: none", group.name())).weak());
+                    });
+                    continue;
+                }
+
+                let is_expanded = expanded.other_expanded.contains(&(group_idx as u8));
+                let arrow = if is_expanded { "\u{25BC}" } else { "\u{25B6}" };
+
+                let resp = ui.add(
+                    egui::Label::new(
+                        egui::RichText::new(format!(
+                            "{} {}  ({} bldgs, ${:.0}/mo)",
+                            arrow,
+                            group.name(),
+                            group_count,
+                            group_maintenance
+                        ))
+                        .strong(),
+                    )
+                    .sense(egui::Sense::click()),
+                );
+
+                if resp.clicked() {
+                    if is_expanded {
+                        expanded.other_expanded.remove(&(group_idx as u8));
+                    } else {
+                        expanded.other_expanded.insert(group_idx as u8);
+                    }
+                }
+
+                if resp.secondary_clicked() {
+                    if let Some(mode) = group.overlay_mode() {
+                        if overlay.mode == mode {
+                            overlay.mode = OverlayMode::None;
+                        } else {
+                            overlay.mode = mode;
+                        }
+                    }
+                }
+
+                if is_expanded {
+                    for &st in group.service_types() {
+                        let type_stats = compute_service_type_stats(st, &service_list);
+                        ui.horizontal(|ui| {
+                            ui.add_space(24.0);
+                            if type_stats.count > 0 {
+                                ui.label(
+                                    egui::RichText::new(format!(
+                                        "{}: {} bldg(s), ${:.0}/mo",
+                                        st.name(),
+                                        type_stats.count,
+                                        type_stats.monthly_maintenance
+                                    ))
+                                    .small(),
+                                );
+                            } else {
+                                ui.label(
+                                    egui::RichText::new(format!("{}: not built", st.name()))
+                                        .small()
+                                        .weak(),
+                                );
+                            }
+                        });
+                    }
+                }
+
+                ui.add_space(2.0);
+            }
+
+            ui.separator();
+
+            // --- Overall summary ---
+            total_maintenance += other_maintenance;
+
             let overall_pct = if total_demand > 0 {
                 total_covered_all as f64 / total_demand as f64
             } else {
@@ -338,7 +693,7 @@ pub fn service_coverage_panel_ui(
             let overall_color = coverage_color(overall_pct);
 
             ui.horizontal(|ui| {
-                ui.strong("Overall Average:");
+                ui.strong("Overall Coverage:");
                 ui.colored_label(
                     overall_color,
                     format!(
@@ -352,6 +707,14 @@ pub fn service_coverage_panel_ui(
             ui.horizontal(|ui| {
                 ui.strong("Total Service Buildings:");
                 ui.label(format!("{}", service_list.len()));
+            });
+
+            ui.horizontal(|ui| {
+                ui.strong("Total Monthly Maintenance:");
+                ui.colored_label(
+                    egui::Color32::from_rgb(220, 180, 80),
+                    format!("${:.0}", total_maintenance),
+                );
             });
 
             // Active overlay indicator
@@ -374,7 +737,11 @@ pub struct ServiceCoveragePanelPlugin;
 impl Plugin for ServiceCoveragePanelPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ServiceCoveragePanelVisible>()
-            .add_systems(Update, service_coverage_panel_ui);
+            .init_resource::<ExpandedCategories>()
+            .add_systems(
+                Update,
+                (service_coverage_keybind, service_coverage_panel_ui),
+            );
     }
 }
 
@@ -593,6 +960,7 @@ mod tests {
         assert_eq!(stats.covered_cells, 0);
         assert_eq!(stats.building_count, 0);
         assert!((stats.coverage_pct - 0.0).abs() < f64::EPSILON);
+        assert!((stats.monthly_maintenance - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -692,6 +1060,77 @@ mod tests {
         assert_eq!(edu_stats.building_count, 1); // school only
     }
 
+    #[test]
+    fn test_coverage_computes_maintenance() {
+        let grid = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+        let coverage = ServiceCoverageGrid::default();
+
+        let hospital = ServiceBuilding {
+            service_type: ServiceType::Hospital,
+            grid_x: 10,
+            grid_y: 10,
+            radius: 400.0,
+        };
+        let clinic = ServiceBuilding {
+            service_type: ServiceType::MedicalClinic,
+            grid_x: 20,
+            grid_y: 20,
+            radius: 192.0,
+        };
+
+        let services: Vec<&ServiceBuilding> = vec![&hospital, &clinic];
+
+        let stats = compute_category_stats(ServiceCategory::Health, &grid, &coverage, &services);
+
+        let expected = ServiceBuilding::monthly_maintenance(ServiceType::Hospital)
+            + ServiceBuilding::monthly_maintenance(ServiceType::MedicalClinic);
+        assert!((stats.monthly_maintenance - expected).abs() < f64::EPSILON);
+    }
+
+    // =========================================================================
+    // Per-service-type stats tests
+    // =========================================================================
+
+    #[test]
+    fn test_service_type_stats_empty() {
+        let services: Vec<&ServiceBuilding> = vec![];
+        let stats = compute_service_type_stats(ServiceType::Hospital, &services);
+        assert_eq!(stats.count, 0);
+        assert!((stats.monthly_maintenance - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_service_type_stats_counts_correct_type() {
+        let hospital = ServiceBuilding {
+            service_type: ServiceType::Hospital,
+            grid_x: 10,
+            grid_y: 10,
+            radius: 400.0,
+        };
+        let clinic = ServiceBuilding {
+            service_type: ServiceType::MedicalClinic,
+            grid_x: 20,
+            grid_y: 20,
+            radius: 192.0,
+        };
+        let hospital2 = ServiceBuilding {
+            service_type: ServiceType::Hospital,
+            grid_x: 30,
+            grid_y: 30,
+            radius: 400.0,
+        };
+
+        let services: Vec<&ServiceBuilding> = vec![&hospital, &clinic, &hospital2];
+
+        let stats = compute_service_type_stats(ServiceType::Hospital, &services);
+        assert_eq!(stats.count, 2);
+        let expected = ServiceBuilding::monthly_maintenance(ServiceType::Hospital) * 2.0;
+        assert!((stats.monthly_maintenance - expected).abs() < f64::EPSILON);
+
+        let clinic_stats = compute_service_type_stats(ServiceType::MedicalClinic, &services);
+        assert_eq!(clinic_stats.count, 1);
+    }
+
     // =========================================================================
     // Visibility tests
     // =========================================================================
@@ -754,5 +1193,104 @@ mod tests {
             compute_category_stats(ServiceCategory::Health, &grid, &coverage, &services);
         assert_eq!(health_stats.covered_cells, 0);
         assert!((health_stats.coverage_pct - 0.0).abs() < f64::EPSILON);
+    }
+
+    // =========================================================================
+    // Other service groups tests
+    // =========================================================================
+
+    #[test]
+    fn test_other_service_groups_count() {
+        assert_eq!(OtherServiceGroup::ALL.len(), 7);
+    }
+
+    #[test]
+    fn test_other_group_names_non_empty() {
+        for group in OtherServiceGroup::ALL {
+            assert!(!group.name().is_empty());
+        }
+    }
+
+    #[test]
+    fn test_garbage_group_matches() {
+        let types = OtherServiceGroup::Garbage.service_types();
+        assert!(types.contains(&ServiceType::Landfill));
+        assert!(types.contains(&ServiceType::RecyclingCenter));
+        assert!(types.contains(&ServiceType::Incinerator));
+        assert!(types.contains(&ServiceType::TransferStation));
+    }
+
+    #[test]
+    fn test_death_care_group_matches() {
+        let types = OtherServiceGroup::DeathCare.service_types();
+        assert!(types.contains(&ServiceType::Cemetery));
+        assert!(types.contains(&ServiceType::Crematorium));
+    }
+
+    #[test]
+    fn test_heating_group_matches() {
+        let types = OtherServiceGroup::Heating.service_types();
+        assert!(types.contains(&ServiceType::HeatingBoiler));
+        assert!(types.contains(&ServiceType::DistrictHeatingPlant));
+        assert!(types.contains(&ServiceType::GeothermalPlant));
+    }
+
+    #[test]
+    fn test_garbage_has_overlay() {
+        assert_eq!(
+            OtherServiceGroup::Garbage.overlay_mode(),
+            Some(OverlayMode::Garbage)
+        );
+    }
+
+    #[test]
+    fn test_water_service_has_overlay() {
+        assert_eq!(
+            OtherServiceGroup::WaterService.overlay_mode(),
+            Some(OverlayMode::Water)
+        );
+    }
+
+    #[test]
+    fn test_death_care_no_overlay() {
+        assert_eq!(OtherServiceGroup::DeathCare.overlay_mode(), None);
+    }
+
+    // =========================================================================
+    // Category service_types completeness test
+    // =========================================================================
+
+    #[test]
+    fn test_category_service_types_match_matches_service() {
+        for cat in ServiceCategory::ALL {
+            for &st in cat.service_types() {
+                assert!(
+                    cat.matches_service(st),
+                    "{:?}.matches_service({:?}) should be true",
+                    cat,
+                    st
+                );
+            }
+        }
+    }
+
+    // =========================================================================
+    // ExpandedCategories tests
+    // =========================================================================
+
+    #[test]
+    fn test_expanded_categories_default_empty() {
+        let expanded = ExpandedCategories::default();
+        assert!(expanded.expanded.is_empty());
+        assert!(expanded.other_expanded.is_empty());
+    }
+
+    #[test]
+    fn test_expanded_categories_toggle() {
+        let mut expanded = ExpandedCategories::default();
+        expanded.expanded.insert(0);
+        assert!(expanded.expanded.contains(&0));
+        expanded.expanded.remove(&0);
+        assert!(!expanded.expanded.contains(&0));
     }
 }


### PR DESCRIPTION
## Summary

- Enhances the service coverage panel with per-service-type statistics, utilization data, and maintenance costs
- Adds K keybind to toggle panel visibility
- Adds collapsible per-service-type breakdown within each coverage category (Health, Education, Police, Fire, Parks, Entertainment, Telecom, Transport)
- Adds "Other Services" section for services without coverage tracking (Garbage, Death Care, Governance, Welfare, Postal, Water Service, Heating)
- Shows monthly maintenance costs per category and per service type
- Adds coverage progress bars and right-click overlay toggle on category rows

Closes #868

## Test plan

- [ ] Press K key to toggle the service coverage panel visibility
- [ ] Verify all 8 coverage categories display with correct coverage percentages
- [ ] Click a category row to expand/collapse per-service-type breakdown
- [ ] Verify building counts and maintenance costs update when placing service buildings
- [ ] Verify color coding: green (>80%), yellow (50-80%), red (<50%)
- [ ] Right-click a category to toggle the corresponding map overlay
- [ ] Verify "Other Services" section shows Garbage, Death Care, etc.
- [ ] Run `cargo test --workspace` to confirm all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)