### PR TITLE
Optimize CI: concurrency groups + remove redundant main trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
     branches: [main]
   merge_group:
-  push:
-    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Add `concurrency` group with `cancel-in-progress: true` — when a new push arrives on the same branch, cancel the previous (stale) CI run instead of wasting a runner slot
- Remove `push: branches: [main]` trigger — PR checks already validate code before merge; re-running on merge is redundant (we had 3 simultaneous `main` runs competing with 8 PR runs for runners)

## Impact
With 8+ parallel PRs, CI runner contention was the main bottleneck. These two changes should roughly halve queue wait times by:
1. Not running stale CI (old push superseded by new push)
2. Not running redundant CI on merge-to-main

## Test plan
- [x] CI still runs on PRs (this PR itself validates it)
- [ ] Verify stale runs get cancelled when pushing again to a branch
- [ ] Verify no CI runs on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)