### PR TITLE
Fix WASM compilation: remove invalid Msaa resource insert

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -49,11 +49,6 @@ fn main() {
         unfocused_mode: UpdateMode::reactive_low_power(std::time::Duration::from_millis(100)),
     });
 
-    // Disable MSAA on WASM — WebGL2 has limited multisampling support and
-    // it can cause visual artifacts or performance issues on some browsers.
-    #[cfg(target_arch = "wasm32")]
-    app.insert_resource(Msaa::Off);
-
     app.add_plugins((
         simulation::SimulationPlugin,
         rendering::RenderingPlugin,


### PR DESCRIPTION
## Summary
- `Msaa` is not a `Resource` on `wasm32-unknown-unknown` with WebGL2 in Bevy 0.15, causing the `wasm-check` CI job to fail on every PR
- WebGL2 already defaults to no MSAA, so the explicit `app.insert_resource(Msaa::Off)` was unnecessary
- This is why every merged PR showed a red X — `wasm-check` isn't a required check, so PRs merged despite the failure

## What was happening
Every single merged PR had a failing `wasm-check` job because `crates/app/src/main.rs:55` called `app.insert_resource(Msaa::Off)` behind `#[cfg(target_arch = "wasm32")]`, but `Msaa` doesn't implement `Resource` on the WASM target.

## Fix
Removed the WASM-only `Msaa::Off` resource insert. WebGL2 doesn't support MSAA and Bevy handles this correctly by default.

## Recommendation
Consider adding `wasm-check` to the required status checks in branch protection so WASM compilation breakage blocks merging in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)