### PR TITLE
Add crime types and justice pipeline (SERV-005)

### DIFF
--- a/crates/simulation/src/crime_justice.rs
+++ b/crates/simulation/src/crime_justice.rs
@@ -1,0 +1,499 @@
+//! SERV-005: Crime Types and Justice Pipeline
+//!
+//! Typed crime events, a justice pipeline (crime -> police response -> arrest
+//! -> court -> jail), and per-district crime statistics. Crime frequency
+//! depends on poverty, unemployment, and density. Police effectiveness and
+//! jail capacity create feedback loops influencing deterrence.
+
+use bevy::prelude::*;
+use bitcode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+use crate::crime::CrimeGrid;
+use crate::districts::{Districts, DISTRICTS_X, DISTRICTS_Y, DISTRICT_SIZE};
+use crate::services::{ServiceBuilding, ServiceType};
+use crate::Saveable;
+
+// ---------------------------------------------------------------------------
+// Crime types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encode, Decode, Serialize, Deserialize)]
+pub enum CrimeType {
+    PettyTheft,
+    Burglary,
+    Assault,
+    OrganizedCrime,
+}
+
+impl CrimeType {
+    pub fn base_weight(self) -> f32 {
+        match self {
+            Self::PettyTheft => 0.50,
+            Self::Burglary => 0.25,
+            Self::Assault => 0.15,
+            Self::OrganizedCrime => 0.10,
+        }
+    }
+    pub fn poverty_factor(self) -> f32 {
+        match self {
+            Self::PettyTheft => 1.5,
+            Self::Burglary => 1.2,
+            Self::Assault => 0.8,
+            Self::OrganizedCrime => 1.0,
+        }
+    }
+    pub fn unemployment_factor(self) -> f32 {
+        match self {
+            Self::PettyTheft => 1.3,
+            Self::Burglary => 1.4,
+            Self::Assault => 0.6,
+            Self::OrganizedCrime => 1.6,
+        }
+    }
+    pub fn density_factor(self) -> f32 {
+        match self {
+            Self::PettyTheft => 1.0,
+            Self::Burglary => 0.8,
+            Self::Assault => 1.3,
+            Self::OrganizedCrime => 1.5,
+        }
+    }
+    pub fn jail_time(self) -> u32 {
+        match self {
+            Self::PettyTheft => 1,
+            Self::Burglary => 3,
+            Self::Assault => 5,
+            Self::OrganizedCrime => 10,
+        }
+    }
+}
+
+const ALL_CRIME_TYPES: [CrimeType; 4] = [
+    CrimeType::PettyTheft,
+    CrimeType::Burglary,
+    CrimeType::Assault,
+    CrimeType::OrganizedCrime,
+];
+
+// ---------------------------------------------------------------------------
+// Justice pipeline stages
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize)]
+pub struct CrimeEvent {
+    pub crime_type: CrimeType,
+    pub district_x: usize,
+    pub district_y: usize,
+    pub stage: JusticeStage,
+    pub stage_timer: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode, Serialize, Deserialize)]
+pub enum JusticeStage {
+    Reported,
+    PoliceResponding,
+    Arrested,
+    InCourt,
+    InJail,
+    Resolved,
+}
+
+// ---------------------------------------------------------------------------
+// Per-district crime statistics
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, Encode, Decode, Serialize, Deserialize)]
+pub struct DistrictCrimeStats {
+    pub petty_theft_count: u32,
+    pub burglary_count: u32,
+    pub assault_count: u32,
+    pub organized_crime_count: u32,
+    pub total_arrests: u32,
+    pub total_convictions: u32,
+    pub active_cases: u32,
+}
+
+impl DistrictCrimeStats {
+    pub fn total_crimes(&self) -> u32 {
+        self.petty_theft_count
+            + self.burglary_count
+            + self.assault_count
+            + self.organized_crime_count
+    }
+    fn increment(&mut self, ct: CrimeType) {
+        match ct {
+            CrimeType::PettyTheft => self.petty_theft_count += 1,
+            CrimeType::Burglary => self.burglary_count += 1,
+            CrimeType::Assault => self.assault_count += 1,
+            CrimeType::OrganizedCrime => self.organized_crime_count += 1,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main resource
+// ---------------------------------------------------------------------------
+
+pub const PRISON_CAPACITY: u32 = 50;
+const BASE_CRIMES_PER_TICK: f32 = 0.5;
+
+#[derive(Resource, Clone, Debug, Encode, Decode, Serialize, Deserialize)]
+pub struct CrimeJusticeState {
+    pub events: Vec<CrimeEvent>,
+    pub district_stats: Vec<DistrictCrimeStats>,
+    pub jail_population: u32,
+    pub jail_capacity: u32,
+    pub police_effectiveness: f32,
+    pub deterrence: f32,
+    pub rng_state: u64,
+}
+
+impl Default for CrimeJusticeState {
+    fn default() -> Self {
+        Self {
+            events: Vec::new(),
+            district_stats: vec![DistrictCrimeStats::default(); DISTRICTS_X * DISTRICTS_Y],
+            jail_population: 0,
+            jail_capacity: 0,
+            police_effectiveness: 0.0,
+            deterrence: 0.5,
+            rng_state: 12345,
+        }
+    }
+}
+
+impl CrimeJusticeState {
+    pub fn get_district_stats(&self, dx: usize, dy: usize) -> &DistrictCrimeStats {
+        &self.district_stats[dy * DISTRICTS_X + dx]
+    }
+    pub fn get_district_stats_mut(&mut self, dx: usize, dy: usize) -> &mut DistrictCrimeStats {
+        &mut self.district_stats[dy * DISTRICTS_X + dx]
+    }
+    fn next_random(&mut self) -> f32 {
+        let mut x = self.rng_state;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.rng_state = x;
+        (x % 10000) as f32 / 10000.0
+    }
+}
+
+impl Saveable for CrimeJusticeState {
+    const SAVE_KEY: &'static str = "crime_justice";
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        Some(bitcode::encode(self))
+    }
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+pub fn update_police_effectiveness(
+    slow_timer: Res<crate::SlowTickTimer>,
+    services: Query<&ServiceBuilding>,
+    ext_budget: Res<crate::budget::ExtendedBudget>,
+    mut state: ResMut<CrimeJusticeState>,
+) {
+    if !slow_timer.should_run() {
+        return;
+    }
+    let budget = ext_budget.service_budgets.police;
+    let mut score: f32 = 0.0;
+    let mut prison_count: u32 = 0;
+    for service in &services {
+        match service.service_type {
+            ServiceType::PoliceKiosk => score += 5.0,
+            ServiceType::PoliceStation => score += 15.0,
+            ServiceType::PoliceHQ => score += 30.0,
+            ServiceType::Prison => prison_count += 1,
+            _ => {}
+        }
+    }
+    score *= budget;
+    state.police_effectiveness = (1.0 - 1.0 / (1.0 + score * 0.02)).clamp(0.0, 1.0);
+    state.jail_capacity = prison_count * PRISON_CAPACITY;
+    if state.jail_capacity == 0 {
+        state.deterrence = 0.1;
+    } else {
+        let util = state.jail_population as f32 / state.jail_capacity as f32;
+        state.deterrence = (1.0 - util * 0.5).clamp(0.1, 1.0);
+    }
+}
+
+pub fn generate_crimes(
+    slow_timer: Res<crate::SlowTickTimer>,
+    districts: Res<Districts>,
+    crime_grid: Res<CrimeGrid>,
+    mut state: ResMut<CrimeJusticeState>,
+) {
+    if !slow_timer.should_run() {
+        return;
+    }
+    for dy in 0..DISTRICTS_Y {
+        for dx in 0..DISTRICTS_X {
+            let dd = districts.get(dx, dy);
+            if dd.population == 0 {
+                continue;
+            }
+            let total_jobs = dd.commercial_jobs + dd.industrial_jobs + dd.office_jobs;
+            let unemployment_rate = if total_jobs > 0 {
+                1.0 - (dd.employed as f32 / dd.population as f32).clamp(0.0, 1.0)
+            } else {
+                0.8
+            };
+            let poverty_rate = (1.0 - dd.avg_happiness / 100.0).clamp(0.0, 1.0);
+            let density_rate = if dd.residential_capacity > 0 {
+                (dd.population as f32 / dd.residential_capacity as f32).clamp(0.0, 2.0) / 2.0
+            } else {
+                0.0
+            };
+            // Average crime level across district cells
+            let (mut crime_sum, mut cell_count) = (0.0f32, 0u32);
+            let (xs, ys) = (dx * DISTRICT_SIZE, dy * DISTRICT_SIZE);
+            for cy in ys..(ys + DISTRICT_SIZE).min(crate::config::GRID_HEIGHT) {
+                for cx in xs..(xs + DISTRICT_SIZE).min(crate::config::GRID_WIDTH) {
+                    let c = crime_grid.get(cx, cy);
+                    if c > 0 {
+                        crime_sum += c as f32;
+                        cell_count += 1;
+                    }
+                }
+            }
+            let grid_factor = if cell_count > 0 {
+                (crime_sum / cell_count as f32 / 25.0).clamp(0.0, 1.0)
+            } else {
+                0.0
+            };
+            let deterrence_mod = 1.0 - state.deterrence * 0.3;
+            let police_mod = 1.0 - state.police_effectiveness * 0.4;
+
+            for &ct in &ALL_CRIME_TYPES {
+                let combined = (poverty_rate * ct.poverty_factor()
+                    + unemployment_rate * ct.unemployment_factor()
+                    + density_rate * ct.density_factor())
+                    / 3.0;
+                let prob = BASE_CRIMES_PER_TICK
+                    * ct.base_weight()
+                    * combined
+                    * grid_factor
+                    * deterrence_mod
+                    * police_mod;
+                if state.next_random() < prob {
+                    state.events.push(CrimeEvent {
+                        crime_type: ct,
+                        district_x: dx,
+                        district_y: dy,
+                        stage: JusticeStage::Reported,
+                        stage_timer: 0,
+                    });
+                    state.get_district_stats_mut(dx, dy).increment(ct);
+                }
+            }
+        }
+    }
+}
+
+pub fn advance_justice_pipeline(
+    slow_timer: Res<crate::SlowTickTimer>,
+    mut state: ResMut<CrimeJusticeState>,
+) {
+    if !slow_timer.should_run() {
+        return;
+    }
+    let effectiveness = state.police_effectiveness;
+    let jail_cap = state.jail_capacity;
+    let mut jail_pop = state.jail_population;
+    for s in &mut state.district_stats {
+        s.active_cases = 0;
+    }
+    let events = std::mem::take(&mut state.events);
+    let mut kept = Vec::with_capacity(events.len());
+    for mut ev in events {
+        match ev.stage {
+            JusticeStage::Reported => {
+                ev.stage = JusticeStage::PoliceResponding;
+                ev.stage_timer = 1;
+                kept.push(ev);
+            }
+            JusticeStage::PoliceResponding => {
+                if ev.stage_timer > 0 {
+                    ev.stage_timer -= 1;
+                    kept.push(ev);
+                    continue;
+                }
+                let roll = {
+                    let mut x = state.rng_state;
+                    x ^= x << 13;
+                    x ^= x >> 7;
+                    x ^= x << 17;
+                    state.rng_state = x;
+                    (x % 10000) as f32 / 10000.0
+                };
+                if roll < effectiveness * 0.7 + 0.1 {
+                    ev.stage = JusticeStage::Arrested;
+                    ev.stage_timer = 1;
+                    let di = ev.district_y * DISTRICTS_X + ev.district_x;
+                    if di < state.district_stats.len() {
+                        state.district_stats[di].total_arrests += 1;
+                    }
+                    kept.push(ev);
+                }
+                // else criminal escapes
+            }
+            JusticeStage::Arrested => {
+                if ev.stage_timer > 0 {
+                    ev.stage_timer -= 1;
+                    kept.push(ev);
+                    continue;
+                }
+                ev.stage = JusticeStage::InCourt;
+                ev.stage_timer = 1;
+                kept.push(ev);
+            }
+            JusticeStage::InCourt => {
+                if ev.stage_timer > 0 {
+                    ev.stage_timer -= 1;
+                    kept.push(ev);
+                    continue;
+                }
+                if jail_pop < jail_cap {
+                    ev.stage = JusticeStage::InJail;
+                    ev.stage_timer = ev.crime_type.jail_time();
+                    jail_pop += 1;
+                    let di = ev.district_y * DISTRICTS_X + ev.district_x;
+                    if di < state.district_stats.len() {
+                        state.district_stats[di].total_convictions += 1;
+                    }
+                    kept.push(ev);
+                }
+                // else released (overcrowding)
+            }
+            JusticeStage::InJail => {
+                if ev.stage_timer > 0 {
+                    ev.stage_timer -= 1;
+                    kept.push(ev);
+                } else {
+                    jail_pop = jail_pop.saturating_sub(1);
+                }
+            }
+            JusticeStage::Resolved => {} // drop
+        }
+    }
+    for ev in &kept {
+        let di = ev.district_y * DISTRICTS_X + ev.district_x;
+        if di < state.district_stats.len() {
+            state.district_stats[di].active_cases += 1;
+        }
+    }
+    state.events = kept;
+    state.jail_population = jail_pop;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+pub struct CrimeJusticePlugin;
+
+impl Plugin for CrimeJusticePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<CrimeJusticeState>();
+
+        // Register for save/load via the SaveableRegistry.
+        app.init_resource::<crate::SaveableRegistry>();
+        app.world_mut()
+            .resource_mut::<crate::SaveableRegistry>()
+            .register::<CrimeJusticeState>();
+
+        app.add_systems(
+                FixedUpdate,
+                (
+                    update_police_effectiveness,
+                    generate_crimes,
+                    advance_justice_pipeline,
+                )
+                    .chain()
+                    .after(crate::crime::update_crime)
+                    .in_set(crate::SimulationSet::Simulation),
+            );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_crime_type_weights_sum_to_one() {
+        let sum: f32 = ALL_CRIME_TYPES.iter().map(|c| c.base_weight()).sum();
+        assert!((sum - 1.0).abs() < 0.01);
+    }
+    #[test]
+    fn test_crime_type_jail_times_ordered() {
+        assert!(CrimeType::PettyTheft.jail_time() < CrimeType::Burglary.jail_time());
+        assert!(CrimeType::Burglary.jail_time() < CrimeType::Assault.jail_time());
+        assert!(CrimeType::Assault.jail_time() < CrimeType::OrganizedCrime.jail_time());
+    }
+    #[test]
+    fn test_default_state() {
+        let s = CrimeJusticeState::default();
+        assert!(s.events.is_empty());
+        assert_eq!(s.jail_population, 0);
+        assert_eq!(s.district_stats.len(), DISTRICTS_X * DISTRICTS_Y);
+    }
+    #[test]
+    fn test_district_crime_stats_increment() {
+        let mut s = DistrictCrimeStats::default();
+        s.increment(CrimeType::PettyTheft);
+        s.increment(CrimeType::PettyTheft);
+        s.increment(CrimeType::Assault);
+        assert_eq!(s.petty_theft_count, 2);
+        assert_eq!(s.assault_count, 1);
+        assert_eq!(s.total_crimes(), 3);
+    }
+    #[test]
+    fn test_rng_deterministic() {
+        let mut a = CrimeJusticeState::default();
+        let mut b = CrimeJusticeState::default();
+        let sa: Vec<f32> = (0..10).map(|_| a.next_random()).collect();
+        let sb: Vec<f32> = (0..10).map(|_| b.next_random()).collect();
+        assert_eq!(sa, sb);
+    }
+    #[test]
+    fn test_rng_values_in_range() {
+        let mut s = CrimeJusticeState::default();
+        for _ in 0..100 {
+            let v = s.next_random();
+            assert!(v >= 0.0 && v < 1.0, "value {v} out of range");
+        }
+    }
+    #[test]
+    fn test_saveable_roundtrip() {
+        let mut s = CrimeJusticeState::default();
+        s.jail_population = 42;
+        s.police_effectiveness = 0.75;
+        s.events.push(CrimeEvent {
+            crime_type: CrimeType::Burglary,
+            district_x: 3,
+            district_y: 5,
+            stage: JusticeStage::InJail,
+            stage_timer: 2,
+        });
+        let bytes = s.save_to_bytes().unwrap();
+        let r = CrimeJusticeState::load_from_bytes(&bytes);
+        assert_eq!(r.jail_population, 42);
+        assert!((r.police_effectiveness - 0.75).abs() < 0.001);
+        assert_eq!(r.events.len(), 1);
+        assert_eq!(r.events[0].crime_type, CrimeType::Burglary);
+    }
+}

--- a/crates/simulation/src/integration_tests/crime_justice_tests.rs
+++ b/crates/simulation/src/integration_tests/crime_justice_tests.rs
@@ -1,0 +1,260 @@
+//! SERV-005: Integration tests for Crime Types and Justice Pipeline.
+
+use crate::crime_justice::{CrimeJusticeState, CrimeType, JusticeStage, PRISON_CAPACITY};
+use crate::services::ServiceType;
+use crate::test_harness::TestCity;
+
+fn tick_slow(city: &mut TestCity) {
+    city.tick_slow_cycles(1);
+}
+
+// ====================================================================
+// 1. Crime generation
+// ====================================================================
+
+#[test]
+fn test_no_crimes_in_empty_city() {
+    let mut city = TestCity::new();
+    tick_slow(&mut city);
+    let state = city.resource::<CrimeJusticeState>();
+    let total: u32 = state.district_stats.iter().map(|s| s.total_crimes()).sum();
+    assert_eq!(total, 0, "Empty city should have no crimes");
+}
+
+#[test]
+fn test_crimes_generated_in_tel_aviv() {
+    let mut city = TestCity::with_tel_aviv();
+    for _ in 0..10 {
+        tick_slow(&mut city);
+    }
+    let state = city.resource::<CrimeJusticeState>();
+    let total: u32 = state.district_stats.iter().map(|s| s.total_crimes()).sum();
+    assert!(
+        total > 0,
+        "Tel Aviv city should generate crimes, got total={total}"
+    );
+}
+
+#[test]
+fn test_empty_district_has_no_crimes() {
+    // Use Tel Aviv but check a district far from the populated area
+    let mut city = TestCity::with_tel_aviv();
+    for _ in 0..10 {
+        tick_slow(&mut city);
+    }
+    let state = city.resource::<CrimeJusticeState>();
+    // District (15,15) is at the far corner - likely empty
+    let c_corner = state.get_district_stats(15, 15).total_crimes();
+    assert_eq!(c_corner, 0, "Far corner district should have no crimes");
+}
+
+// ====================================================================
+// 2. Police effectiveness
+// ====================================================================
+
+#[test]
+fn test_police_effectiveness_zero_without_services() {
+    let mut city = TestCity::new();
+    tick_slow(&mut city);
+    let s = city.resource::<CrimeJusticeState>();
+    assert!(
+        s.police_effectiveness < 0.01,
+        "No police = ~0 effectiveness"
+    );
+}
+
+#[test]
+fn test_police_effectiveness_increases_with_stations() {
+    let mut city = TestCity::new()
+        .with_service(50, 50, ServiceType::PoliceStation)
+        .with_service(100, 100, ServiceType::PoliceStation);
+    tick_slow(&mut city);
+    let s = city.resource::<CrimeJusticeState>();
+    assert!(
+        s.police_effectiveness > 0.2,
+        "Two stations should give > 0.2, got {}",
+        s.police_effectiveness
+    );
+}
+
+#[test]
+fn test_police_hq_more_effective_than_kiosk() {
+    let mut city_hq = TestCity::new().with_service(50, 50, ServiceType::PoliceHQ);
+    tick_slow(&mut city_hq);
+    let eff_hq = city_hq
+        .resource::<CrimeJusticeState>()
+        .police_effectiveness;
+
+    let mut city_kiosk = TestCity::new().with_service(50, 50, ServiceType::PoliceKiosk);
+    tick_slow(&mut city_kiosk);
+    let eff_kiosk = city_kiosk
+        .resource::<CrimeJusticeState>()
+        .police_effectiveness;
+
+    assert!(eff_hq > eff_kiosk, "HQ ({eff_hq}) > kiosk ({eff_kiosk})");
+}
+
+#[test]
+fn test_police_effectiveness_capped_at_one() {
+    let mut city = TestCity::new()
+        .with_service(10, 10, ServiceType::PoliceHQ)
+        .with_service(30, 30, ServiceType::PoliceHQ)
+        .with_service(50, 50, ServiceType::PoliceHQ)
+        .with_service(70, 70, ServiceType::PoliceHQ)
+        .with_service(90, 90, ServiceType::PoliceHQ);
+    tick_slow(&mut city);
+    let s = city.resource::<CrimeJusticeState>();
+    assert!(
+        s.police_effectiveness <= 1.0,
+        "Capped at 1.0, got {}",
+        s.police_effectiveness
+    );
+}
+
+// ====================================================================
+// 3. Jail capacity and deterrence
+// ====================================================================
+
+#[test]
+fn test_jail_capacity_from_prisons() {
+    let mut city = TestCity::new()
+        .with_service(50, 50, ServiceType::Prison)
+        .with_service(100, 100, ServiceType::Prison);
+    tick_slow(&mut city);
+    let s = city.resource::<CrimeJusticeState>();
+    assert_eq!(s.jail_capacity, 2 * PRISON_CAPACITY);
+}
+
+#[test]
+fn test_low_deterrence_without_prison() {
+    let mut city = TestCity::new();
+    tick_slow(&mut city);
+    let s = city.resource::<CrimeJusticeState>();
+    assert!(
+        s.deterrence <= 0.15,
+        "No prisons = low deterrence, got {}",
+        s.deterrence
+    );
+}
+
+#[test]
+fn test_deterrence_high_with_empty_prison() {
+    let mut city = TestCity::new().with_service(50, 50, ServiceType::Prison);
+    tick_slow(&mut city);
+    let s = city.resource::<CrimeJusticeState>();
+    assert!(
+        s.deterrence > 0.8,
+        "Empty prison = high deterrence, got {}",
+        s.deterrence
+    );
+}
+
+// ====================================================================
+// 4. Justice pipeline
+// ====================================================================
+
+#[test]
+fn test_justice_pipeline_stages_advance() {
+    let mut city = TestCity::new()
+        .with_service(50, 50, ServiceType::PoliceStation)
+        .with_service(60, 60, ServiceType::Prison);
+    {
+        let world = city.world_mut();
+        let mut state = world.resource_mut::<CrimeJusticeState>();
+        state.events.push(crate::crime_justice::CrimeEvent {
+            crime_type: CrimeType::PettyTheft,
+            district_x: 0,
+            district_y: 0,
+            stage: JusticeStage::Reported,
+            stage_timer: 0,
+        });
+        state.police_effectiveness = 0.9;
+        state.jail_capacity = PRISON_CAPACITY;
+    }
+    for _ in 0..10 {
+        tick_slow(&mut city);
+    }
+    let state = city.resource::<CrimeJusticeState>();
+    let reported = state
+        .events
+        .iter()
+        .filter(|e| e.stage == JusticeStage::Reported)
+        .count();
+    assert_eq!(
+        reported, 0,
+        "Reported events should advance past initial stage"
+    );
+}
+
+#[test]
+fn test_resolved_events_are_removed() {
+    let mut city = TestCity::new();
+    {
+        let world = city.world_mut();
+        let mut state = world.resource_mut::<CrimeJusticeState>();
+        state.events.push(crate::crime_justice::CrimeEvent {
+            crime_type: CrimeType::Assault,
+            district_x: 0,
+            district_y: 0,
+            stage: JusticeStage::InJail,
+            stage_timer: 0,
+        });
+        state.jail_population = 1;
+    }
+    tick_slow(&mut city);
+    let state = city.resource::<CrimeJusticeState>();
+    let jail = state
+        .events
+        .iter()
+        .filter(|e| e.stage == JusticeStage::InJail)
+        .count();
+    assert_eq!(jail, 0, "Completed jail term should resolve");
+}
+
+// ====================================================================
+// 5. Crime type properties
+// ====================================================================
+
+#[test]
+fn test_crime_types_have_valid_factors() {
+    for ct in [
+        CrimeType::PettyTheft,
+        CrimeType::Burglary,
+        CrimeType::Assault,
+        CrimeType::OrganizedCrime,
+    ] {
+        assert!(ct.base_weight() > 0.0);
+        assert!(ct.poverty_factor() > 0.0);
+        assert!(ct.unemployment_factor() > 0.0);
+        assert!(ct.density_factor() > 0.0);
+        assert!(ct.jail_time() > 0);
+    }
+}
+
+#[test]
+fn test_petty_theft_most_common() {
+    assert!(CrimeType::PettyTheft.base_weight() > CrimeType::OrganizedCrime.base_weight());
+    assert!(CrimeType::PettyTheft.base_weight() > CrimeType::Assault.base_weight());
+}
+
+// ====================================================================
+// 6. Saveable roundtrip
+// ====================================================================
+
+#[test]
+fn test_crime_justice_state_persists() {
+    use crate::Saveable;
+    let mut s = CrimeJusticeState::default();
+    s.jail_population = 15;
+    s.jail_capacity = 100;
+    s.police_effectiveness = 0.65;
+    s.deterrence = 0.8;
+    s.get_district_stats_mut(3, 4).petty_theft_count = 42;
+    let bytes = s.save_to_bytes().expect("should serialize");
+    let r = CrimeJusticeState::load_from_bytes(&bytes);
+    assert_eq!(r.jail_population, 15);
+    assert_eq!(r.jail_capacity, 100);
+    assert!((r.police_effectiveness - 0.65).abs() < 0.001);
+    assert!((r.deterrence - 0.8).abs() < 0.001);
+    assert_eq!(r.get_district_stats(3, 4).petty_theft_count, 42);
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -82,6 +82,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
     app.add_plugins(drought::DroughtPlugin);
     app.add_plugins(noise::NoisePlugin);
     app.add_plugins(crime::CrimePlugin);
+    app.add_plugins(crime_justice::CrimeJusticePlugin);
     app.add_plugins(health::HealthPlugin);
     app.add_plugins(death_care::DeathCarePlugin);
     app.add_plugins(climate_change::ClimateChangePlugin);

--- a/crates/simulation/src/saveable_keys.rs
+++ b/crates/simulation/src/saveable_keys.rs
@@ -19,6 +19,7 @@ pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
     "coal_power",
     "colorblind_settings",
     "crime_grid",
+    "crime_justice",
     "cumulative_zoning",
     "day_night_controls",
     "dismissed_advisor_tips",


### PR DESCRIPTION
## Summary
- Implement 4 crime types (petty theft, burglary, assault, organized crime) with frequency driven by poverty, unemployment, and population density
- Add justice pipeline: crime reported -> police response -> arrest -> court -> jail, with police effectiveness based on officer count/budget and jail capacity limits
- Track per-district crime statistics; state persists via Saveable extension map

Closes #748

## Test plan
- [ ] Verify no crimes in empty city
- [ ] Verify crimes generated with population and crime conditions
- [ ] Verify high unemployment increases crime rate
- [ ] Verify police effectiveness scales with police buildings
- [ ] Verify HQ more effective than kiosk
- [ ] Verify jail capacity from prisons
- [ ] Verify deterrence drops without prisons
- [ ] Verify justice pipeline stages advance
- [ ] Verify resolved events are removed
- [ ] Verify per-district stats tracked independently
- [ ] Verify police reduce crime generation
- [ ] Verify saveable roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)