### PR TITLE
Fix load/new-game entity teardown race (exclusive systems)

### DIFF
--- a/crates/save/src/save_helpers.rs
+++ b/crates/save/src/save_helpers.rs
@@ -12,7 +12,7 @@ use simulation::composting::CompostingState;
 use simulation::cso::SewerSystemState;
 use simulation::degree_days::DegreeDays;
 use simulation::drought::DroughtState;
-use simulation::flood_simulation::{FloodGrid, FloodState};
+use simulation::flood_simulation::FloodState;
 use simulation::fog::FogState;
 use simulation::groundwater_depletion::GroundwaterDepletionState;
 use simulation::hazardous_waste::HazardousWasteState;
@@ -24,7 +24,7 @@ use simulation::loans::LoanBook;
 use simulation::policies::Policies;
 use simulation::recycling::{RecyclingEconomics, RecyclingState};
 use simulation::reservoir::ReservoirState;
-use simulation::snow::{SnowGrid, SnowPlowingState, SnowStats};
+use simulation::snow::{SnowGrid, SnowPlowingState};
 use simulation::storm_drainage::StormDrainageState;
 use simulation::stormwater::StormwaterGrid;
 use simulation::unlocks::UnlockState;
@@ -75,46 +75,4 @@ pub(crate) struct V2ResourcesRead<'w> {
     pub snow_grid: Res<'w, SnowGrid>,
     pub snow_plowing_state: Res<'w, SnowPlowingState>,
     pub agriculture_state: Res<'w, AgricultureState>,
-}
-
-/// Mutable access to the V2+ resources.
-#[derive(SystemParam)]
-pub(crate) struct V2ResourcesWrite<'w> {
-    pub policies: ResMut<'w, Policies>,
-    pub weather: ResMut<'w, Weather>,
-    pub unlock_state: ResMut<'w, UnlockState>,
-    pub extended_budget: ResMut<'w, ExtendedBudget>,
-    pub loan_book: ResMut<'w, LoanBook>,
-    pub virtual_population: ResMut<'w, VirtualPopulation>,
-    pub life_sim_timer: ResMut<'w, LifeSimTimer>,
-    pub stormwater_grid: ResMut<'w, StormwaterGrid>,
-    pub degree_days: ResMut<'w, DegreeDays>,
-    pub climate_zone: ResMut<'w, ClimateZone>,
-    pub construction_modifiers: ResMut<'w, ConstructionModifiers>,
-    pub recycling_state: ResMut<'w, RecyclingState>,
-    pub recycling_economics: ResMut<'w, RecyclingEconomics>,
-    pub wind_damage_state: ResMut<'w, WindDamageState>,
-    pub uhi_grid: ResMut<'w, UhiGrid>,
-    pub drought_state: ResMut<'w, DroughtState>,
-    pub heat_wave_state: ResMut<'w, HeatWaveState>,
-    pub composting_state: ResMut<'w, CompostingState>,
-    pub cold_snap_state: ResMut<'w, ColdSnapState>,
-    pub water_treatment_state: ResMut<'w, WaterTreatmentState>,
-    pub groundwater_depletion_state: ResMut<'w, GroundwaterDepletionState>,
-    pub wastewater_state: ResMut<'w, WastewaterState>,
-    pub hazardous_waste_state: ResMut<'w, HazardousWasteState>,
-    pub storm_drainage_state: ResMut<'w, StormDrainageState>,
-    pub landfill_capacity_state: ResMut<'w, LandfillCapacityState>,
-    pub flood_state: ResMut<'w, FloodState>,
-    pub flood_grid: ResMut<'w, FloodGrid>,
-    pub reservoir_state: ResMut<'w, ReservoirState>,
-    pub landfill_gas_state: ResMut<'w, LandfillGasState>,
-    pub cso_state: ResMut<'w, SewerSystemState>,
-    pub water_conservation_state: ResMut<'w, WaterConservationState>,
-    pub fog_state: ResMut<'w, FogState>,
-    pub urban_growth_boundary: ResMut<'w, UrbanGrowthBoundary>,
-    pub snow_grid: ResMut<'w, SnowGrid>,
-    pub snow_plowing_state: ResMut<'w, SnowPlowingState>,
-    pub snow_stats: ResMut<'w, SnowStats>,
-    pub agriculture_state: ResMut<'w, AgricultureState>,
 }


### PR DESCRIPTION
## Summary

- Convert `handle_load` and `handle_new_game` from regular Bevy systems using deferred `Commands` to **exclusive systems** (`&mut World`) that despawn and spawn entities immediately
- This eliminates the race condition where gameplay/render systems running in the same `Update` frame could observe partially torn-down state, causing transient "entity not found" errors during load/new-game
- Remove now-unused `ExistingEntities` SystemParam and `V2ResourcesWrite` SystemParam (dead code cleanup)

### Technical details

The root cause was that `Commands`-based despawns are deferred until end-of-stage, but other systems in the same `Update` frame could queue overlapping entity operations on entities about to be despawned. By using `world.despawn(entity)` and `world.spawn(bundle)` directly in exclusive systems, all entity operations take effect immediately before any other systems can observe intermediate state.

Multi-resource mutations that require simultaneous mutable access (e.g., grid + roads) use Bevy's `resource_scope()` pattern for safe concurrent borrowing.

## Test plan

- [ ] CI passes (build, test, clippy, fmt)
- [ ] Load/save round-trip works without "entity not found" errors
- [ ] New game starts cleanly with no stale entities

Closes #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)