### PR TITLE
Add save/load round-trip integration tests (TEST-034)

### DIFF
--- a/crates/simulation/src/integration_tests/save_load_roundtrip_tests.rs
+++ b/crates/simulation/src/integration_tests/save_load_roundtrip_tests.rs
@@ -13,7 +13,7 @@ use crate::citizen::{
     CitizenDetails, CitizenState, CitizenStateComp, Gender, Needs, Personality, Position, Velocity,
 };
 use crate::economy::CityBudget;
-use crate::grid::{CellType, RoadType, WorldGrid, ZoneType};
+use crate::grid::{CellType, RoadType, ZoneType};
 use crate::services::{ServiceBuilding, ServiceType};
 use crate::test_harness::TestCity;
 use crate::time_of_day::GameClock;


### PR DESCRIPTION
## Summary
- Adds `save_load_roundtrip_tests.rs` with 8 integration tests covering all acceptance criteria from issue #813
- Tests verify grid cells (cell_type, zone, road_type), citizen count, treasury, building count, road segment count, service/utility data all survive save/load roundtrips
- Includes determinism test with 10 consecutive save/load cycles

## Test plan
- [ ] CI passes: `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check`
- [ ] New tests exercise the SaveableRegistry save_all/load_all path
- [ ] New tests exercise serde roundtrip of individual components (grid cells, budget, buildings, citizens, services, utilities, game clock)
- [ ] Multiple-cycle test confirms no state drift across 10 roundtrips

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)