### PR TITLE
Add unit tests for SpatialIndex (TEST-053)

### DIFF
--- a/crates/simulation/src/movement.rs
+++ b/crates/simulation/src/movement.rs
@@ -781,3 +781,159 @@ impl Plugin for MovementPlugin {
             );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // find_nearest: basic nearest lookup
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_find_nearest_returns_closest_destination() {
+        let spots = vec![(10, 10), (20, 20), (5, 5), (50, 50)];
+        let result = find_nearest(&spots, 6, 6, 30);
+        assert_eq!(
+            result,
+            Some((5, 5)),
+            "should return (5,5) as closest to (6,6)"
+        );
+    }
+
+    #[test]
+    fn test_find_nearest_empty_returns_none() {
+        let spots: Vec<(usize, usize)> = vec![];
+        let result = find_nearest(&spots, 10, 10, 100);
+        assert_eq!(result, None, "empty destination list should return None");
+    }
+
+    #[test]
+    fn test_find_nearest_all_beyond_max_dist_returns_none() {
+        let spots = vec![(100, 100), (200, 200)];
+        let result = find_nearest(&spots, 0, 0, 10);
+        assert_eq!(result, None, "all spots beyond max_dist should return None");
+    }
+
+    // ------------------------------------------------------------------
+    // find_nearest: multiple destinations correct closest
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_find_nearest_multiple_destinations_various_query_points() {
+        let spots = vec![(10, 10), (50, 50), (90, 90), (200, 200)];
+
+        // From (12, 12): closest is (10, 10) with Manhattan dist 4
+        assert_eq!(find_nearest(&spots, 12, 12, 100), Some((10, 10)));
+
+        // From (48, 52): closest is (50, 50) with Manhattan dist 4
+        assert_eq!(find_nearest(&spots, 48, 52, 100), Some((50, 50)));
+
+        // From (88, 91): closest is (90, 90) with Manhattan dist 3
+        assert_eq!(find_nearest(&spots, 88, 91, 100), Some((90, 90)));
+
+        // From (199, 201): closest is (200, 200) with Manhattan dist 2
+        assert_eq!(find_nearest(&spots, 199, 201, 250), Some((200, 200)));
+    }
+
+    // ------------------------------------------------------------------
+    // find_nearest: exact position match
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_find_nearest_exact_match() {
+        let spots = vec![(10, 10), (20, 20)];
+        let result = find_nearest(&spots, 10, 10, 30);
+        assert_eq!(
+            result,
+            Some((10, 10)),
+            "querying from an exact destination position should return it"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // find_nearest: max_dist boundary
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_find_nearest_at_exact_max_dist_boundary() {
+        let spots = vec![(15, 15)];
+        // Manhattan distance from (10, 10) to (15, 15) = 10
+        let result = find_nearest(&spots, 10, 10, 10);
+        assert_eq!(
+            result,
+            Some((15, 15)),
+            "spot at exactly max_dist should be included"
+        );
+
+        // max_dist = 9 -> should exclude
+        let result2 = find_nearest(&spots, 10, 10, 9);
+        assert_eq!(
+            result2, None,
+            "spot at dist 10 with max_dist 9 should be excluded"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // find_nearest: tiebreaker (min_by_key picks first minimum)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_find_nearest_equidistant_returns_first() {
+        // Two spots equidistant from query point
+        let spots = vec![(10, 12), (12, 10)];
+        // Manhattan dist from (11, 11): |10-11|+|12-11|=2 and |12-11|+|10-11|=2
+        let result = find_nearest(&spots, 11, 11, 30);
+        // min_by_key returns the first encountered minimum
+        assert_eq!(
+            result,
+            Some((10, 12)),
+            "should return first equidistant spot"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // find_nearest: single destination within range
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_find_nearest_single_spot_in_range() {
+        let spots = vec![(100, 100)];
+        let result = find_nearest(&spots, 95, 95, 20);
+        assert_eq!(result, Some((100, 100)));
+    }
+
+    // ------------------------------------------------------------------
+    // find_nearest: grid edge positions (boundary conditions)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_find_nearest_at_grid_edges() {
+        let spots = vec![(0, 0), (255, 255), (0, 255), (255, 0)];
+
+        // From origin, closest is (0, 0)
+        assert_eq!(find_nearest(&spots, 0, 0, 30), Some((0, 0)));
+
+        // From max corner, closest is (255, 255)
+        assert_eq!(find_nearest(&spots, 255, 255, 30), Some((255, 255)));
+
+        // From (1, 254), closest is (0, 255) with dist 2
+        assert_eq!(find_nearest(&spots, 1, 254, 30), Some((0, 255)));
+    }
+
+    // ------------------------------------------------------------------
+    // find_nearest: large max_dist covers all
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_find_nearest_large_max_dist_returns_closest() {
+        let spots = vec![(10, 10), (200, 200)];
+        // Even with a huge max_dist, we should still get the closest
+        let result = find_nearest(&spots, 12, 12, 1000);
+        assert_eq!(
+            result,
+            Some((10, 10)),
+            "should return closest even with large max_dist"
+        );
+    }
+}

--- a/crates/simulation/src/spatial_grid.rs
+++ b/crates/simulation/src/spatial_grid.rs
@@ -70,6 +70,13 @@ impl SpatialGrid {
 mod tests {
     use super::*;
 
+    // World is 4096x4096 pixels (256 grid cells * 16.0 CELL_SIZE)
+    // Buckets are 128x128 pixels, giving 33x33 buckets
+
+    // ------------------------------------------------------------------
+    // Basic insertion and querying
+    // ------------------------------------------------------------------
+
     #[test]
     fn test_spatial_insert_query() {
         let mut grid = SpatialGrid::default();
@@ -94,6 +101,416 @@ mod tests {
         assert_eq!(grid.entity_count(), 1);
 
         grid.clear();
+        assert_eq!(grid.entity_count(), 0);
+    }
+
+    // ------------------------------------------------------------------
+    // Empty grid returns no results
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_empty_grid_query_returns_empty() {
+        let grid = SpatialGrid::default();
+        let result = grid.query_rect(0.0, 0.0, 4096.0, 4096.0);
+        assert!(
+            result.is_empty(),
+            "querying an empty grid should return no entities"
+        );
+    }
+
+    #[test]
+    fn test_empty_grid_entity_count_is_zero() {
+        let grid = SpatialGrid::default();
+        assert_eq!(grid.entity_count(), 0);
+    }
+
+    // ------------------------------------------------------------------
+    // Nearest lookup: query_rect returns closest entity in bucket
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_nearest_lookup_returns_closest_entity() {
+        // Insert several entities; query a small rect around a point
+        // to find the closest one (simulating nearest-lookup via rect query).
+        let mut grid = SpatialGrid::default();
+        let close = Entity::from_raw(10);
+        let medium = Entity::from_raw(20);
+        let far = Entity::from_raw(30);
+
+        // Place entities at increasing distances from (100, 100)
+        grid.insert(close, 110.0, 110.0); // ~14 pixels away
+        grid.insert(medium, 200.0, 200.0); // ~141 pixels away
+        grid.insert(far, 500.0, 500.0); // ~566 pixels away
+
+        // Small rect around (100, 100) should find only the close entity
+        // close is at (110, 110), in bucket (0, 0) (since 110/128 = 0)
+        // A rect from (80, 80) to (127, 127) covers only bucket (0, 0)
+        let result = grid.query_rect(80.0, 80.0, 127.0, 127.0);
+        assert!(
+            result.contains(&close),
+            "close entity should be in the small rect"
+        );
+        assert!(
+            !result.contains(&medium),
+            "medium entity should not be in the small rect"
+        );
+        assert!(
+            !result.contains(&far),
+            "far entity should not be in the small rect"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Multiple destinations: correct closest for various query points
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_multiple_destinations_correct_closest() {
+        let mut grid = SpatialGrid::default();
+
+        // Place entities in distinct buckets across the map
+        let nw = Entity::from_raw(1); // northwest corner
+        let ne = Entity::from_raw(2); // northeast corner
+        let sw = Entity::from_raw(3); // southwest corner
+        let se = Entity::from_raw(4); // southeast corner
+        let center = Entity::from_raw(5); // center
+
+        grid.insert(nw, 64.0, 64.0); // bucket (0, 0)
+        grid.insert(ne, 3900.0, 64.0); // bucket (30, 0)
+        grid.insert(sw, 64.0, 3900.0); // bucket (0, 30)
+        grid.insert(se, 3900.0, 3900.0); // bucket (30, 30)
+        grid.insert(center, 2048.0, 2048.0); // bucket (16, 16)
+
+        // Query near northwest corner - should only find nw
+        let nw_result = grid.query_rect(0.0, 0.0, 127.0, 127.0);
+        assert!(nw_result.contains(&nw));
+        assert_eq!(nw_result.len(), 1);
+
+        // Query near northeast corner - should only find ne
+        let ne_result = grid.query_rect(3840.0, 0.0, 3967.0, 127.0);
+        assert!(ne_result.contains(&ne));
+        assert_eq!(ne_result.len(), 1);
+
+        // Query near center - should only find center
+        let center_result = grid.query_rect(2000.0, 2000.0, 2100.0, 2100.0);
+        assert!(center_result.contains(&center));
+        assert_eq!(center_result.len(), 1);
+
+        // Query the entire world - should find all 5
+        let all_result = grid.query_rect(0.0, 0.0, 4095.0, 4095.0);
+        assert_eq!(all_result.len(), 5);
+    }
+
+    // ------------------------------------------------------------------
+    // All destinations within radius (rect approximation)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_all_destinations_within_radius_found() {
+        let mut grid = SpatialGrid::default();
+
+        // Place a cluster of entities around (500, 500)
+        let e1 = Entity::from_raw(1);
+        let e2 = Entity::from_raw(2);
+        let e3 = Entity::from_raw(3);
+        let e4 = Entity::from_raw(4);
+        let e_far = Entity::from_raw(5);
+
+        grid.insert(e1, 480.0, 480.0);
+        grid.insert(e2, 500.0, 520.0);
+        grid.insert(e3, 520.0, 490.0);
+        grid.insert(e4, 510.0, 510.0);
+        grid.insert(e_far, 2000.0, 2000.0); // far away
+
+        // Query a 200x200 rect centered on (500, 500)
+        let result = grid.query_rect(400.0, 400.0, 600.0, 600.0);
+        assert!(result.contains(&e1), "e1 should be in radius");
+        assert!(result.contains(&e2), "e2 should be in radius");
+        assert!(result.contains(&e3), "e3 should be in radius");
+        assert!(result.contains(&e4), "e4 should be in radius");
+        assert!(!result.contains(&e_far), "e_far should not be in radius");
+        assert_eq!(result.len(), 4);
+    }
+
+    // ------------------------------------------------------------------
+    // Boundary conditions
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_boundary_insert_at_origin() {
+        let mut grid = SpatialGrid::default();
+        let e = Entity::from_raw(1);
+        grid.insert(e, 0.0, 0.0);
+        assert_eq!(grid.entity_count(), 1);
+        let result = grid.query_rect(0.0, 0.0, 1.0, 1.0);
+        assert!(result.contains(&e));
+    }
+
+    #[test]
+    fn test_boundary_insert_at_max_world_edge() {
+        let mut grid = SpatialGrid::default();
+        let e = Entity::from_raw(1);
+        // Place entity near the maximum world coordinate
+        let max_coord = (GRID_WIDTH as f32 * CELL_SIZE) - 1.0; // 4095.0
+        grid.insert(e, max_coord, max_coord);
+        assert_eq!(grid.entity_count(), 1);
+        let result = grid.query_rect(max_coord - 10.0, max_coord - 10.0, max_coord, max_coord);
+        assert!(result.contains(&e));
+    }
+
+    #[test]
+    fn test_boundary_negative_coordinates_ignored() {
+        let mut grid = SpatialGrid::default();
+        let e = Entity::from_raw(1);
+        // Negative coords should fall outside valid bucket range
+        grid.insert(e, -10.0, -10.0);
+        // Entity should not be inserted (flat_index returns None for negative)
+        assert_eq!(grid.entity_count(), 0);
+    }
+
+    #[test]
+    fn test_boundary_beyond_world_coordinates_ignored() {
+        let mut grid = SpatialGrid::default();
+        let e = Entity::from_raw(1);
+        // Way beyond the world boundary
+        grid.insert(e, 10000.0, 10000.0);
+        // Entity should not be inserted (flat_index returns None)
+        assert_eq!(grid.entity_count(), 0);
+    }
+
+    #[test]
+    fn test_boundary_exact_bucket_edge() {
+        let mut grid = SpatialGrid::default();
+        let e1 = Entity::from_raw(1);
+        let e2 = Entity::from_raw(2);
+
+        // Place entities right at bucket boundary (128.0)
+        grid.insert(e1, 127.9, 127.9); // bucket (0, 0)
+        grid.insert(e2, 128.0, 128.0); // bucket (1, 1)
+
+        // Query only bucket (0, 0)
+        let result = grid.query_rect(0.0, 0.0, 127.0, 127.0);
+        assert!(
+            result.contains(&e1),
+            "e1 at 127.9 should be in bucket (0,0)"
+        );
+        assert!(
+            !result.contains(&e2),
+            "e2 at 128.0 should be in bucket (1,1), not (0,0)"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Overlapping positions
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_overlapping_positions_all_returned() {
+        let mut grid = SpatialGrid::default();
+        let e1 = Entity::from_raw(1);
+        let e2 = Entity::from_raw(2);
+        let e3 = Entity::from_raw(3);
+
+        // Insert three entities at the exact same position
+        grid.insert(e1, 100.0, 100.0);
+        grid.insert(e2, 100.0, 100.0);
+        grid.insert(e3, 100.0, 100.0);
+
+        assert_eq!(grid.entity_count(), 3);
+
+        let result = grid.query_rect(0.0, 0.0, 200.0, 200.0);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&e1));
+        assert!(result.contains(&e2));
+        assert!(result.contains(&e3));
+    }
+
+    // ------------------------------------------------------------------
+    // Clear and reuse
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_clear_then_reinsert() {
+        let mut grid = SpatialGrid::default();
+
+        // First pass
+        grid.insert(Entity::from_raw(1), 100.0, 100.0);
+        grid.insert(Entity::from_raw(2), 200.0, 200.0);
+        assert_eq!(grid.entity_count(), 2);
+
+        // Clear
+        grid.clear();
+        assert_eq!(grid.entity_count(), 0);
+        let empty_result = grid.query_rect(0.0, 0.0, 4096.0, 4096.0);
+        assert!(empty_result.is_empty());
+
+        // Reinsert different entities
+        let e3 = Entity::from_raw(3);
+        grid.insert(e3, 300.0, 300.0);
+        assert_eq!(grid.entity_count(), 1);
+        let result = grid.query_rect(200.0, 200.0, 400.0, 400.0);
+        assert!(result.contains(&e3));
+    }
+
+    // ------------------------------------------------------------------
+    // Query with no matches in valid range
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_query_rect_no_match_in_populated_grid() {
+        let mut grid = SpatialGrid::default();
+        grid.insert(Entity::from_raw(1), 100.0, 100.0);
+        grid.insert(Entity::from_raw(2), 200.0, 200.0);
+
+        // Query a region with no entities
+        let result = grid.query_rect(3000.0, 3000.0, 3500.0, 3500.0);
+        assert!(
+            result.is_empty(),
+            "query in empty region should return nothing"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Large-scale insert and query
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_many_inserts_correct_count() {
+        let mut grid = SpatialGrid::default();
+        let count = 1000;
+        for i in 0..count {
+            let x = (i as f32 * 4.0) % 4000.0;
+            let y = (i as f32 * 3.0) % 4000.0;
+            grid.insert(Entity::from_raw(i), x, y);
+        }
+        assert_eq!(grid.entity_count(), count as usize);
+    }
+
+    // ------------------------------------------------------------------
+    // flat_index correctness
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_flat_index_valid_range() {
+        // Bucket (0,0) should map to index 0
+        assert_eq!(SpatialGrid::flat_index(0, 0), Some(0));
+        // Bucket (1,0) should map to index 1
+        assert_eq!(SpatialGrid::flat_index(1, 0), Some(1));
+        // Bucket (0,1) should map to index BUCKETS_X
+        assert_eq!(SpatialGrid::flat_index(0, 1), Some(BUCKETS_X));
+        // Last valid bucket
+        assert_eq!(
+            SpatialGrid::flat_index(BUCKETS_X as i32 - 1, BUCKETS_Y as i32 - 1),
+            Some(TOTAL_BUCKETS - 1)
+        );
+    }
+
+    #[test]
+    fn test_flat_index_out_of_bounds() {
+        assert_eq!(SpatialGrid::flat_index(-1, 0), None);
+        assert_eq!(SpatialGrid::flat_index(0, -1), None);
+        assert_eq!(SpatialGrid::flat_index(-1, -1), None);
+        assert_eq!(SpatialGrid::flat_index(BUCKETS_X as i32, 0), None);
+        assert_eq!(SpatialGrid::flat_index(0, BUCKETS_Y as i32), None);
+        assert_eq!(
+            SpatialGrid::flat_index(BUCKETS_X as i32, BUCKETS_Y as i32),
+            None
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Query rect spanning negative-to-positive range
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_query_rect_with_negative_coords_clips_to_valid() {
+        let mut grid = SpatialGrid::default();
+        let e = Entity::from_raw(42);
+        grid.insert(e, 10.0, 10.0); // bucket (0, 0)
+
+        // Query rect starting from negative coords but overlapping bucket (0,0)
+        let result = grid.query_rect(-100.0, -100.0, 50.0, 50.0);
+        assert!(
+            result.contains(&e),
+            "entity at (10,10) should be found even with negative query bounds"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Single-bucket query precision
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_single_bucket_multiple_entities() {
+        let mut grid = SpatialGrid::default();
+        // All in bucket (1, 1) -> x in [128, 256), y in [128, 256)
+        let e1 = Entity::from_raw(1);
+        let e2 = Entity::from_raw(2);
+        let e3 = Entity::from_raw(3);
+
+        grid.insert(e1, 130.0, 130.0);
+        grid.insert(e2, 200.0, 200.0);
+        grid.insert(e3, 255.0, 255.0);
+
+        // Query exactly bucket (1, 1)
+        let result = grid.query_rect(128.0, 128.0, 255.0, 255.0);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&e1));
+        assert!(result.contains(&e2));
+        assert!(result.contains(&e3));
+    }
+
+    // ------------------------------------------------------------------
+    // Entities along grid edges (first and last columns/rows)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_entities_along_grid_edges() {
+        let mut grid = SpatialGrid::default();
+
+        // Top edge (y=0)
+        let top = Entity::from_raw(1);
+        grid.insert(top, 2048.0, 0.0);
+
+        // Bottom edge (y near max)
+        let bottom = Entity::from_raw(2);
+        grid.insert(bottom, 2048.0, 4090.0);
+
+        // Left edge (x=0)
+        let left = Entity::from_raw(3);
+        grid.insert(left, 0.0, 2048.0);
+
+        // Right edge (x near max)
+        let right = Entity::from_raw(4);
+        grid.insert(right, 4090.0, 2048.0);
+
+        assert_eq!(grid.entity_count(), 4);
+
+        // Verify each can be found
+        let top_result = grid.query_rect(2000.0, 0.0, 2100.0, 10.0);
+        assert!(top_result.contains(&top));
+
+        let bottom_result = grid.query_rect(2000.0, 4080.0, 2100.0, 4095.0);
+        assert!(bottom_result.contains(&bottom));
+
+        let left_result = grid.query_rect(0.0, 2000.0, 10.0, 2100.0);
+        assert!(left_result.contains(&left));
+
+        let right_result = grid.query_rect(4080.0, 2000.0, 4095.0, 2100.0);
+        assert!(right_result.contains(&right));
+    }
+
+    // ------------------------------------------------------------------
+    // Default grid has correct bucket count
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_default_grid_has_correct_bucket_count() {
+        let grid = SpatialGrid::default();
+        // 33 * 33 = 1089 buckets
+        assert_eq!(BUCKETS_X, 33);
+        assert_eq!(BUCKETS_Y, 33);
+        assert_eq!(TOTAL_BUCKETS, 33 * 33);
         assert_eq!(grid.entity_count(), 0);
     }
 }


### PR DESCRIPTION
## Summary
- Comprehensive unit tests for `SpatialGrid` spatial indexing: empty grid, nearest lookup, multiple destinations, radius queries, boundary conditions (origin, max edge, negative coords, bucket edges), overlapping positions, clear/reuse, flat_index validation, and grid edge entities
- Unit tests for `find_nearest` (used by `DestinationCache`): closest destination, empty list, max_dist boundary, equidistant tiebreaker, grid edge positions
- 27 new tests covering all critical spatial query behaviors

## Test plan
- [x] All new tests pass with `cargo test --workspace`
- [x] Code formatted with `cargo fmt --all`
- [x] No modifications to shared files beyond adding `#[cfg(test)]` module to `movement.rs`

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)