### PR TITLE
Migrate WASM saves from localStorage to IndexedDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,7 @@ name = "megacity"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "criterion",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "getrandom 0.4.1",
@@ -4821,9 +4822,14 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bitcode",
+ "flate2",
+ "futures-channel",
+ "js-sys",
  "rendering",
  "serde",
  "simulation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 

--- a/crates/save/Cargo.toml
+++ b/crates/save/Cargo.toml
@@ -11,5 +11,26 @@ simulation = { path = "../simulation" }
 rendering = { path = "../rendering" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { version = "0.3", features = ["Window", "Storage"] }
+web-sys = { version = "0.3", features = [
+    "Window",
+    "Storage",
+    "Event",
+    "EventTarget",
+    "IdbFactory",
+    "IdbDatabase",
+    "IdbObjectStore",
+    "IdbObjectStoreParameters",
+    "IdbOpenDbRequest",
+    "IdbRequest",
+    "IdbTransaction",
+    "IdbTransactionMode",
+    "IdbVersionChangeEvent",
+    "DomStringList",
+    "DomException",
+    "console",
+] }
+js-sys = "0.3"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+futures-channel = "0.3"
 flate2 = "1.1"

--- a/crates/save/src/wasm_idb.rs
+++ b/crates/save/src/wasm_idb.rs
@@ -1,0 +1,297 @@
+//! IndexedDB storage backend for WASM saves.
+//!
+//! Replaces the old localStorage + base64 approach with IndexedDB which
+//! supports storing large binary blobs (50 MB+) without the ~5 MB
+//! localStorage limit.
+
+use js_sys::Uint8Array;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{
+    IdbDatabase, IdbObjectStore, IdbOpenDbRequest, IdbRequest, IdbTransactionMode, Window,
+};
+
+const DB_NAME: &str = "megacity_saves";
+const DB_VERSION: u32 = 1;
+const STORE_NAME: &str = "saves";
+const SAVE_KEY: &str = "megacity_save";
+
+/// Legacy localStorage key (for migration).
+const LEGACY_KEY: &str = "megacity_save";
+
+fn window() -> Result<Window, String> {
+    web_sys::window().ok_or_else(|| "no window".to_string())
+}
+
+/// Open (or create) the IndexedDB database.
+async fn open_db() -> Result<IdbDatabase, String> {
+    let window = window()?;
+    let idb_factory = window
+        .indexed_db()
+        .map_err(|e| format!("indexedDB error: {:?}", e))?
+        .ok_or("indexedDB not available")?;
+
+    let open_request: IdbOpenDbRequest = idb_factory
+        .open_with_u32(DB_NAME, DB_VERSION)
+        .map_err(|e| format!("failed to open db: {:?}", e))?;
+
+    // Handle upgrade (create object store on first use).
+    let on_upgrade = Closure::once(move |event: web_sys::IdbVersionChangeEvent| {
+        let target = event.target().expect("event target");
+        let request: IdbOpenDbRequest = target.unchecked_into();
+        let db: IdbDatabase = request.result().expect("result").unchecked_into();
+        if !db.object_store_names().contains(STORE_NAME) {
+            db.create_object_store(STORE_NAME)
+                .expect("create object store");
+        }
+    });
+    open_request.set_onupgradeneeded(Some(on_upgrade.as_ref().unchecked_ref()));
+
+    let db = idb_request_to_future(&open_request).await?;
+    let db: IdbDatabase = db.unchecked_into();
+
+    // Drop closure so it doesn't leak
+    drop(on_upgrade);
+
+    Ok(db)
+}
+
+/// Convert an IdbRequest into a Future that resolves when the request completes.
+async fn idb_request_to_future(request: &IdbRequest) -> Result<JsValue, String> {
+    let (sender, receiver) = futures_channel::oneshot::channel::<Result<JsValue, String>>();
+    let sender = std::rc::Rc::new(std::cell::RefCell::new(Some(sender)));
+
+    let sender_ok = sender.clone();
+    let request_clone = request.clone();
+    let on_success = Closure::once(move |_event: web_sys::Event| {
+        if let Some(tx) = sender_ok.borrow_mut().take() {
+            let result = request_clone.result().unwrap_or(JsValue::UNDEFINED);
+            let _ = tx.send(Ok(result));
+        }
+    });
+
+    let sender_err = sender;
+    let request_clone2 = request.clone();
+    let on_error = Closure::once(move |_event: web_sys::Event| {
+        if let Some(tx) = sender_err.borrow_mut().take() {
+            let err = request_clone2
+                .error()
+                .ok()
+                .flatten()
+                .map(|e| format!("{:?}", e.message()))
+                .unwrap_or_else(|| "unknown IDB error".to_string());
+            let _ = tx.send(Err(err));
+        }
+    });
+
+    request.set_onsuccess(Some(on_success.as_ref().unchecked_ref()));
+    request.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+
+    let result = receiver
+        .await
+        .map_err(|_| "IDB request channel dropped".to_string())?;
+
+    // Clean up event handlers
+    request.set_onsuccess(None);
+    request.set_onerror(None);
+
+    result
+}
+
+/// Save compressed binary data to IndexedDB.
+pub async fn idb_save(bytes: Vec<u8>) -> Result<(), String> {
+    use flate2::write::DeflateEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+
+    // Compress with deflate (same as before, but no base64 step).
+    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(&bytes)
+        .map_err(|e| format!("compression write error: {}", e))?;
+    let compressed = encoder
+        .finish()
+        .map_err(|e| format!("compression finish error: {}", e))?;
+
+    let db = open_db().await?;
+
+    let transaction = db
+        .transaction_with_str_and_mode(STORE_NAME, IdbTransactionMode::Readwrite)
+        .map_err(|e| format!("transaction error: {:?}", e))?;
+    let store: IdbObjectStore = transaction
+        .object_store(STORE_NAME)
+        .map_err(|e| format!("object store error: {:?}", e))?;
+
+    // Store as Uint8Array (binary, no base64 overhead).
+    let js_array = Uint8Array::from(&compressed[..]);
+    let request = store
+        .put_with_key(&js_array, &JsValue::from_str(SAVE_KEY))
+        .map_err(|e| format!("put error: {:?}", e))?;
+
+    idb_request_to_future(&request).await?;
+
+    web_sys::console::log_1(
+        &format!(
+            "Saved {} bytes ({} compressed) to IndexedDB",
+            bytes.len(),
+            compressed.len()
+        )
+        .into(),
+    );
+
+    Ok(())
+}
+
+/// Load compressed binary data from IndexedDB.
+/// Falls back to localStorage for migration of old saves.
+pub async fn idb_load() -> Result<Vec<u8>, String> {
+    // First try IndexedDB.
+    match idb_load_from_db().await {
+        Ok(Some(bytes)) => return Ok(bytes),
+        Ok(None) => {
+            // No save in IndexedDB; try migrating from localStorage.
+            web_sys::console::log_1(
+                &"No save in IndexedDB, checking localStorage for migration...".into(),
+            );
+        }
+        Err(e) => {
+            web_sys::console::log_1(
+                &format!(
+                    "IndexedDB load failed ({}), trying localStorage fallback...",
+                    e
+                )
+                .into(),
+            );
+        }
+    }
+
+    // Try loading from legacy localStorage.
+    match load_from_local_storage() {
+        Ok(bytes) => {
+            web_sys::console::log_1(&"Migrated save from localStorage to IndexedDB".into());
+            // Migrate: save to IndexedDB so future loads use IndexedDB directly.
+            // We re-compress inside idb_save, so pass the decompressed bytes.
+            let bytes_clone = bytes.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                if let Err(e) = idb_save(bytes_clone).await {
+                    web_sys::console::log_1(
+                        &format!("Migration save to IndexedDB failed: {}", e).into(),
+                    );
+                } else {
+                    // Remove legacy localStorage entry after successful migration.
+                    let _ = remove_legacy_local_storage();
+                }
+            });
+            Ok(bytes)
+        }
+        Err(_) => Err("no save found".to_string()),
+    }
+}
+
+/// Attempt to load from IndexedDB. Returns Ok(None) if no save exists.
+async fn idb_load_from_db() -> Result<Option<Vec<u8>>, String> {
+    use flate2::read::DeflateDecoder;
+    use std::io::Read;
+
+    let db = open_db().await?;
+
+    let transaction = db
+        .transaction_with_str_and_mode(STORE_NAME, IdbTransactionMode::Readonly)
+        .map_err(|e| format!("transaction error: {:?}", e))?;
+    let store = transaction
+        .object_store(STORE_NAME)
+        .map_err(|e| format!("object store error: {:?}", e))?;
+
+    let request = store
+        .get(&JsValue::from_str(SAVE_KEY))
+        .map_err(|e| format!("get error: {:?}", e))?;
+
+    let result = idb_request_to_future(&request).await?;
+
+    if result.is_undefined() || result.is_null() {
+        return Ok(None);
+    }
+
+    let array: Uint8Array = result.unchecked_into();
+    let raw = array.to_vec();
+
+    // Decompress; fall back to raw for uncompressed data.
+    let mut decoder = DeflateDecoder::new(&raw[..]);
+    let mut decompressed = Vec::new();
+    match decoder.read_to_end(&mut decompressed) {
+        Ok(_) => Ok(Some(decompressed)),
+        Err(_) => Ok(Some(raw)),
+    }
+}
+
+/// Load from legacy localStorage (base64-encoded, possibly compressed).
+fn load_from_local_storage() -> Result<Vec<u8>, String> {
+    use flate2::read::DeflateDecoder;
+    use std::io::Read;
+
+    let window = window()?;
+    let storage = window
+        .local_storage()
+        .map_err(|_| "localStorage error")?
+        .ok_or("no localStorage")?;
+    let encoded = storage
+        .get_item(LEGACY_KEY)
+        .map_err(|_| "failed to get localStorage item")?
+        .ok_or("no save found in localStorage")?;
+    let raw = base64_decode(&encoded).map_err(|e| format!("base64 decode error: {}", e))?;
+
+    // Try to decompress; fall back to raw bytes for old uncompressed saves.
+    let mut decoder = DeflateDecoder::new(&raw[..]);
+    let mut decompressed = Vec::new();
+    match decoder.read_to_end(&mut decompressed) {
+        Ok(_) => Ok(decompressed),
+        Err(_) => Ok(raw),
+    }
+}
+
+/// Remove legacy localStorage entry after migration.
+fn remove_legacy_local_storage() -> Result<(), String> {
+    let window = window()?;
+    let storage = window
+        .local_storage()
+        .map_err(|_| "localStorage error")?
+        .ok_or("no localStorage")?;
+    storage
+        .remove_item(LEGACY_KEY)
+        .map_err(|_| "failed to remove localStorage item")?;
+    Ok(())
+}
+
+/// Decode base64 string to bytes (for legacy localStorage migration).
+fn base64_decode(input: &str) -> Result<Vec<u8>, &'static str> {
+    fn decode_char(c: u8) -> Result<u32, &'static str> {
+        match c {
+            b'A'..=b'Z' => Ok((c - b'A') as u32),
+            b'a'..=b'z' => Ok((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Ok((c - b'0' + 52) as u32),
+            b'+' => Ok(62),
+            b'/' => Ok(63),
+            _ => Err("invalid base64 character"),
+        }
+    }
+    let input = input.as_bytes();
+    let mut result = Vec::with_capacity(input.len() * 3 / 4);
+    let chunks: Vec<&[u8]> = input.chunks(4).collect();
+    for chunk in chunks {
+        if chunk.len() < 2 {
+            break;
+        }
+        let a = decode_char(chunk[0])?;
+        let b = decode_char(chunk[1])?;
+        result.push(((a << 2) | (b >> 4)) as u8);
+        if chunk.len() > 2 && chunk[2] != b'=' {
+            let c = decode_char(chunk[2])?;
+            result.push((((b & 0xF) << 4) | (c >> 2)) as u8);
+            if chunk.len() > 3 && chunk[3] != b'=' {
+                let d = decode_char(chunk[3])?;
+                result.push((((c & 0x3) << 6) | d) as u8);
+            }
+        }
+    }
+    Ok(result)
+}


### PR DESCRIPTION
## Summary
- Replace localStorage + base64 save backend with IndexedDB for WASM builds, removing the ~5MB size limit that causes silent save failures on large cities
- IndexedDB stores compressed binary directly (no base64 overhead), supporting 50MB+ saves
- Async two-phase load pattern bridges IndexedDB's async API with Bevy's synchronous ECS systems
- Automatic migration from localStorage on first load: reads legacy save, copies to IndexedDB, removes old entry

## Changes
- **New `wasm_idb` module** (`crates/save/src/wasm_idb.rs`): async IndexedDB open/read/write using `web-sys` + `futures-channel` for callback-to-future bridging
- **Save path**: fire-and-forget async write via `spawn_local` + `idb_save` (compressed binary, no base64)
- **Load path**: three-phase async pattern:
  1. `start_wasm_load` — consumes `LoadGameEvent`, kicks off async IndexedDB read
  2. `poll_wasm_load` — checks shared buffer each frame, fires `WasmLoadReady` when data arrives
  3. `handle_wasm_load_ready` — restores world state from loaded bytes
- **Refactored** `restore_from_bytes` helper shared by native file I/O and WASM IndexedDB load paths
- **Migration**: `idb_load` tries IndexedDB first, falls back to localStorage with base64 decode, then migrates data to IndexedDB
- Native (non-WASM) save/load path unchanged

## Test plan
- [ ] All existing tests pass (`cargo test --workspace` — 208 tests)
- [ ] No clippy warnings (`cargo clippy --workspace -- -D warnings`)
- [ ] Code formatted (`cargo fmt --all -- --check`)
- [ ] WASM build compiles (CI wasm check)
- [ ] Manual test: save/load works in browser after deployment
- [ ] Manual test: existing localStorage saves migrate automatically on first load

Closes #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)