### PR TITLE
WASM hardening: CI compile check and storage quota errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,19 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+  wasm-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm
+
+      - name: Check WASM compilation
+        run: cargo check --target wasm32-unknown-unknown -p megacity


### PR DESCRIPTION
## Summary
- Add `wasm-check` CI job that compiles the app for `wasm32-unknown-unknown` to catch WASM-breaking changes early (informational only, not a required check)
- Add `WasmStorageError` enum with `QuotaExceeded` variant to detect when IndexedDB storage quota is exceeded
- Surface save failures to players via the existing notification system with user-friendly messages (e.g., "Save failed: storage full. Try deleting old saves or clearing browser data.")
- Add `WasmSaveErrorBuffer` resource to bridge async IndexedDB errors back to the Bevy ECS

Closes #1246

## Test plan
- [ ] Verify `wasm-check` CI job passes (cargo check for wasm32 target)
- [ ] Verify existing `test` and `fmt` CI jobs still pass
- [ ] On WASM: save game works normally when storage is available
- [ ] On WASM: when storage quota is exceeded, a warning notification appears in the ticker

🤖 Generated with [Claude Code](https://claude.com/claude-code)