### PR TITLE
Extract plugin registration and saveable keys to reduce merge conflicts

### DIFF
--- a/crates/rendering/src/lib.rs
+++ b/crates/rendering/src/lib.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy::time::common_conditions::on_timer;
 
 pub mod angle_snap;
 pub mod auto_grid_draw;
@@ -43,6 +42,8 @@ pub mod parallel_snap;
 pub mod screenshot;
 pub mod zone_brush_preview;
 
+mod plugin_registration;
+
 use angle_snap::AngleSnapState;
 use camera::{CameraDrag, LeftClickDrag, RightClickDrag};
 use input::{
@@ -69,172 +70,10 @@ impl Plugin for RenderingPlugin {
             .init_resource::<RoadDrawState>()
             .init_resource::<GridSnap>()
             .init_resource::<AngleSnapState>()
-            .init_resource::<IntersectionSnap>()
-            .add_systems(
-                Startup,
-                (
-                    camera::setup_camera,
-                    setup_lighting,
-                    terrain_render::spawn_terrain_chunks,
-                    building_preview_mesh::setup_building_preview_meshes,
-                    cursor_preview::spawn_cursor_preview,
-                    building_meshes::load_building_models,
-                )
-                    .chain()
-                    .after(simulation::world_init::init_world),
-            )
-            .add_systems(
-                Update,
-                (
-                    camera::camera_pan_keyboard,
-                    camera::camera_pan_drag,
-                    camera::camera_left_drag,
-                    camera::camera_orbit_drag,
-                    camera::camera_zoom,
-                    camera::camera_zoom_keyboard,
-                    camera::camera_rotate_keyboard,
-                    camera::apply_orbit_camera,
-                ),
-            )
-            .add_systems(
-                Update,
-                (
-                    input::update_cursor_grid_pos,
-                    angle_snap::update_angle_snap,
-                    input::update_intersection_snap,
-                    grid_align::align_cursor_to_grid
-                        .after(angle_snap::update_angle_snap)
-                        .after(parallel_snap::apply_parallel_snap_to_cursor)
-                        .before(input::handle_tool_input),
-                    grid_align::align_angle_snap_to_grid
-                        .after(angle_snap::update_angle_snap)
-                        .before(input::handle_tool_input),
-                    grid_align::align_intersection_snap_to_grid
-                        .after(input::update_intersection_snap)
-                        .before(input::handle_tool_input),
-                    input::handle_tool_input,
-                    input::handle_tree_tool,
-                    input::handle_road_upgrade_tool,
-                    input::keyboard_tool_switch,
-                    input::toggle_grid_snap,
-                    input::toggle_curve_draw_mode,
-                    input::handle_escape_key,
-                    input::delete_selected_building,
-                    input::tick_status_message,
-                    overlay::toggle_overlay_keys,
-                ),
-            )
-            .add_systems(
-                Update,
-                (
-                    terrain_render::dirty_chunks_on_overlay_change,
-                    terrain_render::rebuild_dirty_chunks,
-                    cursor_preview::update_cursor_preview,
-                    cursor_preview::draw_bezier_preview,
-                    angle_snap::draw_angle_snap_indicator,
-                    cursor_preview::draw_intersection_snap_indicator,
-                    road_render::sync_road_segment_meshes,
-                    lane_markings::sync_lane_marking_meshes,
-                    road_grade::draw_road_grade_indicators,
-                ),
-            )
-            .add_systems(Update, day_night::update_day_night_cycle)
-            .add_systems(Update, day_night::update_fog_rendering)
-            .add_systems(
-                Update,
-                (
-                    building_render::spawn_building_meshes,
-                    building_render::update_building_meshes,
-                    building_render::update_construction_visuals,
-                    building_render::cleanup_orphan_building_meshes
-                        .run_if(on_timer(std::time::Duration::from_secs(1))),
-                    props::spawn_tree_props,
-                    props::spawn_road_props,
-                    props::spawn_parked_cars,
-                ),
-            )
-            .add_systems(
-                Update,
-                (
-                    citizen_render::spawn_citizen_sprites,
-                    citizen_render::trigger_lod_fade,
-                    citizen_render::update_citizen_sprites,
-                    citizen_render::update_lod_fade,
-                    citizen_render::despawn_abstract_sprites,
-                )
-                    .chain(),
-            )
-            .add_systems(
-                Update,
-                (
-                    building_render::spawn_planted_tree_meshes,
-                    building_render::cleanup_planted_tree_meshes
-                        .run_if(on_timer(std::time::Duration::from_secs(1))),
-                    status_icons::update_building_status_icons
-                        .run_if(on_timer(std::time::Duration::from_secs(2))),
-                    building_status_enhanced::update_enhanced_status_icons
-                        .run_if(on_timer(std::time::Duration::from_secs(2))),
-                    building_status_enhanced::lod_enhanced_status_icons,
-                ),
-            )
-            .add_systems(
-                Update,
-                (
-                    construction_anim::spawn_construction_props,
-                    construction_anim::update_construction_anim,
-                    construction_anim::animate_crane_rotation,
-                    construction_anim::cleanup_construction_props,
-                    construction_anim::cleanup_orphan_construction_props
-                        .run_if(on_timer(std::time::Duration::from_secs(1))),
-                ),
-            )
-            .add_systems(
-                Update,
-                (
-                    selection_highlight::manage_selection_highlights,
-                    selection_highlight::animate_selection_highlights,
-                    selection_highlight::draw_connected_highlights,
-                ),
-            )
-            .add_systems(Update, oneway_arrows::draw_oneway_arrows)
-            .add_plugins(traffic_los_render::TrafficLosRenderPlugin)
-            .add_plugins(traffic_arrows::TrafficArrowsPlugin)
-            .add_plugins(wind_streamlines::WindStreamlinesPlugin)
-            .add_plugins(tree_props::TreePropsPlugin)
-            .add_plugins(network_viz::NetworkVizPlugin);
+            .init_resource::<IntersectionSnap>();
 
-        // Screenshot plugin (F12 to capture)
-        app.add_plugins(screenshot::ScreenshotPlugin);
-
-        // Building mesh variant plugin (level-aware model selection)
-        app.add_plugins(building_mesh_variants::BuildingMeshVariantsPlugin);
-
-        // Satellite view at maximum zoom-out
-        app.add_plugins(satellite_view::SatelliteViewPlugin);
-
-        // Parallel road snapping (UX-026)
-        app.add_plugins(parallel_snap::ParallelSnapPlugin);
-
-        // Parallel road drawing mode (UX-021)
-        app.add_plugins(parallel_draw::ParallelDrawPlugin);
-
-        // Box selection (UX-011)
-        app.add_plugins(box_selection::BoxSelectionPlugin);
-
-        // Zone brush preview (UX-018)
-        app.add_plugins(zone_brush_preview::ZoneBrushPreviewPlugin);
-
-        // Enhanced click-to-select with priority ordering (UX-009)
-        app.add_plugins(enhanced_select::EnhancedSelectPlugin);
-
-        // Intersection auto-detection preview (UX-023)
-        app.add_plugins(intersection_preview::IntersectionPreviewPlugin);
-
-        // Freehand road drawing (UX-020)
-        app.add_plugins(freehand_draw::FreehandDrawPlugin);
-
-        // Auto-grid road placement (TRAF-010)
-        app.add_plugins(auto_grid_draw::AutoGridDrawPlugin);
+        // Register all rendering systems and plugins (extracted for conflict-free additions)
+        plugin_registration::register_rendering_systems(app);
     }
 }
 

--- a/crates/rendering/src/plugin_registration.rs
+++ b/crates/rendering/src/plugin_registration.rs
@@ -1,0 +1,199 @@
+use bevy::prelude::*;
+use bevy::time::common_conditions::on_timer;
+
+use crate::*;
+
+/// Register all rendering plugins and systems.
+///
+/// Each plugin is registered on its own line for conflict-free parallel additions.
+/// When adding a new rendering plugin, just append a new `app.add_plugins(...)` line
+/// at the end of the appropriate section.
+pub(crate) fn register_rendering_systems(app: &mut App) {
+    app.add_systems(
+        Startup,
+        (
+            camera::setup_camera,
+            super::setup_lighting,
+            terrain_render::spawn_terrain_chunks,
+            building_preview_mesh::setup_building_preview_meshes,
+            cursor_preview::spawn_cursor_preview,
+            building_meshes::load_building_models,
+        )
+            .chain()
+            .after(simulation::world_init::init_world),
+    );
+
+    // Camera controls
+    app.add_systems(
+        Update,
+        (
+            camera::camera_pan_keyboard,
+            camera::camera_pan_drag,
+            camera::camera_left_drag,
+            camera::camera_orbit_drag,
+            camera::camera_zoom,
+            camera::camera_zoom_keyboard,
+            camera::camera_rotate_keyboard,
+            camera::apply_orbit_camera,
+        ),
+    );
+
+    // Input and tool handling
+    app.add_systems(
+        Update,
+        (
+            input::update_cursor_grid_pos,
+            angle_snap::update_angle_snap,
+            input::update_intersection_snap,
+            grid_align::align_cursor_to_grid
+                .after(angle_snap::update_angle_snap)
+                .after(parallel_snap::apply_parallel_snap_to_cursor)
+                .before(input::handle_tool_input),
+            grid_align::align_angle_snap_to_grid
+                .after(angle_snap::update_angle_snap)
+                .before(input::handle_tool_input),
+            grid_align::align_intersection_snap_to_grid
+                .after(input::update_intersection_snap)
+                .before(input::handle_tool_input),
+            input::handle_tool_input,
+            input::handle_tree_tool,
+            input::handle_road_upgrade_tool,
+            input::keyboard_tool_switch,
+            input::toggle_grid_snap,
+            input::toggle_curve_draw_mode,
+            input::handle_escape_key,
+            input::delete_selected_building,
+            input::tick_status_message,
+            overlay::toggle_overlay_keys,
+        ),
+    );
+
+    // Terrain and road rendering
+    app.add_systems(
+        Update,
+        (
+            terrain_render::dirty_chunks_on_overlay_change,
+            terrain_render::rebuild_dirty_chunks,
+            cursor_preview::update_cursor_preview,
+            cursor_preview::draw_bezier_preview,
+            angle_snap::draw_angle_snap_indicator,
+            cursor_preview::draw_intersection_snap_indicator,
+            road_render::sync_road_segment_meshes,
+            lane_markings::sync_lane_marking_meshes,
+            road_grade::draw_road_grade_indicators,
+        ),
+    );
+
+    // Day/night cycle
+    app.add_systems(Update, day_night::update_day_night_cycle);
+    app.add_systems(Update, day_night::update_fog_rendering);
+
+    // Building rendering
+    app.add_systems(
+        Update,
+        (
+            building_render::spawn_building_meshes,
+            building_render::update_building_meshes,
+            building_render::update_construction_visuals,
+            building_render::cleanup_orphan_building_meshes
+                .run_if(on_timer(std::time::Duration::from_secs(1))),
+            props::spawn_tree_props,
+            props::spawn_road_props,
+            props::spawn_parked_cars,
+        ),
+    );
+
+    // Citizen rendering
+    app.add_systems(
+        Update,
+        (
+            citizen_render::spawn_citizen_sprites,
+            citizen_render::trigger_lod_fade,
+            citizen_render::update_citizen_sprites,
+            citizen_render::update_lod_fade,
+            citizen_render::despawn_abstract_sprites,
+        )
+            .chain(),
+    );
+
+    // Status icons and trees
+    app.add_systems(
+        Update,
+        (
+            building_render::spawn_planted_tree_meshes,
+            building_render::cleanup_planted_tree_meshes
+                .run_if(on_timer(std::time::Duration::from_secs(1))),
+            status_icons::update_building_status_icons
+                .run_if(on_timer(std::time::Duration::from_secs(2))),
+            building_status_enhanced::update_enhanced_status_icons
+                .run_if(on_timer(std::time::Duration::from_secs(2))),
+            building_status_enhanced::lod_enhanced_status_icons,
+        ),
+    );
+
+    // Construction animations
+    app.add_systems(
+        Update,
+        (
+            construction_anim::spawn_construction_props,
+            construction_anim::update_construction_anim,
+            construction_anim::animate_crane_rotation,
+            construction_anim::cleanup_construction_props,
+            construction_anim::cleanup_orphan_construction_props
+                .run_if(on_timer(std::time::Duration::from_secs(1))),
+        ),
+    );
+
+    // Selection highlights
+    app.add_systems(
+        Update,
+        (
+            selection_highlight::manage_selection_highlights,
+            selection_highlight::animate_selection_highlights,
+            selection_highlight::draw_connected_highlights,
+        ),
+    );
+
+    // One-way arrows
+    app.add_systems(Update, oneway_arrows::draw_oneway_arrows);
+
+    // Feature plugins
+    app.add_plugins(traffic_los_render::TrafficLosRenderPlugin);
+    app.add_plugins(traffic_arrows::TrafficArrowsPlugin);
+    app.add_plugins(wind_streamlines::WindStreamlinesPlugin);
+    app.add_plugins(tree_props::TreePropsPlugin);
+    app.add_plugins(network_viz::NetworkVizPlugin);
+
+    // Screenshot plugin (F12 to capture)
+    app.add_plugins(screenshot::ScreenshotPlugin);
+
+    // Building mesh variant plugin (level-aware model selection)
+    app.add_plugins(building_mesh_variants::BuildingMeshVariantsPlugin);
+
+    // Satellite view at maximum zoom-out
+    app.add_plugins(satellite_view::SatelliteViewPlugin);
+
+    // Parallel road snapping (UX-026)
+    app.add_plugins(parallel_snap::ParallelSnapPlugin);
+
+    // Parallel road drawing mode (UX-021)
+    app.add_plugins(parallel_draw::ParallelDrawPlugin);
+
+    // Box selection (UX-011)
+    app.add_plugins(box_selection::BoxSelectionPlugin);
+
+    // Zone brush preview (UX-018)
+    app.add_plugins(zone_brush_preview::ZoneBrushPreviewPlugin);
+
+    // Enhanced click-to-select with priority ordering (UX-009)
+    app.add_plugins(enhanced_select::EnhancedSelectPlugin);
+
+    // Intersection auto-detection preview (UX-023)
+    app.add_plugins(intersection_preview::IntersectionPreviewPlugin);
+
+    // Freehand road drawing (UX-020)
+    app.add_plugins(freehand_draw::FreehandDrawPlugin);
+
+    // Auto-grid road placement (TRAF-010)
+    app.add_plugins(auto_grid_draw::AutoGridDrawPlugin);
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -1,0 +1,182 @@
+use bevy::prelude::*;
+
+use crate::*;
+
+/// Register all simulation feature plugins.
+///
+/// Each plugin is registered on its own line for conflict-free parallel additions.
+/// When adding a new feature plugin, just append a new `app.add_plugins(...)` line
+/// at the end of the appropriate section.
+pub(crate) fn register_feature_plugins(app: &mut App) {
+    // Core simulation chain
+    app.add_plugins(game_params::GameParamsPlugin);
+    app.add_plugins(time_of_day::TimeOfDayPlugin);
+    app.add_plugins(zones::ZonesPlugin);
+    app.add_plugins(buildings::BuildingsPlugin);
+    app.add_plugins(education_jobs::EducationJobsPlugin);
+    app.add_plugins(citizen_spawner::CitizenSpawnerPlugin);
+    app.add_plugins(movement::MovementPlugin);
+    app.add_plugins(traffic::TrafficPlugin);
+    app.add_plugins(bicycle_lanes::BicycleLanesPlugin);
+
+    // Happiness and services
+    app.add_plugins(postal::PostalPlugin);
+    app.add_plugins(happiness::HappinessPlugin);
+    app.add_plugins(economy::EconomyPlugin);
+    app.add_plugins(stats::StatsPlugin);
+    app.add_plugins(chart_data::ChartDataPlugin);
+    app.add_plugins(utilities::UtilitiesPlugin);
+    app.add_plugins(network_viz::NetworkVizPlugin);
+    app.add_plugins(education::EducationPlugin);
+
+    // Pollution, land value, garbage, districts
+    app.add_plugins(pollution::PollutionPlugin);
+    app.add_plugins(land_value::LandValuePlugin);
+    app.add_plugins(garbage::GarbagePlugin);
+    app.add_plugins(districts::DistrictsPlugin);
+    app.add_plugins(district_policies::DistrictPoliciesPlugin);
+    app.add_plugins(superblock::SuperblockPlugin);
+    app.add_plugins(neighborhood_quality::NeighborhoodQualityPlugin);
+    app.add_plugins(lifecycle::LifecyclePlugin);
+    app.add_plugins(building_upgrade::BuildingUpgradePlugin);
+    app.add_plugins(imports_exports::ImportsExportsPlugin);
+    app.add_plugins(historic_preservation::HistoricPreservationPlugin);
+    app.add_plugins(inclusionary_zoning::InclusionaryZoningPlugin);
+    app.add_plugins(far_transfer::FarTransferPlugin);
+
+    // Waste and recycling
+    app.add_plugins(waste_effects::WasteEffectsPlugin);
+    app.add_plugins(recycling::RecyclingPlugin);
+    app.add_plugins(road_maintenance::RoadMaintenancePlugin);
+    app.add_plugins(road_upgrade::RoadUpgradePlugin);
+    app.add_plugins(curve_road_drawing::CurveRoadDrawingPlugin);
+    app.add_plugins(oneway::OneWayPlugin);
+    app.add_plugins(traffic_accidents::TrafficAccidentsPlugin);
+    app.add_plugins(traffic_congestion::TrafficCongestionPlugin);
+    app.add_plugins(traffic_los::TrafficLosPlugin);
+    app.add_plugins(road_hierarchy::RoadHierarchyPlugin);
+    app.add_plugins(bus_transit::BusTransitPlugin);
+    app.add_plugins(transit_hub::TransitHubPlugin);
+    app.add_plugins(loans::LoansPlugin);
+    app.add_plugins(bulldoze_refund::BulldozeRefundPlugin);
+    app.add_plugins(roundabout::RoundaboutPlugin);
+
+    // Day/night visual controls
+    app.add_plugins(day_night_controls::DayNightControlsPlugin);
+
+    // Weather and environment
+    app.add_plugins(weather::WeatherPlugin);
+    app.add_plugins(fog::FogPlugin);
+    app.add_plugins(degree_days::DegreeDaysPlugin);
+    app.add_plugins(heating::HeatingPlugin);
+    app.add_plugins(wind::WindPlugin);
+    app.add_plugins(wind_damage::WindDamagePlugin);
+    app.add_plugins(urban_heat_island::UrbanHeatIslandPlugin);
+    app.add_plugins(uhi_mitigation::UhiMitigationPlugin);
+    app.add_plugins(drought::DroughtPlugin);
+    app.add_plugins(noise::NoisePlugin);
+    app.add_plugins(crime::CrimePlugin);
+    app.add_plugins(health::HealthPlugin);
+    app.add_plugins(death_care::DeathCarePlugin);
+    app.add_plugins(climate_change::ClimateChangePlugin);
+    app.add_plugins(seasonal_rendering::SeasonalRenderingPlugin);
+
+    // Water systems
+    app.add_plugins(water_pollution::WaterPollutionPlugin);
+    app.add_plugins(groundwater::GroundwaterPlugin);
+    app.add_plugins(stormwater::StormwaterPlugin);
+    app.add_plugins(water_demand::WaterDemandPlugin);
+    app.add_plugins(heat_wave::HeatWavePlugin);
+    app.add_plugins(heat_mitigation::HeatMitigationPlugin);
+    app.add_plugins(composting::CompostingPlugin);
+    app.add_plugins(cold_snap::ColdSnapPlugin);
+    app.add_plugins(cso::CsoPlugin);
+    app.add_plugins(water_treatment::WaterTreatmentPlugin);
+    app.add_plugins(water_conservation::WaterConservationPlugin);
+    app.add_plugins(water_pressure::WaterPressurePlugin);
+    app.add_plugins(groundwater_depletion::GroundwaterDepletionPlugin);
+    app.add_plugins(wastewater::WastewaterPlugin);
+
+    // Waste management
+    app.add_plugins(hazardous_waste::HazardousWastePlugin);
+    app.add_plugins(landfill::LandfillPlugin);
+    app.add_plugins(landfill_gas::LandfillGasPlugin);
+    app.add_plugins(landfill_warning::LandfillWarningPlugin);
+    app.add_plugins(waste_policies::WastePoliciesPlugin);
+
+    // Infrastructure and resources
+    app.add_plugins(storm_drainage::StormDrainagePlugin);
+    app.add_plugins(water_sources::WaterSourcesPlugin);
+    app.add_plugins(natural_resources::NaturalResourcesPlugin);
+    app.add_plugins(wealth::WealthPlugin);
+    app.add_plugins(tourism::TourismPlugin);
+    app.add_plugins(unlocks::UnlocksPlugin);
+    app.add_plugins(reservoir::ReservoirPlugin);
+    app.add_plugins(flood_simulation::FloodSimulationPlugin);
+    app.add_plugins(flood_protection::FloodProtectionPlugin);
+    app.add_plugins(trees::TreesPlugin);
+    app.add_plugins(airport::AirportPlugin);
+    app.add_plugins(metro_transit::MetroTransitPlugin);
+    app.add_plugins(train_transit::TrainTransitPlugin);
+    app.add_plugins(snow::SnowPlugin);
+
+    // Transit and connections
+    app.add_plugins(tram_transit::TramTransitPlugin);
+    app.add_plugins(outside_connections::OutsideConnectionsPlugin);
+
+    // Production and economy
+    app.add_plugins(agriculture::AgriculturePlugin);
+    app.add_plugins(production::ProductionPlugin);
+    app.add_plugins(market::MarketPlugin);
+    app.add_plugins(events::EventsPlugin);
+    app.add_plugins(notifications::NotificationsPlugin);
+    app.add_plugins(specialization::SpecializationPlugin);
+    app.add_plugins(advisors::AdvisorsPlugin);
+    app.add_plugins(achievements::AchievementsPlugin);
+    app.add_plugins(freight_traffic::FreightTrafficPlugin);
+
+    // Building lifecycle and disasters
+    app.add_plugins(abandonment::AbandonmentPlugin);
+    app.add_plugins(fire::FirePlugin);
+    app.add_plugins(forest_fire::ForestFirePlugin);
+    app.add_plugins(disasters::DisastersPlugin);
+
+    // Citizens and population
+    app.add_plugins(life_simulation::LifeSimulationPlugin);
+    app.add_plugins(homelessness::HomelessnessPlugin);
+    app.add_plugins(welfare::WelfarePlugin);
+    app.add_plugins(immigration::ImmigrationPlugin);
+    app.add_plugins(lod::LodPlugin);
+    app.add_plugins(virtual_population::VirtualPopulationPlugin);
+    app.add_plugins(urban_growth_boundary::UrbanGrowthBoundaryPlugin);
+    app.add_plugins(nimby::NimbyPlugin);
+    app.add_plugins(walkability::WalkabilityPlugin);
+    app.add_plugins(form_transect::FormTransectPlugin);
+    app.add_plugins(cumulative_zoning::CumulativeZoningPlugin);
+    app.add_plugins(parking::ParkingPlugin);
+    app.add_plugins(tutorial::TutorialPlugin);
+    app.add_plugins(multi_select::MultiSelectPlugin);
+    app.add_plugins(blueprints::BlueprintPlugin);
+    app.add_plugins(simulation_invariants::SimulationInvariantsPlugin);
+
+    // Mode choice (TRAF-007)
+    app.add_plugins(mode_choice::ModeChoicePlugin);
+
+    // Localization infrastructure
+    app.add_plugins(localization::LocalizationPlugin);
+
+    // Accessibility
+    app.add_plugins(colorblind::ColorblindPlugin);
+
+    // Customizable keybindings
+    app.add_plugins(keybindings::KeyBindingsPlugin);
+
+    // Freehand road drawing (UX-020)
+    app.add_plugins(freehand_road::FreehandRoadPlugin);
+
+    // Auto-grid road placement (TRAF-010)
+    app.add_plugins(auto_grid_road::AutoGridRoadPlugin);
+
+    // Undo/redo system
+    app.add_plugins(undo_redo::UndoRedoPlugin);
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy_egui::EguiPlugin;
 
 pub mod advisor_tips;
 pub mod auto_grid_ui;
@@ -35,78 +34,13 @@ pub mod waste_dashboard;
 pub mod water_dashboard;
 pub mod zone_brush_ui;
 
+mod plugin_registration;
+
 pub struct UiPlugin;
 
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(EguiPlugin)
-            .add_plugins(cell_info_panel::CellInfoPanelPlugin)
-            .add_plugins(cell_tooltip::CellTooltipPlugin)
-            .add_plugins(citizen_info::CitizenInfoPlugin)
-            .add_plugins(context_menu::ContextMenuPlugin)
-            .add_plugins(district_inspect::DistrictInspectPlugin)
-            .add_plugins(road_segment_info::RoadSegmentInfoPlugin)
-            .add_plugins(waste_dashboard::WasteDashboardPlugin)
-            .add_plugins(localization::LocalizationUiPlugin)
-            .add_plugins(multi_select::MultiSelectUiPlugin)
-            .add_plugins(progressive_disclosure::ProgressiveDisclosurePlugin)
-            .add_plugins(service_coverage_panel::ServiceCoveragePanelPlugin)
-            .add_plugins(oneway_ui::OneWayUiPlugin)
-            .add_plugins(settings_panel::SettingsPanelPlugin)
-            .add_plugins(advisor_tips::AdvisorTipsPlugin)
-            .add_plugins(auto_grid_ui::AutoGridUiPlugin)
-            .add_plugins(keybindings_panel::KeybindingsPanelPlugin)
-            .add_plugins(search::SearchPlugin)
-            .add_plugins(overlay_legend::OverlayLegendPlugin)
-            .add_plugins(dual_overlay::DualOverlayPlugin)
-            .add_plugins(two_key_shortcuts::TwoKeyShortcutPlugin)
-            .add_plugins(minimap::MinimapPlugin)
-            .add_plugins(notification_ticker::NotificationTickerPlugin)
-            .add_plugins(box_selection::BoxSelectionUiPlugin)
-            .add_plugins(zone_brush_ui::ZoneBrushUiPlugin)
-            .add_plugins(info_panel::budget::BudgetBreakdownPlugin)
-            .init_resource::<day_night_panel::DayNightPanelVisible>()
-            .init_resource::<milestones::Milestones>()
-            .init_resource::<graphs::HistoryData>()
-            .init_resource::<graphs::ChartsState>()
-            .init_resource::<toolbar::OpenCategory>()
-            .init_resource::<toolbar::ToolCatalog>()
-            .init_resource::<info_panel::CoverageCache>()
-            .init_resource::<info_panel::JournalVisible>()
-            .init_resource::<info_panel::ChartsVisible>()
-            .init_resource::<info_panel::AdvisorVisible>()
-            .init_resource::<info_panel::PoliciesVisible>()
-            .init_resource::<info_panel::BudgetPanelVisible>()
-            .init_resource::<water_dashboard::WaterDashboardVisible>()
-            .add_systems(Startup, theme::apply_cute_theme)
-            .add_systems(
-                Update,
-                (
-                    milestones::check_milestones,
-                    graphs::record_history,
-                    toolbar::toolbar_ui,
-                    info_panel::info_panel_ui,
-                    info_panel::update_coverage_cache,
-                ),
-            )
-            .add_systems(
-                Update,
-                (
-                    milestones::milestones_ui,
-                    graphs::graphs_ui,
-                    info_panel::policies_ui,
-                    info_panel::panel_keybinds,
-                    info_panel::quick_save_load_keybinds,
-                    info_panel::event_journal_ui,
-                    info_panel::advisor_window_ui,
-                    info_panel::budget_panel_ui,
-                    toolbar::speed_keybinds,
-                    info_panel::groundwater_tooltip_ui,
-                    water_dashboard::water_dashboard_ui,
-                    tutorial::tutorial_ui,
-                    day_night_panel::day_night_panel_ui,
-                    road_cost_display::road_cost_display_ui,
-                ),
-            );
+        // Register all UI systems and plugins (extracted for conflict-free additions)
+        plugin_registration::register_ui_systems(app);
     }
 }

--- a/crates/ui/src/plugin_registration.rs
+++ b/crates/ui/src/plugin_registration.rs
@@ -1,0 +1,88 @@
+use bevy::prelude::*;
+use bevy_egui::EguiPlugin;
+
+use crate::*;
+
+/// Register all UI plugins and systems.
+///
+/// Each plugin is registered on its own line for conflict-free parallel additions.
+/// When adding a new UI plugin, just append a new `app.add_plugins(...)` line
+/// at the end of the appropriate section.
+pub(crate) fn register_ui_systems(app: &mut App) {
+    // Core egui
+    app.add_plugins(EguiPlugin);
+
+    // UI feature plugins
+    app.add_plugins(cell_info_panel::CellInfoPanelPlugin);
+    app.add_plugins(cell_tooltip::CellTooltipPlugin);
+    app.add_plugins(citizen_info::CitizenInfoPlugin);
+    app.add_plugins(context_menu::ContextMenuPlugin);
+    app.add_plugins(district_inspect::DistrictInspectPlugin);
+    app.add_plugins(road_segment_info::RoadSegmentInfoPlugin);
+    app.add_plugins(waste_dashboard::WasteDashboardPlugin);
+    app.add_plugins(localization::LocalizationUiPlugin);
+    app.add_plugins(multi_select::MultiSelectUiPlugin);
+    app.add_plugins(progressive_disclosure::ProgressiveDisclosurePlugin);
+    app.add_plugins(service_coverage_panel::ServiceCoveragePanelPlugin);
+    app.add_plugins(oneway_ui::OneWayUiPlugin);
+    app.add_plugins(settings_panel::SettingsPanelPlugin);
+    app.add_plugins(advisor_tips::AdvisorTipsPlugin);
+    app.add_plugins(auto_grid_ui::AutoGridUiPlugin);
+    app.add_plugins(keybindings_panel::KeybindingsPanelPlugin);
+    app.add_plugins(search::SearchPlugin);
+    app.add_plugins(overlay_legend::OverlayLegendPlugin);
+    app.add_plugins(dual_overlay::DualOverlayPlugin);
+    app.add_plugins(two_key_shortcuts::TwoKeyShortcutPlugin);
+    app.add_plugins(minimap::MinimapPlugin);
+    app.add_plugins(notification_ticker::NotificationTickerPlugin);
+    app.add_plugins(box_selection::BoxSelectionUiPlugin);
+    app.add_plugins(zone_brush_ui::ZoneBrushUiPlugin);
+    app.add_plugins(info_panel::budget::BudgetBreakdownPlugin);
+
+    // UI resources
+    app.init_resource::<day_night_panel::DayNightPanelVisible>();
+    app.init_resource::<milestones::Milestones>();
+    app.init_resource::<graphs::HistoryData>();
+    app.init_resource::<graphs::ChartsState>();
+    app.init_resource::<toolbar::OpenCategory>();
+    app.init_resource::<toolbar::ToolCatalog>();
+    app.init_resource::<info_panel::CoverageCache>();
+    app.init_resource::<info_panel::JournalVisible>();
+    app.init_resource::<info_panel::ChartsVisible>();
+    app.init_resource::<info_panel::AdvisorVisible>();
+    app.init_resource::<info_panel::PoliciesVisible>();
+    app.init_resource::<info_panel::BudgetPanelVisible>();
+    app.init_resource::<water_dashboard::WaterDashboardVisible>();
+
+    // UI systems
+    app.add_systems(Startup, theme::apply_cute_theme);
+    app.add_systems(
+        Update,
+        (
+            milestones::check_milestones,
+            graphs::record_history,
+            toolbar::toolbar_ui,
+            info_panel::info_panel_ui,
+            info_panel::update_coverage_cache,
+        ),
+    );
+    app.add_systems(
+        Update,
+        (
+            milestones::milestones_ui,
+            graphs::graphs_ui,
+            info_panel::policies_ui,
+            info_panel::panel_keybinds,
+            info_panel::quick_save_load_keybinds,
+            info_panel::event_journal_ui,
+            info_panel::advisor_window_ui,
+            info_panel::budget_panel_ui,
+            toolbar::speed_keybinds,
+            info_panel::groundwater_tooltip_ui,
+            water_dashboard::water_dashboard_ui,
+            tutorial::tutorial_ui,
+            day_night_panel::day_night_panel_ui,
+            road_cost_display::road_cost_display_ui,
+        ),
+    );
+}


### PR DESCRIPTION
## Summary

- Extracts all `app.add_plugins(...)` calls from `simulation/src/lib.rs`, `rendering/src/lib.rs`, and `ui/src/lib.rs` into dedicated `plugin_registration.rs` files
- Converts tuple-based `add_plugins((A, B, C))` to individual `app.add_plugins(X);` lines so parallel PRs adding plugins on separate lines auto-merge without conflicts
- Extracts `EXPECTED_SAVEABLE_KEYS` and `validate_saveable_registry` into `simulation/src/saveable_keys.rs` with `pub use` re-exports to preserve the public API
- No functional changes -- all existing `use simulation::*` imports continue to work

## Motivation

The three `lib.rs` files are the most conflict-prone files in the codebase. When multiple parallel PRs each add a new feature plugin, they all modify the same `app.add_plugins((...))` tuple in the same `build()` method, causing merge conflicts even though the changes are logically independent. By extracting plugin registrations into separate files with one `app.add_plugins()` per line, git can auto-merge parallel additions without conflicts.

## Files changed

| File | Change |
|------|--------|
| `simulation/src/lib.rs` | Removed plugin registrations and saveable keys (826 → 530 lines) |
| `simulation/src/plugin_registration.rs` | **New** - all feature plugin registrations (182 lines) |
| `simulation/src/saveable_keys.rs` | **New** - `EXPECTED_SAVEABLE_KEYS` + `validate_saveable_registry` (105 lines) |
| `rendering/src/lib.rs` | Removed system/plugin registrations (262 → 101 lines) |
| `rendering/src/plugin_registration.rs` | **New** - all rendering system/plugin registrations (199 lines) |
| `ui/src/lib.rs` | Removed system/plugin registrations (112 → 46 lines) |
| `ui/src/plugin_registration.rs` | **New** - all UI system/plugin registrations (88 lines) |

## Test plan

- [ ] `cargo build --workspace` compiles successfully
- [ ] `cargo test --workspace` all tests pass
- [ ] `cargo clippy --workspace -- -D warnings` no warnings
- [ ] `cargo fmt --all -- --check` formatting is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)