### PR TITLE
Isolate save/load into staged exclusive pipeline (SaveLoadState)

### DIFF
--- a/crates/save/src/lib.rs
+++ b/crates/save/src/lib.rs
@@ -1,9 +1,7 @@
-use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use std::collections::HashSet;
 
 mod save_codec;
-mod save_helpers;
 mod save_migrate;
 mod save_restore;
 mod save_types;
@@ -15,7 +13,6 @@ mod wasm_idb;
 
 pub use saveable_ext::SaveableAppExt;
 
-use save_helpers::{V2ResourcesRead, V2ResourcesWrite};
 use serialization::{
     create_save_data, migrate_save, restore_agriculture, restore_climate_zone, restore_cold_snap,
     restore_composting, restore_construction_modifiers, restore_cso, restore_degree_days,
@@ -30,6 +27,7 @@ use serialization::{
     u8_to_road_type, u8_to_service_type, u8_to_utility_type, u8_to_zone_type, CitizenSaveInput,
     SaveData, CURRENT_SAVE_VERSION,
 };
+use simulation::SaveLoadState;
 use simulation::SaveableRegistry;
 
 use simulation::agriculture::AgricultureState;
@@ -86,76 +84,20 @@ use rendering::building_render::BuildingMesh3d;
 use rendering::citizen_render::CitizenSprite;
 
 // ---------------------------------------------------------------------------
-// Extension map buffer resources
+// Buffer resources
 // ---------------------------------------------------------------------------
 
-/// Holds a fully-built SaveData that still needs extension map population.
-/// Written by `handle_save`, consumed by `flush_save_with_extensions`.
+/// Holds raw bytes loaded from disk (native) or IndexedDB (WASM) that the
+/// exclusive load system will parse and restore.
 #[derive(Resource, Default)]
-struct PendingSaveData(Option<SaveData>);
-
-/// Holds extension map data loaded from a save file.
-/// Written by `handle_load`, consumed by `apply_load_extensions`.
-#[derive(Resource, Default)]
-struct PendingLoadExtensions(Option<std::collections::BTreeMap<String, Vec<u8>>>);
-
-/// Signals that a new game was started, so extension-registered resources need resetting.
-/// Written by `handle_new_game`, consumed by `reset_saveable_extensions`.
-#[derive(Resource, Default)]
-struct PendingNewGameReset(bool);
+struct PendingLoadBytes(Option<Vec<u8>>);
 
 /// On WASM, holds bytes arriving from an async IndexedDB read.
 /// The `poll_wasm_load` system checks this each frame and, when data arrives,
-/// fires an internal `WasmLoadReady` event so the normal restore path runs.
+/// stores it in `PendingLoadBytes` and triggers state transition.
 #[cfg(target_arch = "wasm32")]
 #[derive(Resource, Default)]
 struct WasmLoadBuffer(std::rc::Rc<std::cell::RefCell<Option<Result<Vec<u8>, String>>>>);
-
-/// Internal event carrying bytes loaded asynchronously from IndexedDB.
-#[cfg(target_arch = "wasm32")]
-#[derive(Event)]
-struct WasmLoadReady(Vec<u8>);
-/// Bundles entity queries for despawning existing game entities during load/new-game.
-#[derive(SystemParam)]
-struct ExistingEntities<'w, 's> {
-    buildings: Query<'w, 's, Entity, With<Building>>,
-    citizens: Query<'w, 's, Entity, With<Citizen>>,
-    utilities: Query<'w, 's, Entity, With<UtilitySource>>,
-    services: Query<'w, 's, Entity, With<ServiceBuilding>>,
-    water_sources: Query<'w, 's, Entity, With<WaterSource>>,
-    meshes: Query<'w, 's, Entity, With<BuildingMesh3d>>,
-    sprites: Query<'w, 's, Entity, With<CitizenSprite>>,
-}
-
-impl ExistingEntities<'_, '_> {
-    /// Collect all game entities into a deduplicated set so each entity is
-    /// despawned at most once (entities may match multiple queries).
-    fn all_entities(&self) -> HashSet<Entity> {
-        let mut set = HashSet::new();
-        for e in &self.buildings {
-            set.insert(e);
-        }
-        for e in &self.citizens {
-            set.insert(e);
-        }
-        for e in &self.utilities {
-            set.insert(e);
-        }
-        for e in &self.services {
-            set.insert(e);
-        }
-        for e in &self.water_sources {
-            set.insert(e);
-        }
-        for e in &self.meshes {
-            set.insert(e);
-        }
-        for e in &self.sprites {
-            set.insert(e);
-        }
-        set
-    }
-}
 
 pub struct SavePlugin;
 
@@ -165,47 +107,36 @@ impl Plugin for SavePlugin {
             .add_event::<LoadGameEvent>()
             .add_event::<NewGameEvent>()
             .init_resource::<SaveableRegistry>()
-            .init_resource::<PendingSaveData>()
-            .init_resource::<PendingLoadExtensions>()
-            .init_resource::<PendingNewGameReset>();
+            .init_resource::<PendingLoadBytes>();
 
         // On WASM, register IndexedDB async load infrastructure.
         #[cfg(target_arch = "wasm32")]
-        app.add_event::<WasmLoadReady>()
-            .init_resource::<WasmLoadBuffer>();
+        app.init_resource::<WasmLoadBuffer>();
 
-        app.add_systems(
-            Update,
-            (
-                handle_save,
-                handle_new_game,
-                // Extension-map systems run AFTER the core handlers in the same frame.
-                flush_save_with_extensions.after(handle_save),
-                reset_saveable_extensions.after(handle_new_game),
-            ),
-        );
+        // Event detection: runs every frame, reads events and triggers state
+        // transitions.  These are lightweight systems that only read events.
+        app.add_systems(Update, (detect_save_event, detect_new_game_event));
 
-        // Native: synchronous load path.
+        // Native: synchronous load event detection (reads file, stores bytes,
+        // transitions to Loading state).
         #[cfg(not(target_arch = "wasm32"))]
-        app.add_systems(
-            Update,
-            (handle_load, apply_load_extensions.after(handle_load)),
-        );
+        app.add_systems(Update, detect_load_event);
 
-        // WASM: async two-phase load path.
-        // 1) `start_wasm_load` consumes LoadGameEvent and kicks off async IndexedDB read
-        // 2) `poll_wasm_load` checks for completed read and fires WasmLoadReady
-        // 3) `handle_wasm_load_ready` restores world state from the loaded bytes
+        // WASM: async two-phase load detection.
+        // 1) `start_wasm_load` kicks off async IndexedDB read
+        // 2) `poll_wasm_load` checks for completed read and transitions to Loading
         #[cfg(target_arch = "wasm32")]
         app.add_systems(
             Update,
-            (
-                start_wasm_load,
-                poll_wasm_load.after(start_wasm_load),
-                handle_wasm_load_ready.after(poll_wasm_load),
-                apply_load_extensions.after(handle_wasm_load_ready),
-            ),
+            (start_wasm_load, poll_wasm_load.after(start_wasm_load)),
         );
+
+        // Exclusive systems for each state: these run on state entry,
+        // perform all work with exclusive world access, and transition back
+        // to Idle.
+        app.add_systems(OnEnter(SaveLoadState::Saving), exclusive_save);
+        app.add_systems(OnEnter(SaveLoadState::Loading), exclusive_load);
+        app.add_systems(OnEnter(SaveLoadState::NewGame), exclusive_new_game);
     }
 }
 
@@ -218,18 +149,108 @@ pub struct LoadGameEvent;
 #[derive(Event)]
 pub struct NewGameEvent;
 
-#[allow(clippy::too_many_arguments, clippy::type_complexity)]
-fn handle_save(
+// ---------------------------------------------------------------------------
+// Event detection systems (lightweight, run in Update)
+// ---------------------------------------------------------------------------
+
+/// Detects `SaveGameEvent` and transitions to `Saving` state.
+fn detect_save_event(
     mut events: EventReader<SaveGameEvent>,
-    grid: Res<WorldGrid>,
-    roads: Res<RoadNetwork>,
-    segments: Res<RoadSegmentStore>,
-    clock: Res<GameClock>,
-    budget: Res<CityBudget>,
-    demand: Res<ZoneDemand>,
-    buildings: Query<(&Building, Option<&MixedUseBuilding>)>,
-    citizens: Query<
-        (
+    mut next_state: ResMut<NextState<SaveLoadState>>,
+) {
+    if events.read().next().is_some() {
+        // Drain remaining events (only process one per frame).
+        events.read().for_each(drop);
+        next_state.set(SaveLoadState::Saving);
+    }
+}
+
+/// Detects `NewGameEvent` and transitions to `NewGame` state.
+fn detect_new_game_event(
+    mut events: EventReader<NewGameEvent>,
+    mut next_state: ResMut<NextState<SaveLoadState>>,
+) {
+    if events.read().next().is_some() {
+        events.read().for_each(drop);
+        next_state.set(SaveLoadState::NewGame);
+    }
+}
+
+/// Native: detects `LoadGameEvent`, reads save file, stores bytes, and
+/// transitions to `Loading` state.
+#[cfg(not(target_arch = "wasm32"))]
+fn detect_load_event(
+    mut events: EventReader<LoadGameEvent>,
+    mut next_state: ResMut<NextState<SaveLoadState>>,
+    mut pending: ResMut<PendingLoadBytes>,
+) {
+    if events.read().next().is_some() {
+        events.read().for_each(drop);
+        let path = save_file_path();
+        match std::fs::read(&path) {
+            Ok(bytes) => {
+                pending.0 = Some(bytes);
+                next_state.set(SaveLoadState::Loading);
+            }
+            Err(e) => {
+                eprintln!("Failed to load: {}", e);
+            }
+        }
+    }
+}
+
+/// WASM phase 1: consumes `LoadGameEvent` and kicks off an async IndexedDB read.
+#[cfg(target_arch = "wasm32")]
+fn start_wasm_load(mut events: EventReader<LoadGameEvent>, buffer: Res<WasmLoadBuffer>) {
+    for _ in events.read() {
+        let slot = buffer.0.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            let result = wasm_idb::idb_load().await;
+            *slot.borrow_mut() = Some(result);
+        });
+    }
+}
+
+/// WASM phase 2: polls the shared buffer; when bytes arrive, stores them in
+/// `PendingLoadBytes` and transitions to `Loading` state.
+#[cfg(target_arch = "wasm32")]
+fn poll_wasm_load(
+    buffer: Res<WasmLoadBuffer>,
+    mut pending: ResMut<PendingLoadBytes>,
+    mut next_state: ResMut<NextState<SaveLoadState>>,
+) {
+    let mut slot = buffer.0.borrow_mut();
+    if let Some(result) = slot.take() {
+        match result {
+            Ok(bytes) => {
+                pending.0 = Some(bytes);
+                next_state.set(SaveLoadState::Loading);
+            }
+            Err(e) => {
+                web_sys::console::error_1(&format!("Failed to load from IndexedDB: {}", e).into());
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exclusive save system
+// ---------------------------------------------------------------------------
+
+/// Exclusive system that performs the entire save operation with full world
+/// access.  Runs on `OnEnter(SaveLoadState::Saving)`, then transitions back
+/// to `Idle`.
+fn exclusive_save(world: &mut World) {
+    // -- Stage 1: Collect entity data via queries (needs &mut World) --
+    let building_data: Vec<(Building, Option<MixedUseBuilding>)> = {
+        let mut q = world.query::<(&Building, Option<&MixedUseBuilding>)>();
+        q.iter(world)
+            .map(|(b, mu)| (b.clone(), mu.cloned()))
+            .collect()
+    };
+
+    let citizen_data: Vec<CitizenSaveInput> = {
+        let mut q = world.query::<(
             Entity,
             &CitizenDetails,
             &CitizenStateComp,
@@ -242,24 +263,8 @@ fn handle_save(
             &Needs,
             &ActivityTimer,
             &Family,
-        ),
-        With<Citizen>,
-    >,
-    utility_sources: Query<&UtilitySource>,
-    service_buildings: Query<&ServiceBuilding>,
-    water_sources: Query<&WaterSource>,
-    v2: V2ResourcesRead,
-    lifecycle_timer: Res<LifecycleTimer>,
-    mut pending: ResMut<PendingSaveData>,
-) {
-    for _ in events.read() {
-        let building_data: Vec<(Building, Option<MixedUseBuilding>)> = buildings
-            .iter()
-            .map(|(b, mu)| (b.clone(), mu.cloned()))
-            .collect();
-
-        let citizen_data: Vec<CitizenSaveInput> = citizens
-            .iter()
+        )>();
+        q.iter(world)
             .map(
                 |(entity, d, state, home, work, path, vel, pos, pers, needs, timer, family)| {
                     CitizenSaveInput {
@@ -280,916 +285,137 @@ fn handle_save(
                     }
                 },
             )
-            .collect();
+            .collect()
+    };
 
-        let utility_data: Vec<_> = utility_sources.iter().cloned().collect();
-        let service_data: Vec<(ServiceBuilding,)> =
-            service_buildings.iter().map(|sb| (sb.clone(),)).collect();
-        let water_source_data: Vec<WaterSource> = water_sources.iter().cloned().collect();
+    let utility_data: Vec<UtilitySource> = {
+        let mut q = world.query::<&UtilitySource>();
+        q.iter(world).cloned().collect()
+    };
+
+    let service_data: Vec<(ServiceBuilding,)> = {
+        let mut q = world.query::<&ServiceBuilding>();
+        q.iter(world).map(|sb| (sb.clone(),)).collect()
+    };
+
+    let water_source_data: Vec<WaterSource> = {
+        let mut q = world.query::<&WaterSource>();
+        q.iter(world).cloned().collect()
+    };
+
+    // -- Stage 2: Read resources and build SaveData (only needs & World) --
+    let save = {
+        let grid = world.resource::<WorldGrid>();
+        let roads = world.resource::<RoadNetwork>();
+        let segments = world.resource::<RoadSegmentStore>();
+        let clock = world.resource::<GameClock>();
+        let budget = world.resource::<CityBudget>();
+        let demand = world.resource::<ZoneDemand>();
+        let lifecycle_timer = world.resource::<LifecycleTimer>();
+        let policies = world.resource::<Policies>();
+        let weather = world.resource::<Weather>();
+        let unlock_state = world.resource::<UnlockState>();
+        let extended_budget = world.resource::<ExtendedBudget>();
+        let loan_book = world.resource::<LoanBook>();
+        let virtual_population = world.resource::<VirtualPopulation>();
+        let life_sim_timer = world.resource::<LifeSimTimer>();
+        let stormwater_grid = world.resource::<StormwaterGrid>();
+        let degree_days = world.resource::<DegreeDays>();
+        let climate_zone = world.resource::<ClimateZone>();
+        let construction_modifiers = world.resource::<ConstructionModifiers>();
+        let recycling_state = world.resource::<RecyclingState>();
+        let recycling_economics = world.resource::<RecyclingEconomics>();
+        let wind_damage_state = world.resource::<WindDamageState>();
+        let uhi_grid = world.resource::<UhiGrid>();
+        let drought_state = world.resource::<DroughtState>();
+        let heat_wave_state = world.resource::<HeatWaveState>();
+        let composting_state = world.resource::<CompostingState>();
+        let cold_snap_state = world.resource::<ColdSnapState>();
+        let water_treatment_state = world.resource::<WaterTreatmentState>();
+        let groundwater_depletion_state = world.resource::<GroundwaterDepletionState>();
+        let wastewater_state = world.resource::<WastewaterState>();
+        let hazardous_waste_state = world.resource::<HazardousWasteState>();
+        let storm_drainage_state = world.resource::<StormDrainageState>();
+        let landfill_capacity_state = world.resource::<LandfillCapacityState>();
+        let flood_state = world.resource::<FloodState>();
+        let reservoir_state = world.resource::<ReservoirState>();
+        let landfill_gas_state = world.resource::<LandfillGasState>();
+        let cso_state = world.resource::<SewerSystemState>();
+        let water_conservation_state = world.resource::<WaterConservationState>();
+        let fog_state = world.resource::<FogState>();
+        let urban_growth_boundary = world.resource::<UrbanGrowthBoundary>();
+        let snow_grid = world.resource::<SnowGrid>();
+        let snow_plowing_state = world.resource::<SnowPlowingState>();
+        let agriculture_state = world.resource::<AgricultureState>();
 
         let segment_ref = if segments.segments.is_empty() {
             None
         } else {
-            Some(&*segments)
+            Some(segments)
         };
 
-        let save = create_save_data(
-            &grid,
-            &roads,
-            &clock,
-            &budget,
-            &demand,
+        create_save_data(
+            grid,
+            roads,
+            clock,
+            budget,
+            demand,
             &building_data,
             &citizen_data,
             &utility_data,
             &service_data,
             segment_ref,
-            Some(&v2.policies),
-            Some(&v2.weather),
-            Some(&v2.unlock_state),
-            Some(&v2.extended_budget),
-            Some(&v2.loan_book),
-            Some(&lifecycle_timer),
-            Some(&v2.virtual_population),
-            Some(&v2.life_sim_timer),
-            Some(&v2.stormwater_grid),
+            Some(policies),
+            Some(weather),
+            Some(unlock_state),
+            Some(extended_budget),
+            Some(loan_book),
+            Some(lifecycle_timer),
+            Some(virtual_population),
+            Some(life_sim_timer),
+            Some(stormwater_grid),
             if water_source_data.is_empty() {
                 None
             } else {
                 Some(&water_source_data)
             },
-            Some(&v2.degree_days),
-            Some(&v2.climate_zone),
-            Some(&v2.construction_modifiers),
-            Some((&v2.recycling_state, &v2.recycling_economics)),
-            Some(&v2.wind_damage_state),
-            Some(&v2.uhi_grid),
-            Some(&v2.drought_state),
-            Some(&v2.heat_wave_state),
-            Some(&v2.composting_state),
-            Some(&v2.cold_snap_state),
-            Some(&v2.water_treatment_state),
-            Some(&v2.groundwater_depletion_state),
-            Some(&v2.wastewater_state),
-            Some(&v2.hazardous_waste_state),
-            Some(&v2.storm_drainage_state),
-            Some(&v2.landfill_capacity_state),
-            Some(&v2.flood_state),
-            Some(&v2.reservoir_state),
-            Some(&v2.landfill_gas_state),
-            Some(&v2.cso_state),
-            Some(&v2.water_conservation_state),
-            Some(&v2.fog_state),
-            Some(&v2.urban_growth_boundary),
-            Some((&v2.snow_grid, &v2.snow_plowing_state)),
-            Some(&v2.agriculture_state),
-        );
-
-        // Store in buffer; the exclusive flush system will add extensions and write to disk.
-        pending.0 = Some(save);
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[allow(clippy::too_many_arguments)]
-fn handle_load(
-    mut events: EventReader<LoadGameEvent>,
-    mut commands: Commands,
-    mut grid: ResMut<WorldGrid>,
-    mut roads: ResMut<RoadNetwork>,
-    mut segments: ResMut<RoadSegmentStore>,
-    mut clock: ResMut<GameClock>,
-    mut budget: ResMut<CityBudget>,
-    mut demand: ResMut<ZoneDemand>,
-    existing: ExistingEntities,
-    mut v2: V2ResourcesWrite,
-    mut lifecycle_timer: ResMut<LifecycleTimer>,
-    mut pending_ext: ResMut<PendingLoadExtensions>,
-) {
-    for _ in events.read() {
-        let bytes = {
-            let path = save_file_path();
-            match std::fs::read(&path) {
-                Ok(b) => b,
-                Err(e) => {
-                    eprintln!("Failed to load: {}", e);
-                    continue;
-                }
-            }
-        };
-
-        restore_from_bytes(
-            &bytes,
-            &mut commands,
-            &mut grid,
-            &mut roads,
-            &mut segments,
-            &mut clock,
-            &mut budget,
-            &mut demand,
-            &existing,
-            &mut v2,
-            &mut lifecycle_timer,
-            &mut pending_ext,
-        );
-
-        println!("Loaded save from {}", save_file_path());
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn restore_from_bytes(
-    bytes: &[u8],
-    commands: &mut Commands,
-    grid: &mut ResMut<WorldGrid>,
-    roads: &mut ResMut<RoadNetwork>,
-    segments: &mut ResMut<RoadSegmentStore>,
-    clock: &mut ResMut<GameClock>,
-    budget: &mut ResMut<CityBudget>,
-    demand: &mut ResMut<ZoneDemand>,
-    existing: &ExistingEntities,
-    v2: &mut V2ResourcesWrite,
-    lifecycle_timer: &mut ResMut<LifecycleTimer>,
-    pending_ext: &mut ResMut<PendingLoadExtensions>,
-) {
-    let mut save = match SaveData::decode(bytes) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("Failed to decode save: {}", e);
-            return;
-        }
+            Some(degree_days),
+            Some(climate_zone),
+            Some(construction_modifiers),
+            Some((recycling_state, recycling_economics)),
+            Some(wind_damage_state),
+            Some(uhi_grid),
+            Some(drought_state),
+            Some(heat_wave_state),
+            Some(composting_state),
+            Some(cold_snap_state),
+            Some(water_treatment_state),
+            Some(groundwater_depletion_state),
+            Some(wastewater_state),
+            Some(hazardous_waste_state),
+            Some(storm_drainage_state),
+            Some(landfill_capacity_state),
+            Some(flood_state),
+            Some(reservoir_state),
+            Some(landfill_gas_state),
+            Some(cso_state),
+            Some(water_conservation_state),
+            Some(fog_state),
+            Some(urban_growth_boundary),
+            Some((snow_grid, snow_plowing_state)),
+            Some(agriculture_state),
+        )
     };
 
-    // Migrate older save formats to current version
-    let old_version = match migrate_save(&mut save) {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("Save migration failed: {}", e);
-            return;
-        }
-    };
-    if old_version != CURRENT_SAVE_VERSION {
-        println!(
-            "Migrated save from v{} to v{}",
-            old_version, CURRENT_SAVE_VERSION
-        );
-    }
-
-    // Clear existing entities -- deduplicate to avoid double-despawn when
-    // an entity matches multiple queries (e.g. Citizen + CitizenSprite).
-    for entity in existing.all_entities() {
-        if let Some(mut ec) = commands.get_entity(entity) {
-            ec.despawn();
-        }
-    }
-
-    // Restore grid
-    **grid = WorldGrid::new(save.grid.width, save.grid.height);
-    for (i, sc) in save.grid.cells.iter().enumerate() {
-        grid.cells[i].elevation = sc.elevation;
-        grid.cells[i].cell_type = match sc.cell_type {
-            1 => simulation::grid::CellType::Water,
-            2 => simulation::grid::CellType::Road,
-            _ => simulation::grid::CellType::Grass,
-        };
-        grid.cells[i].zone = u8_to_zone_type(sc.zone);
-        grid.cells[i].road_type = u8_to_road_type(sc.road_type);
-        grid.cells[i].has_power = sc.has_power;
-        grid.cells[i].has_water = sc.has_water;
-    }
-
-    // Restore roads - use saved road types, not default Local
-    **roads = RoadNetwork::default();
-    // Save the road types before place_road overwrites them
-    let saved_road_types: Vec<(usize, usize, u8)> = save
-        .roads
-        .road_positions
-        .iter()
-        .map(|(x, y)| {
-            let idx = y * grid.width + x;
-            let rt = if idx < save.grid.cells.len() {
-                save.grid.cells[idx].road_type
-            } else {
-                0
-            };
-            (*x, *y, rt)
-        })
-        .collect();
-    for (x, y, _) in &saved_road_types {
-        roads.place_road(grid, *x, *y);
-    }
-    // Restore the saved road types (place_road overwrites with Local)
-    for (x, y, rt) in &saved_road_types {
-        if grid.in_bounds(*x, *y) {
-            grid.get_mut(*x, *y).road_type = u8_to_road_type(*rt);
-        }
-    }
-
-    // Restore road segments (if present in save)
-    if let Some(ref saved_segments) = save.road_segments {
-        let mut restored = restore_road_segment_store(saved_segments);
-        restored.rasterize_all(grid, roads);
-        **segments = restored;
-    } else {
-        **segments = RoadSegmentStore::default();
-    }
-
-    // Restore clock
-    clock.day = save.clock.day;
-    clock.hour = save.clock.hour;
-    clock.speed = save.clock.speed;
-    clock.paused = false;
-
-    // Restore budget
-    budget.treasury = save.budget.treasury;
-    budget.tax_rate = save.budget.tax_rate;
-    budget.last_collection_day = save.budget.last_collection_day;
-
-    // Restore demand
-    demand.residential = save.demand.residential;
-    demand.commercial = save.demand.commercial;
-    demand.industrial = save.demand.industrial;
-    demand.office = save.demand.office;
-    demand.vacancy_residential = save.demand.vacancy_residential;
-    demand.vacancy_commercial = save.demand.vacancy_commercial;
-    demand.vacancy_industrial = save.demand.vacancy_industrial;
-    demand.vacancy_office = save.demand.vacancy_office;
-
-    // Restore buildings
-    for sb in &save.buildings {
-        let zone = u8_to_zone_type(sb.zone_type);
-        let building = Building {
-            zone_type: zone,
-            level: sb.level,
-            grid_x: sb.grid_x,
-            grid_y: sb.grid_y,
-            capacity: sb.capacity,
-            occupants: sb.occupants,
-        };
-        let entity = if zone.is_mixed_use() {
-            // Restore MixedUseBuilding component; use saved data if non-zero,
-            // otherwise derive from static capacities for the level.
-            let (comm_cap, res_cap) = if sb.commercial_capacity > 0 || sb.residential_capacity > 0 {
-                (sb.commercial_capacity, sb.residential_capacity)
-            } else {
-                MixedUseBuilding::capacities_for_level(sb.level)
-            };
-            commands
-                .spawn((
-                    building,
-                    MixedUseBuilding {
-                        commercial_capacity: comm_cap,
-                        commercial_occupants: sb.commercial_occupants,
-                        residential_capacity: res_cap,
-                        residential_occupants: sb.residential_occupants,
-                    },
-                ))
-                .id()
-        } else {
-            commands.spawn(building).id()
-        };
-        if grid.in_bounds(sb.grid_x, sb.grid_y) {
-            grid.get_mut(sb.grid_x, sb.grid_y).building_id = Some(entity);
-        }
-    }
-
-    // Restore utility sources
-    for su in &save.utility_sources {
-        let ut = u8_to_utility_type(su.utility_type);
-        commands.spawn(UtilitySource {
-            utility_type: ut,
-            grid_x: su.grid_x,
-            grid_y: su.grid_y,
-            range: su.range,
-        });
-    }
-
-    // Restore service buildings
-    for ss in &save.service_buildings {
-        if let Some(service_type) = u8_to_service_type(ss.service_type) {
-            let radius = ServiceBuilding::coverage_radius(service_type);
-            let entity = commands
-                .spawn(ServiceBuilding {
-                    service_type,
-                    grid_x: ss.grid_x,
-                    grid_y: ss.grid_y,
-                    radius,
-                })
-                .id();
-            if grid.in_bounds(ss.grid_x, ss.grid_y) {
-                grid.get_mut(ss.grid_x, ss.grid_y).building_id = Some(entity);
-            }
-        }
-    }
-
-    // Restore water sources
-    if let Some(ref saved_water_sources) = save.water_sources {
-        for sws in saved_water_sources {
-            if let Some(ws) = restore_water_source(sws) {
-                let entity = commands.spawn(ws).id();
-                if grid.in_bounds(sws.grid_x, sws.grid_y) {
-                    grid.get_mut(sws.grid_x, sws.grid_y).building_id = Some(entity);
-                }
-            }
-        }
-    }
-
-    // Restore citizens
-    let mut citizen_entities: Vec<Entity> = Vec::with_capacity(save.citizens.len());
-    for sc in &save.citizens {
-        let state = match sc.state {
-            1 => CitizenState::CommutingToWork,
-            2 => CitizenState::Working,
-            3 => CitizenState::CommutingHome,
-            4 => CitizenState::CommutingToShop,
-            5 => CitizenState::Shopping,
-            6 => CitizenState::CommutingToLeisure,
-            7 => CitizenState::AtLeisure,
-            8 => CitizenState::CommutingToSchool,
-            9 => CitizenState::AtSchool,
-            _ => CitizenState::AtHome,
-        };
-
-        // We need building entities for home/work locations.
-        // Find them from the grid if possible, otherwise use a dummy.
-        let home_building = if grid.in_bounds(sc.home_x, sc.home_y) {
-            grid.get(sc.home_x, sc.home_y)
-                .building_id
-                .unwrap_or(Entity::PLACEHOLDER)
-        } else {
-            Entity::PLACEHOLDER
-        };
-
-        let work_building = if grid.in_bounds(sc.work_x, sc.work_y) {
-            grid.get(sc.work_x, sc.work_y)
-                .building_id
-                .unwrap_or(Entity::PLACEHOLDER)
-        } else {
-            Entity::PLACEHOLDER
-        };
-
-        // Restore position: use saved position if available (non-zero),
-        // otherwise fall back to home grid position (backward compat).
-        let (pos_x, pos_y) = if sc.pos_x != 0.0 || sc.pos_y != 0.0 {
-            (sc.pos_x, sc.pos_y)
-        } else {
-            WorldGrid::grid_to_world(sc.home_x, sc.home_y)
-        };
-
-        // Restore path cache: convert saved waypoints to RoadNodes and
-        // validate that all waypoints reference valid grid positions.
-        let (path_cache, restored_state) = {
-            let waypoints: Vec<RoadNode> = sc
-                .path_waypoints
-                .iter()
-                .map(|&(x, y)| RoadNode(x, y))
-                .collect();
-
-            let all_valid = waypoints.iter().all(|n| grid.in_bounds(n.0, n.1));
-
-            if !waypoints.is_empty() && all_valid {
-                let mut pc = PathCache::new(waypoints);
-                pc.current_index = sc.path_current_index;
-                (pc, state)
-            } else if state.is_commuting() {
-                (PathCache::new(vec![]), CitizenState::AtHome)
-            } else {
-                (PathCache::new(vec![]), state)
-            }
-        };
-
-        // Restore velocity from saved data (defaults to zero for old saves).
-        let velocity = Velocity {
-            x: sc.velocity_x,
-            y: sc.velocity_y,
-        };
-
-        // Restore gender from saved value; fall back to age parity for old saves
-        let gender = if sc.gender == 1 {
-            Gender::Female
-        } else {
-            Gender::Male
-        };
-
-        // Restore salary: use saved value if non-zero, otherwise derive from education
-        let salary = if sc.salary != 0.0 {
-            sc.salary
-        } else {
-            CitizenDetails::base_salary_for_education(sc.education)
-        };
-
-        // Restore savings: use saved value if non-zero, otherwise derive from salary
-        let savings = if sc.savings != 0.0 {
-            sc.savings
-        } else {
-            salary * 2.0
-        };
-
-        let cit_entity = commands
-            .spawn((
-                Citizen,
-                CitizenDetails {
-                    age: sc.age,
-                    gender,
-                    happiness: sc.happiness,
-                    health: sc.health,
-                    education: sc.education,
-                    salary,
-                    savings,
-                },
-                CitizenStateComp(restored_state),
-                HomeLocation {
-                    grid_x: sc.home_x,
-                    grid_y: sc.home_y,
-                    building: home_building,
-                },
-                WorkLocation {
-                    grid_x: sc.work_x,
-                    grid_y: sc.work_y,
-                    building: work_building,
-                },
-                Position { x: pos_x, y: pos_y },
-                velocity,
-                path_cache,
-                Personality {
-                    ambition: sc.ambition,
-                    sociability: sc.sociability,
-                    materialism: sc.materialism,
-                    resilience: sc.resilience,
-                },
-                Needs {
-                    hunger: sc.need_hunger,
-                    energy: sc.need_energy,
-                    social: sc.need_social,
-                    fun: sc.need_fun,
-                    comfort: sc.need_comfort,
-                },
-                Family::default(),
-                ActivityTimer(sc.activity_timer),
-                LodTier::default(),
-            ))
-            .id();
-        citizen_entities.push(cit_entity);
-    }
-
-    // Second pass: restore family relationships using saved citizen indices.
-    // Each SaveCitizen stores partner/children/parent as indices into the
-    // citizen array. Convert those indices to the new Entity IDs.
-    let num_citizens = citizen_entities.len();
-    for (i, sc) in save.citizens.iter().enumerate() {
-        let mut family = Family::default();
-        if (sc.family_partner as usize) < num_citizens {
-            family.partner = Some(citizen_entities[sc.family_partner as usize]);
-        }
-        for &child_idx in &sc.family_children {
-            if (child_idx as usize) < num_citizens {
-                family.children.push(citizen_entities[child_idx as usize]);
-            }
-        }
-        if (sc.family_parent as usize) < num_citizens {
-            family.parent = Some(citizen_entities[sc.family_parent as usize]);
-        }
-        // Only update if there are actual relationships to restore
-        if family.partner.is_some() || !family.children.is_empty() || family.parent.is_some() {
-            if let Some(mut ec) = commands.get_entity(citizen_entities[i]) {
-                ec.insert(family);
-            }
-        }
-    }
-
-    // Restore V2 fields (policies, weather, unlocks, extended budget, loans)
-    // If the save is from V1 (fields are None), use defaults.
-    if let Some(ref saved_policies) = save.policies {
-        *v2.policies = restore_policies(saved_policies);
-    } else {
-        *v2.policies = Policies::default();
-    }
-
-    if let Some(ref saved_weather) = save.weather {
-        *v2.weather = restore_weather(saved_weather);
-        *v2.climate_zone = restore_climate_zone(saved_weather);
-    } else {
-        *v2.weather = Weather::default();
-        *v2.climate_zone = ClimateZone::default();
-    }
-
-    if let Some(ref saved_unlocks) = save.unlock_state {
-        *v2.unlock_state = restore_unlock_state(saved_unlocks);
-    } else {
-        *v2.unlock_state = UnlockState::default();
-    }
-
-    if let Some(ref saved_ext_budget) = save.extended_budget {
-        *v2.extended_budget = restore_extended_budget(saved_ext_budget);
-    } else {
-        *v2.extended_budget = ExtendedBudget::default();
-    }
-
-    if let Some(ref saved_loans) = save.loan_book {
-        *v2.loan_book = restore_loan_book(saved_loans);
-    } else {
-        *v2.loan_book = LoanBook::default();
-    }
-
-    // Restore lifecycle timer (prevents mass aging/death burst on load)
-    if let Some(ref saved_timer) = save.lifecycle_timer {
-        **lifecycle_timer = restore_lifecycle_timer(saved_timer);
-    } else {
-        // Old save without lifecycle timer: set last_aging_day to current day
-        // to prevent immediate aging burst on load.
-        lifecycle_timer.last_aging_day = clock.day;
-        lifecycle_timer.last_emigration_tick = 0;
-    }
-
-    // Restore virtual population (prevents population count mismatch on load)
-    if let Some(ref saved_vp) = save.virtual_population {
-        *v2.virtual_population = restore_virtual_population(saved_vp);
-    } else {
-        *v2.virtual_population = VirtualPopulation::default();
-    }
-
-    // Restore life sim timer (prevents all life events firing simultaneously on load)
-    if let Some(ref saved_lst) = save.life_sim_timer {
-        *v2.life_sim_timer = restore_life_sim_timer(saved_lst);
-    } else {
-        *v2.life_sim_timer = LifeSimTimer::default();
-    }
-
-    // Restore stormwater grid
-    if let Some(ref saved_sw) = save.stormwater_grid {
-        *v2.stormwater_grid = restore_stormwater_grid(saved_sw);
-    } else {
-        *v2.stormwater_grid = StormwaterGrid::default();
-    }
-
-    // Restore degree days (HDD/CDD tracking)
-    if let Some(ref saved_dd) = save.degree_days {
-        *v2.degree_days = restore_degree_days(saved_dd);
-    } else {
-        *v2.degree_days = DegreeDays::default();
-    }
-
-    // Restore construction modifiers (recomputed each tick from weather, but
-    // persisting avoids a 1-tick stale value after load).
-    if let Some(ref saved_cm) = save.construction_modifiers {
-        *v2.construction_modifiers = restore_construction_modifiers(saved_cm);
-    } else {
-        *v2.construction_modifiers = ConstructionModifiers::default();
-    }
-
-    // Restore recycling state and economics
-    if let Some(ref saved_recycling) = save.recycling_state {
-        let (rs, re) = restore_recycling(saved_recycling);
-        *v2.recycling_state = rs;
-        *v2.recycling_economics = re;
-    } else {
-        *v2.recycling_state = RecyclingState::default();
-        *v2.recycling_economics = RecyclingEconomics::default();
-    }
-
-    // Restore wind damage state
-    if let Some(ref saved_wds) = save.wind_damage_state {
-        *v2.wind_damage_state = restore_wind_damage_state(saved_wds);
-    } else {
-        *v2.wind_damage_state = WindDamageState::default();
-    }
-
-    // Restore UHI grid
-    if let Some(ref saved_uhi) = save.uhi_grid {
-        *v2.uhi_grid = restore_uhi_grid(saved_uhi);
-    } else {
-        *v2.uhi_grid = UhiGrid::default();
-    }
-
-    // Restore drought state
-    if let Some(ref saved_drought) = save.drought_state {
-        *v2.drought_state = restore_drought(saved_drought);
-    } else {
-        *v2.drought_state = DroughtState::default();
-    }
-
-    // Restore heat wave state
-    if let Some(ref saved_hw) = save.heat_wave_state {
-        *v2.heat_wave_state = restore_heat_wave(saved_hw);
-    } else {
-        *v2.heat_wave_state = HeatWaveState::default();
-    }
-
-    // Restore composting state
-    if let Some(ref saved_cs) = save.composting_state {
-        *v2.composting_state = restore_composting(saved_cs);
-    } else {
-        *v2.composting_state = CompostingState::default();
-    }
-
-    // Restore cold snap state
-    if let Some(ref saved_cs) = save.cold_snap_state {
-        *v2.cold_snap_state = restore_cold_snap(saved_cs);
-    } else {
-        *v2.cold_snap_state = ColdSnapState::default();
-    }
-
-    // Restore water treatment state
-    if let Some(ref wts) = save.water_treatment_state {
-        *v2.water_treatment_state = restore_water_treatment(wts);
-    } else {
-        *v2.water_treatment_state = WaterTreatmentState::default();
-    }
-
-    // Restore groundwater depletion state
-    if let Some(ref gds) = save.groundwater_depletion_state {
-        *v2.groundwater_depletion_state = restore_groundwater_depletion(gds);
-    } else {
-        *v2.groundwater_depletion_state = GroundwaterDepletionState::default();
-    }
-
-    // Restore wastewater state
-    if let Some(ref ws) = save.wastewater_state {
-        *v2.wastewater_state = restore_wastewater(ws);
-    } else {
-        *v2.wastewater_state = WastewaterState::default();
-    }
-
-    // Restore hazardous waste state
-    if let Some(ref hws) = save.hazardous_waste_state {
-        *v2.hazardous_waste_state = restore_hazardous_waste(hws);
-    } else {
-        *v2.hazardous_waste_state = HazardousWasteState::default();
-    }
-
-    // Restore storm drainage state
-    if let Some(ref sds) = save.storm_drainage_state {
-        *v2.storm_drainage_state = restore_storm_drainage(sds);
-    } else {
-        *v2.storm_drainage_state = StormDrainageState::default();
-    }
-
-    // Restore landfill capacity state
-    if let Some(ref lcs) = save.landfill_capacity_state {
-        *v2.landfill_capacity_state = restore_landfill_capacity(lcs);
-    } else {
-        *v2.landfill_capacity_state = LandfillCapacityState::default();
-    }
-
-    // Restore flood state
-    if let Some(ref fs) = save.flood_state {
-        *v2.flood_state = restore_flood_state(fs);
-    }
-    // FloodGrid is transient, always reset to default
-    *v2.flood_grid = FloodGrid::default();
-
-    // Restore reservoir state
-    if let Some(ref rs) = save.reservoir_state {
-        *v2.reservoir_state = restore_reservoir_state(rs);
-    }
-
-    // Restore landfill gas state
-    if let Some(ref lgs) = save.landfill_gas_state {
-        *v2.landfill_gas_state = restore_landfill_gas(lgs);
-    }
-
-    // Restore CSO state
-    if let Some(ref s) = save.cso_state {
-        *v2.cso_state = restore_cso(s);
-    }
-
-    // Restore water conservation state
-    if let Some(ref s) = save.water_conservation_state {
-        *v2.water_conservation_state = restore_water_conservation(s);
-    }
-
-    // Restore fog state
-    if let Some(ref s) = save.fog_state {
-        *v2.fog_state = restore_fog_state(s);
-    }
-
-    // Restore agriculture state
-    if let Some(ref s) = save.agriculture_state {
-        *v2.agriculture_state = restore_agriculture(s);
-    }
-
-    // Restore urban growth boundary
-    if let Some(ref s) = save.urban_growth_boundary {
-        *v2.urban_growth_boundary = restore_urban_growth_boundary(s);
-    } else {
-        *v2.urban_growth_boundary = UrbanGrowthBoundary::default();
-    }
-
-    // Restore snow state
-    if let Some(ref s) = save.snow_state {
-        let (sg, sp) = restore_snow(s);
-        *v2.snow_grid = sg;
-        *v2.snow_plowing_state = sp;
-    } else {
-        *v2.snow_grid = SnowGrid::default();
-        *v2.snow_plowing_state = SnowPlowingState::default();
-    }
-    *v2.snow_stats = SnowStats::default();
-
-    // Store extension map for the exclusive system to apply via SaveableRegistry.
-    // Always enqueue -- even an empty map -- so that registered resources whose
-    // keys are absent get reset to defaults (prevents cross-save contamination).
-    pending_ext.0 = Some(save.extensions.clone());
-}
-
-// ---------------------------------------------------------------------------
-// WASM: async IndexedDB load systems
-// ---------------------------------------------------------------------------
-
-/// Phase 1: consumes `LoadGameEvent` and kicks off an async IndexedDB read.
-#[cfg(target_arch = "wasm32")]
-fn start_wasm_load(mut events: EventReader<LoadGameEvent>, buffer: Res<WasmLoadBuffer>) {
-    for _ in events.read() {
-        let slot = buffer.0.clone();
-        wasm_bindgen_futures::spawn_local(async move {
-            let result = wasm_idb::idb_load().await;
-            *slot.borrow_mut() = Some(result);
-        });
-    }
-}
-
-/// Phase 2: polls the shared buffer; when bytes arrive, fires `WasmLoadReady`.
-#[cfg(target_arch = "wasm32")]
-fn poll_wasm_load(buffer: Res<WasmLoadBuffer>, mut ready_events: EventWriter<WasmLoadReady>) {
-    let mut slot = buffer.0.borrow_mut();
-    if let Some(result) = slot.take() {
-        match result {
-            Ok(bytes) => {
-                ready_events.send(WasmLoadReady(bytes));
-            }
-            Err(e) => {
-                web_sys::console::error_1(&format!("Failed to load from IndexedDB: {}", e).into());
-            }
-        }
-    }
-}
-
-/// Phase 3: restores world state from the bytes loaded by IndexedDB.
-#[cfg(target_arch = "wasm32")]
-#[allow(clippy::too_many_arguments)]
-fn handle_wasm_load_ready(
-    mut events: EventReader<WasmLoadReady>,
-    mut commands: Commands,
-    mut grid: ResMut<WorldGrid>,
-    mut roads: ResMut<RoadNetwork>,
-    mut segments: ResMut<RoadSegmentStore>,
-    mut clock: ResMut<GameClock>,
-    mut budget: ResMut<CityBudget>,
-    mut demand: ResMut<ZoneDemand>,
-    existing: ExistingEntities,
-    mut v2: V2ResourcesWrite,
-    mut lifecycle_timer: ResMut<LifecycleTimer>,
-    mut pending_ext: ResMut<PendingLoadExtensions>,
-) {
-    for event in events.read() {
-        restore_from_bytes(
-            &event.0,
-            &mut commands,
-            &mut grid,
-            &mut roads,
-            &mut segments,
-            &mut clock,
-            &mut budget,
-            &mut demand,
-            &existing,
-            &mut v2,
-            &mut lifecycle_timer,
-            &mut pending_ext,
-        );
-
-        web_sys::console::log_1(&"Loaded save from IndexedDB".into());
-    }
-}
-
-/// Handle "New Game" -- despawn all entities, reset all resources, regenerate world.
-#[allow(clippy::too_many_arguments)]
-fn handle_new_game(
-    mut events: EventReader<NewGameEvent>,
-    mut commands: Commands,
-    existing: ExistingEntities,
-    mut grid: ResMut<WorldGrid>,
-    mut roads: ResMut<RoadNetwork>,
-    mut segments: ResMut<RoadSegmentStore>,
-    mut clock: ResMut<GameClock>,
-    mut budget: ResMut<CityBudget>,
-    mut demand: ResMut<ZoneDemand>,
-    mut v2: V2ResourcesWrite,
-    mut lifecycle_timer: ResMut<LifecycleTimer>,
-    mut pending_reset: ResMut<PendingNewGameReset>,
-) {
-    for _ in events.read() {
-        // Despawn all game entities -- deduplicate to avoid double-despawn when
-        // an entity matches multiple queries (e.g. Citizen + CitizenSprite).
-        for entity in existing.all_entities() {
-            if let Some(mut ec) = commands.get_entity(entity) {
-                ec.despawn();
-            }
-        }
-
-        // Reset world grid to fresh empty terrain
-        let width = grid.width;
-        let height = grid.height;
-        *grid = WorldGrid::new(width, height);
-        *roads = RoadNetwork::default();
-        *segments = RoadSegmentStore::default();
-
-        // Reset clock
-        clock.day = 1;
-        clock.hour = 8.0;
-        clock.speed = 1.0;
-        clock.paused = false;
-
-        // Reset budget to starting money
-        budget.treasury = 50_000.0;
-        budget.tax_rate = 0.10;
-        budget.last_collection_day = 0;
-
-        // Reset demand
-        *demand = ZoneDemand::default();
-
-        // Reset V2 resources
-        *v2.policies = Policies::default();
-        *v2.weather = Weather::default();
-        *v2.climate_zone = ClimateZone::default();
-        *v2.unlock_state = UnlockState::default();
-        *v2.extended_budget = ExtendedBudget::default();
-        *v2.loan_book = LoanBook::default();
-        *v2.virtual_population = VirtualPopulation::default();
-        *lifecycle_timer = LifecycleTimer::default();
-        *v2.life_sim_timer = LifeSimTimer::default();
-        *v2.stormwater_grid = StormwaterGrid::default();
-        *v2.degree_days = DegreeDays::default();
-        *v2.construction_modifiers = ConstructionModifiers::default();
-        *v2.recycling_state = RecyclingState::default();
-        *v2.recycling_economics = RecyclingEconomics::default();
-        *v2.wind_damage_state = WindDamageState::default();
-        *v2.uhi_grid = UhiGrid::default();
-        *v2.drought_state = DroughtState::default();
-        *v2.heat_wave_state = HeatWaveState::default();
-        *v2.composting_state = CompostingState::default();
-        *v2.cold_snap_state = ColdSnapState::default();
-        *v2.water_treatment_state = WaterTreatmentState::default();
-        *v2.groundwater_depletion_state = GroundwaterDepletionState::default();
-        *v2.wastewater_state = WastewaterState::default();
-        *v2.hazardous_waste_state = HazardousWasteState::default();
-        *v2.storm_drainage_state = StormDrainageState::default();
-        *v2.landfill_capacity_state = LandfillCapacityState::default();
-        *v2.flood_state = FloodState::default();
-        *v2.flood_grid = FloodGrid::default();
-        *v2.reservoir_state = ReservoirState::default();
-        *v2.landfill_gas_state = LandfillGasState::default();
-        *v2.cso_state = SewerSystemState::default();
-        *v2.water_conservation_state = WaterConservationState::default();
-        *v2.fog_state = FogState::default();
-        *v2.urban_growth_boundary = UrbanGrowthBoundary::default();
-        *v2.snow_grid = SnowGrid::default();
-        *v2.snow_plowing_state = SnowPlowingState::default();
-        *v2.snow_stats = SnowStats::default();
-        *v2.agriculture_state = AgricultureState::default();
-
-        // Signal the exclusive system to reset extension-registered resources.
-        pending_reset.0 = true;
-
-        // Generate a flat terrain with water on west edge (simple starter map)
-        for y in 0..height {
-            for x in 0..width {
-                let cell = grid.get_mut(x, y);
-                if x < 10 {
-                    cell.cell_type = simulation::grid::CellType::Water;
-                    cell.elevation = 0.3;
-                } else {
-                    cell.cell_type = simulation::grid::CellType::Grass;
-                    cell.elevation = 0.5;
-                }
-            }
-        }
-
-        println!("New game started — blank map with $50,000 treasury");
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Exclusive systems for extension map save/load/reset
-// ---------------------------------------------------------------------------
-
-/// Exclusive system: takes the pending SaveData, populates extensions from the
-/// SaveableRegistry, encodes, and writes the final save file to disk.
-fn flush_save_with_extensions(world: &mut World) {
-    // Take the pending save data (if any).
-    let save_opt = world.resource_mut::<PendingSaveData>().0.take();
-    let Some(mut save) = save_opt else {
-        return;
-    };
-
-    // Temporarily remove the registry so we can read resources from the world
-    // without conflicting borrows.
+    // -- Stage 2: Populate extension map from SaveableRegistry --
+    let mut save = save;
     let registry = world
         .remove_resource::<SaveableRegistry>()
         .expect("SaveableRegistry must exist");
     save.extensions = registry.save_all(world);
     world.insert_resource(registry);
 
-    // Encode and write.
+    // -- Stage 3: Encode and write to disk/IndexedDB --
     let bytes = save.encode();
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -1218,40 +444,841 @@ fn flush_save_with_extensions(world: &mut World) {
             }
         });
     }
+
+    // -- Stage 4: Transition back to Idle --
+    world
+        .resource_mut::<NextState<SaveLoadState>>()
+        .set(SaveLoadState::Idle);
 }
 
-/// Exclusive system: applies pending extension map data to the world via
-/// the SaveableRegistry after `handle_load` has restored all named fields.
-fn apply_load_extensions(world: &mut World) {
-    let ext_opt = world.resource_mut::<PendingLoadExtensions>().0.take();
-    let Some(extensions) = ext_opt else {
+// ---------------------------------------------------------------------------
+// Exclusive load system
+// ---------------------------------------------------------------------------
+
+/// Exclusive system that performs the entire load operation with full world
+/// access.  Entity despawns are immediate (no deferred Commands).
+/// Runs on `OnEnter(SaveLoadState::Loading)`, then transitions back to `Idle`.
+fn exclusive_load(world: &mut World) {
+    // Take pending bytes (either from native file read or WASM IndexedDB).
+    let bytes = world.resource_mut::<PendingLoadBytes>().0.take();
+    let Some(bytes) = bytes else {
+        eprintln!("exclusive_load: no pending bytes — skipping");
+        world
+            .resource_mut::<NextState<SaveLoadState>>()
+            .set(SaveLoadState::Idle);
         return;
     };
 
-    // Temporarily remove the registry from the world so we can iterate its
-    // entries while mutating the world (the entries themselves are never
-    // modified, only the world's other resources).
+    // -- Stage 1: Parse and migrate --
+    let mut save = match SaveData::decode(&bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Failed to decode save: {}", e);
+            world
+                .resource_mut::<NextState<SaveLoadState>>()
+                .set(SaveLoadState::Idle);
+            return;
+        }
+    };
+
+    let old_version = match migrate_save(&mut save) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Save migration failed: {}", e);
+            world
+                .resource_mut::<NextState<SaveLoadState>>()
+                .set(SaveLoadState::Idle);
+            return;
+        }
+    };
+    if old_version != CURRENT_SAVE_VERSION {
+        println!(
+            "Migrated save from v{} to v{}",
+            old_version, CURRENT_SAVE_VERSION
+        );
+    }
+
+    // -- Stage 2: Despawn existing entities (immediate, not deferred) --
+    despawn_all_game_entities(world);
+
+    // -- Stage 3: Restore resources --
+    restore_resources_from_save(world, &save);
+
+    // -- Stage 4: Spawn entities --
+    spawn_entities_from_save(world, &save);
+
+    // -- Stage 5: Apply extension map via SaveableRegistry --
     let registry = world
         .remove_resource::<SaveableRegistry>()
         .expect("SaveableRegistry must exist");
-    registry.load_all(world, &extensions);
+    registry.load_all(world, &save.extensions);
     world.insert_resource(registry);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    println!("Loaded save from {}", save_file_path());
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::log_1(&"Loaded save from IndexedDB".into());
+
+    // -- Stage 6: Transition back to Idle --
+    world
+        .resource_mut::<NextState<SaveLoadState>>()
+        .set(SaveLoadState::Idle);
 }
 
-/// Exclusive system: resets all extension-registered resources to defaults
-/// after `handle_new_game` has reset the named resources.
-fn reset_saveable_extensions(world: &mut World) {
-    let should_reset = world.resource_mut::<PendingNewGameReset>().0;
-    if !should_reset {
-        return;
-    }
-    world.resource_mut::<PendingNewGameReset>().0 = false;
+// ---------------------------------------------------------------------------
+// Exclusive new-game system
+// ---------------------------------------------------------------------------
 
+/// Exclusive system that resets the world for a new game.  Entity despawns
+/// are immediate (no deferred Commands).
+/// Runs on `OnEnter(SaveLoadState::NewGame)`, then transitions back to `Idle`.
+fn exclusive_new_game(world: &mut World) {
+    // -- Stage 1: Despawn existing entities (immediate) --
+    despawn_all_game_entities(world);
+
+    // -- Stage 2: Reset all resources to defaults --
+    reset_all_resources(world);
+
+    // -- Stage 3: Reset extension-registered resources via SaveableRegistry --
     let registry = world
         .remove_resource::<SaveableRegistry>()
         .expect("SaveableRegistry must exist");
     registry.reset_all(world);
     world.insert_resource(registry);
+
+    // -- Stage 4: Generate starter terrain --
+    {
+        let (width, height) = {
+            let grid = world.resource::<WorldGrid>();
+            (grid.width, grid.height)
+        };
+        let mut grid = world.resource_mut::<WorldGrid>();
+        for y in 0..height {
+            for x in 0..width {
+                let cell = grid.get_mut(x, y);
+                if x < 10 {
+                    cell.cell_type = simulation::grid::CellType::Water;
+                    cell.elevation = 0.3;
+                } else {
+                    cell.cell_type = simulation::grid::CellType::Grass;
+                    cell.elevation = 0.5;
+                }
+            }
+        }
+    }
+
+    println!("New game started — blank map with $50,000 treasury");
+
+    // -- Stage 5: Transition back to Idle --
+    world
+        .resource_mut::<NextState<SaveLoadState>>()
+        .set(SaveLoadState::Idle);
+}
+
+// ---------------------------------------------------------------------------
+// Helper: immediate entity despawn
+// ---------------------------------------------------------------------------
+
+/// Collects all game entities (buildings, citizens, utilities, services,
+/// water sources, meshes, sprites) and despawns them immediately using
+/// direct world access.  This avoids the deferred-Commands race condition.
+fn despawn_all_game_entities(world: &mut World) {
+    let mut entities = HashSet::new();
+
+    // Collect entities from each component query.
+    let mut q = world.query_filtered::<Entity, With<Building>>();
+    for e in q.iter(world) {
+        entities.insert(e);
+    }
+    let mut q = world.query_filtered::<Entity, With<Citizen>>();
+    for e in q.iter(world) {
+        entities.insert(e);
+    }
+    let mut q = world.query_filtered::<Entity, With<UtilitySource>>();
+    for e in q.iter(world) {
+        entities.insert(e);
+    }
+    let mut q = world.query_filtered::<Entity, With<ServiceBuilding>>();
+    for e in q.iter(world) {
+        entities.insert(e);
+    }
+    let mut q = world.query_filtered::<Entity, With<WaterSource>>();
+    for e in q.iter(world) {
+        entities.insert(e);
+    }
+    let mut q = world.query_filtered::<Entity, With<BuildingMesh3d>>();
+    for e in q.iter(world) {
+        entities.insert(e);
+    }
+    let mut q = world.query_filtered::<Entity, With<CitizenSprite>>();
+    for e in q.iter(world) {
+        entities.insert(e);
+    }
+
+    // Despawn each entity immediately.
+    for entity in entities {
+        if world.get_entity(entity).is_ok() {
+            world.despawn(entity);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: restore resources from SaveData
+// ---------------------------------------------------------------------------
+
+/// Restores all core resources from a parsed SaveData.
+fn restore_resources_from_save(world: &mut World, save: &SaveData) {
+    // Restore grid
+    {
+        let mut grid = world.resource_mut::<WorldGrid>();
+        *grid = WorldGrid::new(save.grid.width, save.grid.height);
+        for (i, sc) in save.grid.cells.iter().enumerate() {
+            grid.cells[i].elevation = sc.elevation;
+            grid.cells[i].cell_type = match sc.cell_type {
+                1 => simulation::grid::CellType::Water,
+                2 => simulation::grid::CellType::Road,
+                _ => simulation::grid::CellType::Grass,
+            };
+            grid.cells[i].zone = u8_to_zone_type(sc.zone);
+            grid.cells[i].road_type = u8_to_road_type(sc.road_type);
+            grid.cells[i].has_power = sc.has_power;
+            grid.cells[i].has_water = sc.has_water;
+        }
+    }
+
+    // Restore roads - use saved road types, not default Local
+    {
+        let saved_road_types: Vec<(usize, usize, u8)> = save
+            .roads
+            .road_positions
+            .iter()
+            .map(|(x, y)| {
+                let idx = y * save.grid.width + x;
+                let rt = if idx < save.grid.cells.len() {
+                    save.grid.cells[idx].road_type
+                } else {
+                    0
+                };
+                (*x, *y, rt)
+            })
+            .collect();
+
+        *world.resource_mut::<RoadNetwork>() = RoadNetwork::default();
+
+        // Use resource_scope to access both grid and roads mutably
+        // since place_road needs both.
+        world.resource_scope(|world, mut grid: Mut<WorldGrid>| {
+            let mut roads = world.resource_mut::<RoadNetwork>();
+            for (x, y, _) in &saved_road_types {
+                roads.place_road(&mut *grid, *x, *y);
+            }
+            // Restore the saved road types (place_road overwrites with Local)
+            for (x, y, rt) in &saved_road_types {
+                if grid.in_bounds(*x, *y) {
+                    grid.get_mut(*x, *y).road_type = u8_to_road_type(*rt);
+                }
+            }
+        });
+    }
+
+    // Restore road segments (if present in save)
+    {
+        if let Some(ref saved_segments) = save.road_segments {
+            let mut restored = restore_road_segment_store(saved_segments);
+            world.resource_scope(|world, mut grid: Mut<WorldGrid>| {
+                let mut roads = world.resource_mut::<RoadNetwork>();
+                restored.rasterize_all(&mut *grid, &mut *roads);
+            });
+            *world.resource_mut::<RoadSegmentStore>() = restored;
+        } else {
+            *world.resource_mut::<RoadSegmentStore>() = RoadSegmentStore::default();
+        }
+    }
+
+    // Restore clock
+    {
+        let mut clock = world.resource_mut::<GameClock>();
+        clock.day = save.clock.day;
+        clock.hour = save.clock.hour;
+        clock.speed = save.clock.speed;
+        clock.paused = false;
+    }
+
+    // Restore budget
+    {
+        let mut budget = world.resource_mut::<CityBudget>();
+        budget.treasury = save.budget.treasury;
+        budget.tax_rate = save.budget.tax_rate;
+        budget.last_collection_day = save.budget.last_collection_day;
+    }
+
+    // Restore demand
+    {
+        let mut demand = world.resource_mut::<ZoneDemand>();
+        demand.residential = save.demand.residential;
+        demand.commercial = save.demand.commercial;
+        demand.industrial = save.demand.industrial;
+        demand.office = save.demand.office;
+        demand.vacancy_residential = save.demand.vacancy_residential;
+        demand.vacancy_commercial = save.demand.vacancy_commercial;
+        demand.vacancy_industrial = save.demand.vacancy_industrial;
+        demand.vacancy_office = save.demand.vacancy_office;
+    }
+
+    // Restore V2 fields
+    if let Some(ref saved_policies) = save.policies {
+        *world.resource_mut::<Policies>() = restore_policies(saved_policies);
+    } else {
+        *world.resource_mut::<Policies>() = Policies::default();
+    }
+
+    if let Some(ref saved_weather) = save.weather {
+        *world.resource_mut::<Weather>() = restore_weather(saved_weather);
+        *world.resource_mut::<ClimateZone>() = restore_climate_zone(saved_weather);
+    } else {
+        *world.resource_mut::<Weather>() = Weather::default();
+        *world.resource_mut::<ClimateZone>() = ClimateZone::default();
+    }
+
+    if let Some(ref saved_unlocks) = save.unlock_state {
+        *world.resource_mut::<UnlockState>() = restore_unlock_state(saved_unlocks);
+    } else {
+        *world.resource_mut::<UnlockState>() = UnlockState::default();
+    }
+
+    if let Some(ref saved_ext_budget) = save.extended_budget {
+        *world.resource_mut::<ExtendedBudget>() = restore_extended_budget(saved_ext_budget);
+    } else {
+        *world.resource_mut::<ExtendedBudget>() = ExtendedBudget::default();
+    }
+
+    if let Some(ref saved_loans) = save.loan_book {
+        *world.resource_mut::<LoanBook>() = restore_loan_book(saved_loans);
+    } else {
+        *world.resource_mut::<LoanBook>() = LoanBook::default();
+    }
+
+    // Restore lifecycle timer
+    if let Some(ref saved_timer) = save.lifecycle_timer {
+        *world.resource_mut::<LifecycleTimer>() = restore_lifecycle_timer(saved_timer);
+    } else {
+        let day = world.resource::<GameClock>().day;
+        let mut timer = world.resource_mut::<LifecycleTimer>();
+        timer.last_aging_day = day;
+        timer.last_emigration_tick = 0;
+    }
+
+    // Restore virtual population
+    if let Some(ref saved_vp) = save.virtual_population {
+        *world.resource_mut::<VirtualPopulation>() = restore_virtual_population(saved_vp);
+    } else {
+        *world.resource_mut::<VirtualPopulation>() = VirtualPopulation::default();
+    }
+
+    // Restore life sim timer
+    if let Some(ref saved_lst) = save.life_sim_timer {
+        *world.resource_mut::<LifeSimTimer>() = restore_life_sim_timer(saved_lst);
+    } else {
+        *world.resource_mut::<LifeSimTimer>() = LifeSimTimer::default();
+    }
+
+    // Restore stormwater grid
+    if let Some(ref saved_sw) = save.stormwater_grid {
+        *world.resource_mut::<StormwaterGrid>() = restore_stormwater_grid(saved_sw);
+    } else {
+        *world.resource_mut::<StormwaterGrid>() = StormwaterGrid::default();
+    }
+
+    // Restore degree days
+    if let Some(ref saved_dd) = save.degree_days {
+        *world.resource_mut::<DegreeDays>() = restore_degree_days(saved_dd);
+    } else {
+        *world.resource_mut::<DegreeDays>() = DegreeDays::default();
+    }
+
+    // Restore construction modifiers
+    if let Some(ref saved_cm) = save.construction_modifiers {
+        *world.resource_mut::<ConstructionModifiers>() = restore_construction_modifiers(saved_cm);
+    } else {
+        *world.resource_mut::<ConstructionModifiers>() = ConstructionModifiers::default();
+    }
+
+    // Restore recycling state and economics
+    if let Some(ref saved_recycling) = save.recycling_state {
+        let (rs, re) = restore_recycling(saved_recycling);
+        *world.resource_mut::<RecyclingState>() = rs;
+        *world.resource_mut::<RecyclingEconomics>() = re;
+    } else {
+        *world.resource_mut::<RecyclingState>() = RecyclingState::default();
+        *world.resource_mut::<RecyclingEconomics>() = RecyclingEconomics::default();
+    }
+
+    // Restore wind damage state
+    if let Some(ref saved_wds) = save.wind_damage_state {
+        *world.resource_mut::<WindDamageState>() = restore_wind_damage_state(saved_wds);
+    } else {
+        *world.resource_mut::<WindDamageState>() = WindDamageState::default();
+    }
+
+    // Restore UHI grid
+    if let Some(ref saved_uhi) = save.uhi_grid {
+        *world.resource_mut::<UhiGrid>() = restore_uhi_grid(saved_uhi);
+    } else {
+        *world.resource_mut::<UhiGrid>() = UhiGrid::default();
+    }
+
+    // Restore drought state
+    if let Some(ref saved_drought) = save.drought_state {
+        *world.resource_mut::<DroughtState>() = restore_drought(saved_drought);
+    } else {
+        *world.resource_mut::<DroughtState>() = DroughtState::default();
+    }
+
+    // Restore heat wave state
+    if let Some(ref saved_hw) = save.heat_wave_state {
+        *world.resource_mut::<HeatWaveState>() = restore_heat_wave(saved_hw);
+    } else {
+        *world.resource_mut::<HeatWaveState>() = HeatWaveState::default();
+    }
+
+    // Restore composting state
+    if let Some(ref saved_cs) = save.composting_state {
+        *world.resource_mut::<CompostingState>() = restore_composting(saved_cs);
+    } else {
+        *world.resource_mut::<CompostingState>() = CompostingState::default();
+    }
+
+    // Restore cold snap state
+    if let Some(ref saved_cs) = save.cold_snap_state {
+        *world.resource_mut::<ColdSnapState>() = restore_cold_snap(saved_cs);
+    } else {
+        *world.resource_mut::<ColdSnapState>() = ColdSnapState::default();
+    }
+
+    // Restore water treatment state
+    if let Some(ref wts) = save.water_treatment_state {
+        *world.resource_mut::<WaterTreatmentState>() = restore_water_treatment(wts);
+    } else {
+        *world.resource_mut::<WaterTreatmentState>() = WaterTreatmentState::default();
+    }
+
+    // Restore groundwater depletion state
+    if let Some(ref gds) = save.groundwater_depletion_state {
+        *world.resource_mut::<GroundwaterDepletionState>() = restore_groundwater_depletion(gds);
+    } else {
+        *world.resource_mut::<GroundwaterDepletionState>() = GroundwaterDepletionState::default();
+    }
+
+    // Restore wastewater state
+    if let Some(ref ws) = save.wastewater_state {
+        *world.resource_mut::<WastewaterState>() = restore_wastewater(ws);
+    } else {
+        *world.resource_mut::<WastewaterState>() = WastewaterState::default();
+    }
+
+    // Restore hazardous waste state
+    if let Some(ref hws) = save.hazardous_waste_state {
+        *world.resource_mut::<HazardousWasteState>() = restore_hazardous_waste(hws);
+    } else {
+        *world.resource_mut::<HazardousWasteState>() = HazardousWasteState::default();
+    }
+
+    // Restore storm drainage state
+    if let Some(ref sds) = save.storm_drainage_state {
+        *world.resource_mut::<StormDrainageState>() = restore_storm_drainage(sds);
+    } else {
+        *world.resource_mut::<StormDrainageState>() = StormDrainageState::default();
+    }
+
+    // Restore landfill capacity state
+    if let Some(ref lcs) = save.landfill_capacity_state {
+        *world.resource_mut::<LandfillCapacityState>() = restore_landfill_capacity(lcs);
+    } else {
+        *world.resource_mut::<LandfillCapacityState>() = LandfillCapacityState::default();
+    }
+
+    // Restore flood state
+    if let Some(ref fs) = save.flood_state {
+        *world.resource_mut::<FloodState>() = restore_flood_state(fs);
+    }
+    *world.resource_mut::<FloodGrid>() = FloodGrid::default();
+
+    // Restore reservoir state
+    if let Some(ref rs) = save.reservoir_state {
+        *world.resource_mut::<ReservoirState>() = restore_reservoir_state(rs);
+    }
+
+    // Restore landfill gas state
+    if let Some(ref lgs) = save.landfill_gas_state {
+        *world.resource_mut::<LandfillGasState>() = restore_landfill_gas(lgs);
+    }
+
+    // Restore CSO state
+    if let Some(ref s) = save.cso_state {
+        *world.resource_mut::<SewerSystemState>() = restore_cso(s);
+    }
+
+    // Restore water conservation state
+    if let Some(ref s) = save.water_conservation_state {
+        *world.resource_mut::<WaterConservationState>() = restore_water_conservation(s);
+    }
+
+    // Restore fog state
+    if let Some(ref s) = save.fog_state {
+        *world.resource_mut::<FogState>() = restore_fog_state(s);
+    }
+
+    // Restore agriculture state
+    if let Some(ref s) = save.agriculture_state {
+        *world.resource_mut::<AgricultureState>() = restore_agriculture(s);
+    }
+
+    // Restore urban growth boundary
+    if let Some(ref s) = save.urban_growth_boundary {
+        *world.resource_mut::<UrbanGrowthBoundary>() = restore_urban_growth_boundary(s);
+    } else {
+        *world.resource_mut::<UrbanGrowthBoundary>() = UrbanGrowthBoundary::default();
+    }
+
+    // Restore snow state
+    if let Some(ref s) = save.snow_state {
+        let (sg, sp) = restore_snow(s);
+        *world.resource_mut::<SnowGrid>() = sg;
+        *world.resource_mut::<SnowPlowingState>() = sp;
+    } else {
+        *world.resource_mut::<SnowGrid>() = SnowGrid::default();
+        *world.resource_mut::<SnowPlowingState>() = SnowPlowingState::default();
+    }
+    *world.resource_mut::<SnowStats>() = SnowStats::default();
+}
+
+// ---------------------------------------------------------------------------
+// Helper: spawn entities from SaveData
+// ---------------------------------------------------------------------------
+
+/// Spawns all game entities from a parsed SaveData using direct world access.
+fn spawn_entities_from_save(world: &mut World, save: &SaveData) {
+    // Spawn buildings
+    for sb in &save.buildings {
+        let zone = u8_to_zone_type(sb.zone_type);
+        let building = Building {
+            zone_type: zone,
+            level: sb.level,
+            grid_x: sb.grid_x,
+            grid_y: sb.grid_y,
+            capacity: sb.capacity,
+            occupants: sb.occupants,
+        };
+        let entity = if zone.is_mixed_use() {
+            let (comm_cap, res_cap) = if sb.commercial_capacity > 0 || sb.residential_capacity > 0 {
+                (sb.commercial_capacity, sb.residential_capacity)
+            } else {
+                MixedUseBuilding::capacities_for_level(sb.level)
+            };
+            world
+                .spawn((
+                    building,
+                    MixedUseBuilding {
+                        commercial_capacity: comm_cap,
+                        commercial_occupants: sb.commercial_occupants,
+                        residential_capacity: res_cap,
+                        residential_occupants: sb.residential_occupants,
+                    },
+                ))
+                .id()
+        } else {
+            world.spawn(building).id()
+        };
+        let mut grid = world.resource_mut::<WorldGrid>();
+        if grid.in_bounds(sb.grid_x, sb.grid_y) {
+            grid.get_mut(sb.grid_x, sb.grid_y).building_id = Some(entity);
+        }
+    }
+
+    // Spawn utility sources
+    for su in &save.utility_sources {
+        let ut = u8_to_utility_type(su.utility_type);
+        world.spawn(UtilitySource {
+            utility_type: ut,
+            grid_x: su.grid_x,
+            grid_y: su.grid_y,
+            range: su.range,
+        });
+    }
+
+    // Spawn service buildings
+    for ss in &save.service_buildings {
+        if let Some(service_type) = u8_to_service_type(ss.service_type) {
+            let radius = ServiceBuilding::coverage_radius(service_type);
+            let entity = world
+                .spawn(ServiceBuilding {
+                    service_type,
+                    grid_x: ss.grid_x,
+                    grid_y: ss.grid_y,
+                    radius,
+                })
+                .id();
+            let mut grid = world.resource_mut::<WorldGrid>();
+            if grid.in_bounds(ss.grid_x, ss.grid_y) {
+                grid.get_mut(ss.grid_x, ss.grid_y).building_id = Some(entity);
+            }
+        }
+    }
+
+    // Spawn water sources
+    if let Some(ref saved_water_sources) = save.water_sources {
+        for sws in saved_water_sources {
+            if let Some(ws) = restore_water_source(sws) {
+                let entity = world.spawn(ws).id();
+                let mut grid = world.resource_mut::<WorldGrid>();
+                if grid.in_bounds(sws.grid_x, sws.grid_y) {
+                    grid.get_mut(sws.grid_x, sws.grid_y).building_id = Some(entity);
+                }
+            }
+        }
+    }
+
+    // Spawn citizens
+    let mut citizen_entities: Vec<Entity> = Vec::with_capacity(save.citizens.len());
+    {
+        let grid = world.resource::<WorldGrid>();
+        // Pre-compute all citizen data (to avoid repeated grid lookups while
+        // world is borrowed mutably for spawning).
+        let citizen_spawn_data: Vec<_> = save
+            .citizens
+            .iter()
+            .map(|sc| {
+                let state = match sc.state {
+                    1 => CitizenState::CommutingToWork,
+                    2 => CitizenState::Working,
+                    3 => CitizenState::CommutingHome,
+                    4 => CitizenState::CommutingToShop,
+                    5 => CitizenState::Shopping,
+                    6 => CitizenState::CommutingToLeisure,
+                    7 => CitizenState::AtLeisure,
+                    8 => CitizenState::CommutingToSchool,
+                    9 => CitizenState::AtSchool,
+                    _ => CitizenState::AtHome,
+                };
+
+                let home_building = if grid.in_bounds(sc.home_x, sc.home_y) {
+                    grid.get(sc.home_x, sc.home_y)
+                        .building_id
+                        .unwrap_or(Entity::PLACEHOLDER)
+                } else {
+                    Entity::PLACEHOLDER
+                };
+
+                let work_building = if grid.in_bounds(sc.work_x, sc.work_y) {
+                    grid.get(sc.work_x, sc.work_y)
+                        .building_id
+                        .unwrap_or(Entity::PLACEHOLDER)
+                } else {
+                    Entity::PLACEHOLDER
+                };
+
+                let (pos_x, pos_y) = if sc.pos_x != 0.0 || sc.pos_y != 0.0 {
+                    (sc.pos_x, sc.pos_y)
+                } else {
+                    WorldGrid::grid_to_world(sc.home_x, sc.home_y)
+                };
+
+                let (path_cache, restored_state) = {
+                    let waypoints: Vec<RoadNode> = sc
+                        .path_waypoints
+                        .iter()
+                        .map(|&(x, y)| RoadNode(x, y))
+                        .collect();
+
+                    let all_valid = waypoints.iter().all(|n| grid.in_bounds(n.0, n.1));
+
+                    if !waypoints.is_empty() && all_valid {
+                        let mut pc = PathCache::new(waypoints);
+                        pc.current_index = sc.path_current_index;
+                        (pc, state)
+                    } else if state.is_commuting() {
+                        (PathCache::new(vec![]), CitizenState::AtHome)
+                    } else {
+                        (PathCache::new(vec![]), state)
+                    }
+                };
+
+                let velocity = Velocity {
+                    x: sc.velocity_x,
+                    y: sc.velocity_y,
+                };
+
+                let gender = if sc.gender == 1 {
+                    Gender::Female
+                } else {
+                    Gender::Male
+                };
+
+                let salary = if sc.salary != 0.0 {
+                    sc.salary
+                } else {
+                    CitizenDetails::base_salary_for_education(sc.education)
+                };
+
+                let savings = if sc.savings != 0.0 {
+                    sc.savings
+                } else {
+                    salary * 2.0
+                };
+
+                (
+                    Citizen,
+                    CitizenDetails {
+                        age: sc.age,
+                        gender,
+                        happiness: sc.happiness,
+                        health: sc.health,
+                        education: sc.education,
+                        salary,
+                        savings,
+                    },
+                    CitizenStateComp(restored_state),
+                    HomeLocation {
+                        grid_x: sc.home_x,
+                        grid_y: sc.home_y,
+                        building: home_building,
+                    },
+                    WorkLocation {
+                        grid_x: sc.work_x,
+                        grid_y: sc.work_y,
+                        building: work_building,
+                    },
+                    Position { x: pos_x, y: pos_y },
+                    velocity,
+                    path_cache,
+                    Personality {
+                        ambition: sc.ambition,
+                        sociability: sc.sociability,
+                        materialism: sc.materialism,
+                        resilience: sc.resilience,
+                    },
+                    Needs {
+                        hunger: sc.need_hunger,
+                        energy: sc.need_energy,
+                        social: sc.need_social,
+                        fun: sc.need_fun,
+                        comfort: sc.need_comfort,
+                    },
+                    Family::default(),
+                    ActivityTimer(sc.activity_timer),
+                    LodTier::default(),
+                )
+            })
+            .collect();
+
+        // Drop grid borrow before spawning
+        drop(grid);
+
+        // Spawn citizens
+        for data in citizen_spawn_data {
+            let entity = world.spawn(data).id();
+            citizen_entities.push(entity);
+        }
+    }
+
+    // Second pass: restore family relationships using saved citizen indices.
+    let num_citizens = citizen_entities.len();
+    for (i, sc) in save.citizens.iter().enumerate() {
+        let mut family = Family::default();
+        if (sc.family_partner as usize) < num_citizens {
+            family.partner = Some(citizen_entities[sc.family_partner as usize]);
+        }
+        for &child_idx in &sc.family_children {
+            if (child_idx as usize) < num_citizens {
+                family.children.push(citizen_entities[child_idx as usize]);
+            }
+        }
+        if (sc.family_parent as usize) < num_citizens {
+            family.parent = Some(citizen_entities[sc.family_parent as usize]);
+        }
+        if family.partner.is_some() || !family.children.is_empty() || family.parent.is_some() {
+            if let Ok(mut entity_mut) = world.get_entity_mut(citizen_entities[i]) {
+                entity_mut.insert(family);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: reset all resources for new game
+// ---------------------------------------------------------------------------
+
+fn reset_all_resources(world: &mut World) {
+    {
+        let (width, height) = {
+            let grid = world.resource::<WorldGrid>();
+            (grid.width, grid.height)
+        };
+        *world.resource_mut::<WorldGrid>() = WorldGrid::new(width, height);
+    }
+    *world.resource_mut::<RoadNetwork>() = RoadNetwork::default();
+    *world.resource_mut::<RoadSegmentStore>() = RoadSegmentStore::default();
+
+    // Reset clock
+    {
+        let mut clock = world.resource_mut::<GameClock>();
+        clock.day = 1;
+        clock.hour = 8.0;
+        clock.speed = 1.0;
+        clock.paused = false;
+    }
+
+    // Reset budget
+    {
+        let mut budget = world.resource_mut::<CityBudget>();
+        budget.treasury = 50_000.0;
+        budget.tax_rate = 0.10;
+        budget.last_collection_day = 0;
+    }
+
+    // Reset demand
+    *world.resource_mut::<ZoneDemand>() = ZoneDemand::default();
+
+    // Reset V2 resources
+    *world.resource_mut::<Policies>() = Policies::default();
+    *world.resource_mut::<Weather>() = Weather::default();
+    *world.resource_mut::<ClimateZone>() = ClimateZone::default();
+    *world.resource_mut::<UnlockState>() = UnlockState::default();
+    *world.resource_mut::<ExtendedBudget>() = ExtendedBudget::default();
+    *world.resource_mut::<LoanBook>() = LoanBook::default();
+    *world.resource_mut::<VirtualPopulation>() = VirtualPopulation::default();
+    *world.resource_mut::<LifecycleTimer>() = LifecycleTimer::default();
+    *world.resource_mut::<LifeSimTimer>() = LifeSimTimer::default();
+    *world.resource_mut::<StormwaterGrid>() = StormwaterGrid::default();
+    *world.resource_mut::<DegreeDays>() = DegreeDays::default();
+    *world.resource_mut::<ConstructionModifiers>() = ConstructionModifiers::default();
+    *world.resource_mut::<RecyclingState>() = RecyclingState::default();
+    *world.resource_mut::<RecyclingEconomics>() = RecyclingEconomics::default();
+    *world.resource_mut::<WindDamageState>() = WindDamageState::default();
+    *world.resource_mut::<UhiGrid>() = UhiGrid::default();
+    *world.resource_mut::<DroughtState>() = DroughtState::default();
+    *world.resource_mut::<HeatWaveState>() = HeatWaveState::default();
+    *world.resource_mut::<CompostingState>() = CompostingState::default();
+    *world.resource_mut::<ColdSnapState>() = ColdSnapState::default();
+    *world.resource_mut::<WaterTreatmentState>() = WaterTreatmentState::default();
+    *world.resource_mut::<GroundwaterDepletionState>() = GroundwaterDepletionState::default();
+    *world.resource_mut::<WastewaterState>() = WastewaterState::default();
+    *world.resource_mut::<HazardousWasteState>() = HazardousWasteState::default();
+    *world.resource_mut::<StormDrainageState>() = StormDrainageState::default();
+    *world.resource_mut::<LandfillCapacityState>() = LandfillCapacityState::default();
+    *world.resource_mut::<FloodState>() = FloodState::default();
+    *world.resource_mut::<FloodGrid>() = FloodGrid::default();
+    *world.resource_mut::<ReservoirState>() = ReservoirState::default();
+    *world.resource_mut::<LandfillGasState>() = LandfillGasState::default();
+    *world.resource_mut::<SewerSystemState>() = SewerSystemState::default();
+    *world.resource_mut::<WaterConservationState>() = WaterConservationState::default();
+    *world.resource_mut::<FogState>() = FogState::default();
+    *world.resource_mut::<UrbanGrowthBoundary>() = UrbanGrowthBoundary::default();
+    *world.resource_mut::<SnowGrid>() = SnowGrid::default();
+    *world.resource_mut::<SnowPlowingState>() = SnowPlowingState::default();
+    *world.resource_mut::<SnowStats>() = SnowStats::default();
+    *world.resource_mut::<AgricultureState>() = AgricultureState::default();
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/simulation/src/lib.rs
+++ b/crates/simulation/src/lib.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use std::collections::BTreeMap;
 
+pub use save_load_state::SaveLoadState;
 pub use simulation_sets::{SimulationSet, SimulationUpdateSet};
 
 pub mod abandonment;
@@ -89,6 +90,7 @@ pub mod road_graph_csr;
 pub mod road_maintenance;
 pub mod road_segments;
 pub mod roads;
+pub mod save_load_state;
 pub mod seasonal_rendering;
 pub mod services;
 pub mod simulation_sets;
@@ -393,23 +395,31 @@ impl Plugin for SimulationPlugin {
     fn build(&self, app: &mut App) {
         // -- Deterministic phase ordering ----------------------------------------
         // FixedUpdate: PreSim → Simulation → PostSim
+        // Gate simulation sets on SaveLoadState::Idle so that gameplay systems
+        // are automatically suspended during save/load/new-game operations.
+        let idle = in_state(SaveLoadState::Idle);
         app.configure_sets(
             FixedUpdate,
             (
-                SimulationSet::PreSim,
-                SimulationSet::Simulation,
-                SimulationSet::PostSim,
+                SimulationSet::PreSim.run_if(idle.clone()),
+                SimulationSet::Simulation.run_if(idle.clone()),
+                SimulationSet::PostSim.run_if(idle.clone()),
             )
                 .chain(),
         );
         // Update: Input → Visual
         app.configure_sets(
             Update,
-            (SimulationUpdateSet::Input, SimulationUpdateSet::Visual).chain(),
+            (
+                SimulationUpdateSet::Input.run_if(idle.clone()),
+                SimulationUpdateSet::Visual.run_if(idle),
+            )
+                .chain(),
         );
 
         // Core resources and systems that don't belong to any feature
-        app.init_resource::<TickCounter>()
+        app.init_state::<SaveLoadState>()
+            .init_resource::<TickCounter>()
             .init_resource::<SlowTickTimer>()
             .init_resource::<CsrGraph>()
             .init_resource::<RoadSegmentStore>()

--- a/crates/simulation/src/save_load_state.rs
+++ b/crates/simulation/src/save_load_state.rs
@@ -1,0 +1,32 @@
+//! Global save/load state machine.
+//!
+//! Defines [`SaveLoadState`], a Bevy [`States`] enum that isolates save/load
+//! operations from gameplay.  Gameplay systems should only run while the state
+//! is [`SaveLoadState::Idle`]; the save crate transitions through the other
+//! variants when a save, load, or new-game operation is in progress.
+//!
+//! The state is defined here (in the `simulation` crate) rather than in `save`
+//! so that simulation systems can add `run_if(in_state(SaveLoadState::Idle))`
+//! guards without introducing a circular dependency.
+
+use bevy::prelude::*;
+
+/// Top-level state governing whether a save/load operation is in progress.
+///
+/// When the state is anything other than `Idle`, gameplay and rendering
+/// systems should be suspended.  The save plugin enters the appropriate
+/// non-idle state when an event is received, performs all work in an
+/// exclusive system (so despawns/spawns apply immediately), then transitions
+/// back to `Idle`.
+#[derive(States, Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum SaveLoadState {
+    /// Normal gameplay — no save/load operation in progress.
+    #[default]
+    Idle,
+    /// A save operation is in progress.
+    Saving,
+    /// A load operation is in progress.
+    Loading,
+    /// A new-game reset is in progress.
+    NewGame,
+}

--- a/crates/simulation/src/test_harness.rs
+++ b/crates/simulation/src/test_harness.rs
@@ -5,6 +5,7 @@
 
 use bevy::app::App;
 use bevy::prelude::*;
+use bevy::state::app::StatesPlugin;
 
 use crate::buildings::Building;
 use crate::bulldoze_refund;
@@ -47,6 +48,7 @@ impl TestCity {
     pub fn new() -> Self {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
+        app.add_plugins(StatesPlugin);
 
         // Insert the marker BEFORE SimulationPlugin so init_world skips.
         app.insert_resource(SkipWorldInit);
@@ -93,6 +95,7 @@ impl TestCity {
     pub fn with_tel_aviv() -> Self {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
+        app.add_plugins(StatesPlugin);
         // Skip the tutorial so it doesn't pause the GameClock on first update.
         app.insert_resource(TutorialState {
             completed: true,


### PR DESCRIPTION
## Summary

- Add `SaveLoadState` Bevy State (`Idle`/`Saving`/`Loading`/`NewGame`) to isolate save/load operations from gameplay systems
- Convert all save/load/new-game handlers from deferred `Commands` systems to **exclusive systems** (`&mut World`) that despawn and spawn entities immediately — eliminates the race condition where gameplay systems could observe partially torn-down state
- Gate all simulation `FixedUpdate` and `Update` sets on `SaveLoadState::Idle` so gameplay systems are automatically suspended during save/load operations
- Each operation follows a staged pipeline: parse/migrate → despawn (immediate) → restore resources → spawn entities → apply extensions → transition back to Idle

### Technical details

The root cause of "entity not found" errors during load/new-game was that `Commands`-based despawns are deferred until end-of-stage, but other systems in the same `Update` frame could queue overlapping entity operations on entities about to be despawned.

This PR addresses it at two levels:
1. **Exclusive systems**: `world.despawn(entity)` and `world.spawn(bundle)` apply immediately before any other systems can observe intermediate state
2. **State machine isolation**: gameplay systems are fully suspended while any save/load operation is in progress, preventing any possibility of racing

## Test plan

- [ ] CI passes (build, test, clippy, fmt)
- [ ] Load/save round-trip works without "entity not found" errors
- [ ] New game starts cleanly with no stale entities
- [ ] Gameplay systems resume normally after save/load completes

Closes #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)