### PR TITLE
Add natural gas combined-cycle power plant (POWER-003)

### DIFF
--- a/crates/simulation/src/coal_power.rs
+++ b/crates/simulation/src/coal_power.rs
@@ -47,11 +47,11 @@ pub const COAL_FOOTPRINT: (usize, usize) = (3, 3);
 // PowerPlantType enum
 // =============================================================================
 
-/// The type of power plant. Currently only Coal; future variants will be added
-/// for gas, oil, nuclear, etc.
+/// The type of power plant (coal, natural gas, etc.).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub enum PowerPlantType {
     Coal,
+    NaturalGas,
 }
 
 // =============================================================================

--- a/crates/simulation/src/gas_power.rs
+++ b/crates/simulation/src/gas_power.rs
@@ -1,0 +1,269 @@
+//! POWER-003: Natural Gas Combined-Cycle Power Plant
+//!
+//! Implements natural gas combined-cycle power plants as placeable power
+//! generator buildings that contribute to `EnergyGrid.total_supply_mwh`.
+//! Each gas plant has:
+//!
+//! - 500 MW capacity, 0.45 capacity factor (dispatchable)
+//! - Fuel cost: $40/MWh
+//! - Air pollution source: Q=35.0 (65% less than coal)
+//! - CO2 emissions: 0.4 tons/MWh
+//! - 2×3 building footprint
+
+use bevy::prelude::*;
+use bitcode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+use crate::coal_power::{PowerPlant, PowerPlantType};
+use crate::config::{GRID_HEIGHT, GRID_WIDTH};
+use crate::energy_demand::EnergyGrid;
+use crate::pollution::PollutionGrid;
+use crate::SlowTickTimer;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Maximum generation capacity in MW.
+pub const GAS_CAPACITY_MW: f32 = 500.0;
+
+/// Capacity factor (fraction of capacity actually dispatched on average).
+pub const GAS_CAPACITY_FACTOR: f32 = 0.45;
+
+/// Fuel cost in dollars per MWh generated.
+pub const GAS_FUEL_COST_PER_MWH: f32 = 40.0;
+
+/// Air pollution source strength (65% less than coal's Q=100).
+pub const GAS_POLLUTION_Q: f32 = 35.0;
+
+/// Pollution radiation radius (in grid cells).
+pub const GAS_POLLUTION_RADIUS: i32 = 8;
+
+/// CO2 emission rate in tons per MWh.
+pub const GAS_CO2_TONS_PER_MWH: f32 = 0.4;
+
+/// Building footprint in grid cells (width, height).
+pub const GAS_FOOTPRINT: (usize, usize) = (2, 3);
+
+// =============================================================================
+// PowerPlant constructor for NaturalGas
+// =============================================================================
+
+impl PowerPlant {
+    /// Create a new natural gas combined-cycle power plant at the given grid
+    /// position.
+    pub fn new_gas(grid_x: usize, grid_y: usize) -> Self {
+        Self {
+            plant_type: PowerPlantType::NaturalGas,
+            capacity_mw: GAS_CAPACITY_MW,
+            current_output_mw: GAS_CAPACITY_MW * GAS_CAPACITY_FACTOR,
+            fuel_cost: GAS_FUEL_COST_PER_MWH,
+            grid_x,
+            grid_y,
+        }
+    }
+}
+
+// =============================================================================
+// GasPowerState resource (city-wide gas power stats)
+// =============================================================================
+
+/// Aggregated city-wide state for natural gas power generation.
+#[derive(Resource, Debug, Clone, Serialize, Deserialize, Encode, Decode)]
+pub struct GasPowerState {
+    /// Number of active gas plants in the city.
+    pub plant_count: u32,
+    /// Total generation from all gas plants (MW).
+    pub total_output_mw: f32,
+    /// Total fuel cost across all gas plants ($/tick cycle).
+    pub total_fuel_cost: f32,
+    /// Total CO2 emitted this cycle (tons).
+    pub total_co2_tons: f32,
+}
+
+impl Default for GasPowerState {
+    fn default() -> Self {
+        Self {
+            plant_count: 0,
+            total_output_mw: 0.0,
+            total_fuel_cost: 0.0,
+            total_co2_tons: 0.0,
+        }
+    }
+}
+
+impl crate::Saveable for GasPowerState {
+    const SAVE_KEY: &'static str = "gas_power";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.plant_count == 0 {
+            return None;
+        }
+        Some(bitcode::encode(self))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
+    }
+}
+
+// =============================================================================
+// Systems
+// =============================================================================
+
+/// Aggregates gas power plant output into `EnergyGrid.total_supply_mwh` and
+/// updates `GasPowerState`. Runs every slow tick.
+pub fn aggregate_gas_power(
+    timer: Res<SlowTickTimer>,
+    plants: Query<&PowerPlant>,
+    mut energy_grid: ResMut<EnergyGrid>,
+    mut gas_state: ResMut<GasPowerState>,
+) {
+    if !timer.should_run() {
+        return;
+    }
+
+    let mut count = 0u32;
+    let mut total_output = 0.0f32;
+    let mut total_fuel = 0.0f32;
+    let mut total_co2 = 0.0f32;
+
+    for plant in &plants {
+        if plant.plant_type != PowerPlantType::NaturalGas {
+            continue;
+        }
+        count += 1;
+        total_output += plant.current_output_mw;
+        total_fuel += plant.current_output_mw * plant.fuel_cost;
+        total_co2 += plant.current_output_mw * GAS_CO2_TONS_PER_MWH;
+    }
+
+    gas_state.plant_count = count;
+    gas_state.total_output_mw = total_output;
+    gas_state.total_fuel_cost = total_fuel;
+    gas_state.total_co2_tons = total_co2;
+
+    // Add gas generation to the energy grid supply
+    energy_grid.total_supply_mwh += total_output;
+}
+
+/// Adds air pollution around each gas power plant. Runs every slow tick.
+pub fn gas_pollution(
+    timer: Res<SlowTickTimer>,
+    plants: Query<&PowerPlant>,
+    mut pollution: ResMut<PollutionGrid>,
+) {
+    if !timer.should_run() {
+        return;
+    }
+
+    for plant in &plants {
+        if plant.plant_type != PowerPlantType::NaturalGas {
+            continue;
+        }
+
+        let cx = plant.grid_x as i32;
+        let cy = plant.grid_y as i32;
+        let intensity = GAS_POLLUTION_Q as i32;
+        let radius = GAS_POLLUTION_RADIUS;
+
+        for dy in -radius..=radius {
+            for dx in -radius..=radius {
+                let nx = cx + dx;
+                let ny = cy + dy;
+                if nx >= 0
+                    && ny >= 0
+                    && (nx as usize) < GRID_WIDTH
+                    && (ny as usize) < GRID_HEIGHT
+                {
+                    let dist = dx.abs() + dy.abs();
+                    let decay = (intensity - dist * (intensity / radius)).max(0) as u8;
+                    let cur = pollution.get(nx as usize, ny as usize);
+                    pollution.set(nx as usize, ny as usize, cur.saturating_add(decay));
+                }
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Plugin
+// =============================================================================
+
+/// Plugin that registers natural gas power plant resources and systems.
+pub struct GasPowerPlugin;
+
+impl Plugin for GasPowerPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<GasPowerState>().add_systems(
+            FixedUpdate,
+            (aggregate_gas_power, gas_pollution)
+                .after(crate::pollution::update_pollution)
+                .in_set(crate::SimulationSet::Simulation),
+        );
+
+        // Register for save/load
+        app.init_resource::<crate::SaveableRegistry>();
+        app.world_mut()
+            .resource_mut::<crate::SaveableRegistry>()
+            .register::<GasPowerState>();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gas_plant_new_gas() {
+        let plant = PowerPlant::new_gas(10, 20);
+        assert_eq!(plant.plant_type, PowerPlantType::NaturalGas);
+        assert!((plant.capacity_mw - GAS_CAPACITY_MW).abs() < f32::EPSILON);
+        assert!(
+            (plant.current_output_mw - GAS_CAPACITY_MW * GAS_CAPACITY_FACTOR).abs()
+                < f32::EPSILON
+        );
+        assert!((plant.fuel_cost - GAS_FUEL_COST_PER_MWH).abs() < f32::EPSILON);
+        assert_eq!(plant.grid_x, 10);
+        assert_eq!(plant.grid_y, 20);
+    }
+
+    #[test]
+    fn test_gas_power_state_default() {
+        let state = GasPowerState::default();
+        assert_eq!(state.plant_count, 0);
+        assert!((state.total_output_mw).abs() < f32::EPSILON);
+        assert!((state.total_fuel_cost).abs() < f32::EPSILON);
+        assert!((state.total_co2_tons).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_gas_power_state_save_skip_empty() {
+        use crate::Saveable;
+        let state = GasPowerState::default();
+        assert!(
+            state.save_to_bytes().is_none(),
+            "Empty state should not produce save bytes"
+        );
+    }
+
+    #[test]
+    fn test_gas_power_state_roundtrip() {
+        use crate::Saveable;
+        let state = GasPowerState {
+            plant_count: 2,
+            total_output_mw: 450.0,
+            total_fuel_cost: 18000.0,
+            total_co2_tons: 180.0,
+        };
+        let bytes = state.save_to_bytes().expect("should produce bytes");
+        let loaded = GasPowerState::load_from_bytes(&bytes);
+        assert_eq!(loaded.plant_count, 2);
+        assert!((loaded.total_output_mw - 450.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_gas_footprint() {
+        assert_eq!(GAS_FOOTPRINT, (2, 3));
+    }
+}

--- a/crates/simulation/src/integration_tests/gas_power_tests.rs
+++ b/crates/simulation/src/integration_tests/gas_power_tests.rs
@@ -1,0 +1,240 @@
+//! Integration tests for the natural gas combined-cycle power plant system (POWER-003).
+
+use crate::coal_power::{PowerPlant, PowerPlantType};
+use crate::energy_demand::EnergyGrid;
+use crate::gas_power::{
+    GasPowerState, GAS_CAPACITY_FACTOR, GAS_CAPACITY_MW, GAS_CO2_TONS_PER_MWH,
+    GAS_FUEL_COST_PER_MWH,
+};
+use crate::pollution::PollutionGrid;
+use crate::test_harness::TestCity;
+
+/// Helper: spawn a gas plant entity in the TestCity at (x, y).
+fn spawn_gas_plant(city: &mut TestCity, x: usize, y: usize) {
+    let world = city.world_mut();
+    world.spawn(PowerPlant::new_gas(x, y));
+}
+
+// ====================================================================
+// Resource existence
+// ====================================================================
+
+#[test]
+fn test_gas_power_state_exists_in_new_city() {
+    let city = TestCity::new();
+    let state = city.resource::<GasPowerState>();
+    assert_eq!(state.plant_count, 0);
+}
+
+// ====================================================================
+// Gas plant increases total energy supply
+// ====================================================================
+
+#[test]
+fn test_gas_plant_increases_energy_supply() {
+    let mut city = TestCity::new();
+    spawn_gas_plant(&mut city, 50, 50);
+
+    city.tick_slow_cycle();
+
+    let grid = city.resource::<EnergyGrid>();
+    let expected_output = GAS_CAPACITY_MW * GAS_CAPACITY_FACTOR;
+    assert!(
+        grid.total_supply_mwh >= expected_output - f32::EPSILON,
+        "Energy supply should include gas output ({expected_output} MW), got {}",
+        grid.total_supply_mwh
+    );
+}
+
+#[test]
+fn test_multiple_gas_plants_stack_supply() {
+    let mut city = TestCity::new();
+    spawn_gas_plant(&mut city, 50, 50);
+    spawn_gas_plant(&mut city, 60, 60);
+
+    city.tick_slow_cycle();
+
+    let grid = city.resource::<EnergyGrid>();
+    let expected = GAS_CAPACITY_MW * GAS_CAPACITY_FACTOR * 2.0;
+    assert!(
+        grid.total_supply_mwh >= expected - f32::EPSILON,
+        "Two gas plants should produce at least {expected} MW total supply, got {}",
+        grid.total_supply_mwh
+    );
+}
+
+// ====================================================================
+// Gas plant produces air pollution (less than coal)
+// ====================================================================
+
+#[test]
+fn test_gas_plant_produces_air_pollution() {
+    let mut city = TestCity::new();
+    spawn_gas_plant(&mut city, 50, 50);
+
+    city.tick_slow_cycle();
+
+    let pollution = city.resource::<PollutionGrid>();
+    let at_plant = pollution.get(50, 50);
+    assert!(
+        at_plant > 0,
+        "Pollution at gas plant location should be > 0, got {at_plant}"
+    );
+}
+
+#[test]
+fn test_gas_pollution_less_than_coal() {
+    // Gas plant pollution
+    let mut gas_city = TestCity::new();
+    spawn_gas_plant(&mut gas_city, 50, 50);
+    gas_city.tick_slow_cycle();
+    let gas_pollution = gas_city.resource::<PollutionGrid>().get(50, 50);
+
+    // Coal plant pollution
+    let mut coal_city = TestCity::new();
+    coal_city.world_mut().spawn(PowerPlant::new_coal(50, 50));
+    coal_city.tick_slow_cycle();
+    let coal_pollution = coal_city.resource::<PollutionGrid>().get(50, 50);
+
+    assert!(
+        gas_pollution < coal_pollution,
+        "Gas pollution ({gas_pollution}) should be less than coal ({coal_pollution})"
+    );
+}
+
+#[test]
+fn test_gas_pollution_radiates_outward() {
+    let mut city = TestCity::new();
+    spawn_gas_plant(&mut city, 50, 50);
+
+    city.tick_slow_cycle();
+
+    let pollution = city.resource::<PollutionGrid>();
+    let center = pollution.get(50, 50);
+    let near = pollution.get(53, 50);
+    let far = pollution.get(57, 50);
+
+    assert!(center > 0, "Center should have pollution, got {center}");
+    assert!(
+        near > 0 || center > near,
+        "Near cell should have some pollution"
+    );
+    assert!(
+        far <= center,
+        "Far cell ({far}) should not exceed center ({center})"
+    );
+}
+
+// ====================================================================
+// Fuel cost calculation
+// ====================================================================
+
+#[test]
+fn test_gas_fuel_cost_calculation() {
+    let mut city = TestCity::new();
+    spawn_gas_plant(&mut city, 50, 50);
+
+    city.tick_slow_cycle();
+
+    let state = city.resource::<GasPowerState>();
+    let expected_output = GAS_CAPACITY_MW * GAS_CAPACITY_FACTOR;
+    let expected_fuel_cost = expected_output * GAS_FUEL_COST_PER_MWH;
+
+    assert_eq!(state.plant_count, 1, "Should have 1 gas plant");
+    assert!(
+        (state.total_output_mw - expected_output).abs() < f32::EPSILON,
+        "Total output should be {expected_output}, got {}",
+        state.total_output_mw
+    );
+    assert!(
+        (state.total_fuel_cost - expected_fuel_cost).abs() < 0.01,
+        "Total fuel cost should be {expected_fuel_cost}, got {}",
+        state.total_fuel_cost
+    );
+}
+
+// ====================================================================
+// CO2 emissions
+// ====================================================================
+
+#[test]
+fn test_gas_co2_emissions() {
+    let mut city = TestCity::new();
+    spawn_gas_plant(&mut city, 50, 50);
+
+    city.tick_slow_cycle();
+
+    let state = city.resource::<GasPowerState>();
+    let expected_co2 = GAS_CAPACITY_MW * GAS_CAPACITY_FACTOR * GAS_CO2_TONS_PER_MWH;
+    assert!(
+        (state.total_co2_tons - expected_co2).abs() < f32::EPSILON,
+        "CO2 should be {expected_co2} tons, got {}",
+        state.total_co2_tons
+    );
+}
+
+#[test]
+fn test_gas_co2_lower_than_coal() {
+    // Gas CO2 per MW output should be lower than coal
+    assert!(
+        GAS_CO2_TONS_PER_MWH < crate::coal_power::COAL_CO2_TONS_PER_MWH,
+        "Gas CO2 rate ({}) should be lower than coal ({})",
+        GAS_CO2_TONS_PER_MWH,
+        crate::coal_power::COAL_CO2_TONS_PER_MWH
+    );
+}
+
+// ====================================================================
+// Empty city has zero gas output
+// ====================================================================
+
+#[test]
+fn test_no_gas_plants_zero_output() {
+    let mut city = TestCity::new();
+
+    city.tick_slow_cycle();
+
+    let state = city.resource::<GasPowerState>();
+    assert_eq!(state.plant_count, 0);
+    assert!((state.total_output_mw).abs() < f32::EPSILON);
+    assert!((state.total_fuel_cost).abs() < f32::EPSILON);
+    assert!((state.total_co2_tons).abs() < f32::EPSILON);
+}
+
+// ====================================================================
+// Gas and coal plants coexist
+// ====================================================================
+
+#[test]
+fn test_gas_and_coal_plants_coexist() {
+    let mut city = TestCity::new();
+    spawn_gas_plant(&mut city, 50, 50);
+    city.world_mut().spawn(PowerPlant::new_coal(60, 60));
+
+    city.tick_slow_cycle();
+
+    let gas_state = city.resource::<GasPowerState>();
+    assert_eq!(gas_state.plant_count, 1, "Should count only gas plants");
+
+    let grid = city.resource::<EnergyGrid>();
+    let gas_output = GAS_CAPACITY_MW * GAS_CAPACITY_FACTOR;
+    let coal_output =
+        crate::coal_power::COAL_CAPACITY_MW * crate::coal_power::COAL_CAPACITY_FACTOR;
+    let expected_total = gas_output + coal_output;
+    assert!(
+        grid.total_supply_mwh >= expected_total - f32::EPSILON,
+        "Combined supply should be at least {expected_total} MW, got {}",
+        grid.total_supply_mwh
+    );
+}
+
+// ====================================================================
+// PowerPlant type discrimination
+// ====================================================================
+
+#[test]
+fn test_gas_plant_has_correct_type() {
+    let plant = PowerPlant::new_gas(10, 20);
+    assert_eq!(plant.plant_type, PowerPlantType::NaturalGas);
+    assert_ne!(plant.plant_type, PowerPlantType::Coal);
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -71,6 +71,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
     app.add_plugins(degree_days::DegreeDaysPlugin);
     app.add_plugins(energy_demand::EnergyDemandPlugin);
     app.add_plugins(coal_power::CoalPowerPlugin);
+    app.add_plugins(gas_power::GasPowerPlugin);
     app.add_plugins(heating::HeatingPlugin);
     app.add_plugins(wind::WindPlugin);
     app.add_plugins(wind_damage::WindDamagePlugin);

--- a/crates/simulation/src/saveable_keys.rs
+++ b/crates/simulation/src/saveable_keys.rs
@@ -17,6 +17,7 @@ pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
     "chart_history",
     "climate_change",
     "coal_power",
+    "gas_power",
     "colorblind_settings",
     "cumulative_zoning",
     "day_night_controls",


### PR DESCRIPTION
## Summary
- Adds `GasPowerPlugin` implementing natural gas combined-cycle power plants with 500 MW capacity, 0.45 capacity factor, $40/MWh fuel cost, Q=35 air pollution (65% less than coal), 0.4 t/MWh CO2 emissions, and 2x3 building footprint
- Extends `PowerPlantType` enum with `NaturalGas` variant and adds `PowerPlant::new_gas()` constructor
- Adds `GasPowerState` resource with `Saveable` implementation for save/load persistence
- Includes comprehensive integration tests covering supply contribution, pollution, CO2 emissions, fuel costs, and coexistence with coal plants

## Test plan
- [ ] `test_gas_power_state_exists_in_new_city` — resource initializes correctly
- [ ] `test_gas_plant_increases_energy_supply` — single plant adds to EnergyGrid supply
- [ ] `test_multiple_gas_plants_stack_supply` — multiple plants stack additively
- [ ] `test_gas_plant_produces_air_pollution` — pollution generated at plant location
- [ ] `test_gas_pollution_less_than_coal` — gas pollution lower than coal (Q=35 vs Q=100)
- [ ] `test_gas_pollution_radiates_outward` — pollution decays with distance
- [ ] `test_gas_fuel_cost_calculation` — fuel cost = output * $40/MWh
- [ ] `test_gas_co2_emissions` — CO2 = output * 0.4 t/MWh
- [ ] `test_gas_co2_lower_than_coal` — gas CO2 rate lower than coal
- [ ] `test_no_gas_plants_zero_output` — empty city has zero gas output
- [ ] `test_gas_and_coal_plants_coexist` — both plant types contribute independently
- [ ] `test_gas_plant_has_correct_type` — PowerPlantType::NaturalGas discrimination

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)