### PR TITLE
TRAF-001: BPR travel time function in pathfinding

### DIFF
--- a/crates/simulation/src/grid.rs
+++ b/crates/simulation/src/grid.rs
@@ -131,6 +131,20 @@ impl RoadType {
             RoadType::Highway => 2.0,
         }
     }
+
+    /// Returns the vehicle capacity per time unit for this road type.
+    /// Based on lane count and speed characteristics.
+    /// Used by BPR travel time function to model congestion.
+    pub fn capacity(self) -> u32 {
+        match self {
+            RoadType::Local => 20,
+            RoadType::Avenue => 40,
+            RoadType::Boulevard => 60,
+            RoadType::Highway => 80,
+            RoadType::OneWay => 25,
+            RoadType::Path => 5,
+        }
+    }
 }
 
 impl ZoneType {


### PR DESCRIPTION
## Summary
- Implements Bureau of Public Roads (BPR) congestion function for nonlinear travel time estimation: `travel_time = free_flow_time * (1 + 0.15 * (volume/capacity)^4)`
- Adds `capacity()` to `RoadType` (Local=20, Avenue=40, Boulevard=60, Highway=80, OneWay=25, Path=5)
- Integrates BPR into A* pathfinding via new `csr_find_path_with_traffic()` function that replaces simple distance-based costs with speed- and congestion-aware edge weights
- Updates `process_path_requests` in movement.rs to use traffic-aware routing, enabling natural route diversification under congestion

## Test plan
- [x] Unit tests for BPR function: zero volume, at capacity (1.15x), over capacity (3.4x at 2x), zero capacity edge case
- [x] Unit test for monotonically increasing travel time with volume
- [x] Unit test for nonlinear growth (beta=4 causes super-linear penalty increase)
- [x] Integration test: pathfinding with no congestion finds path
- [x] Integration test: pathfinding avoids congested route in favor of alternate
- [x] Unit test for RoadType::capacity() ordering across tiers

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)