### PR TITLE
Fix flaky homelessness and citizen state machine tests

### DIFF
--- a/crates/simulation/src/integration_tests/citizen_state_machine.rs
+++ b/crates/simulation/src/integration_tests/citizen_state_machine.rs
@@ -104,6 +104,12 @@ fn spawn_citizen_in_state(
 /// Also boosts all existing citizens' stats to prevent lifecycle emigration
 /// (which fires when happiness < 20.0).
 fn prevent_emigration(city: &mut TestCity) {
+    // Set tax rate to 0 so the attractiveness tax_factor contributes
+    // the full 15 points when compute_attractiveness recalculates.
+    {
+        let mut budget = city.world_mut().resource_mut::<crate::economy::CityBudget>();
+        budget.tax_rate = 0.0;
+    }
     {
         let mut attr = city.world_mut().resource_mut::<CityAttractiveness>();
         attr.overall_score = 80.0;


### PR DESCRIPTION
## Summary
- Fixes intermittent test failures in `homelessness.rs` and `citizen_state_machine.rs` integration tests
- Citizens were being despawned mid-test by emigration systems (immigration_wave when CityAttractiveness < 30, lifecycle emigration when happiness < 20)
- Added `prevent_emigration()` and `make_citizens_robust()` helpers that set CityAttractiveness high and boost citizen stats before each tick window
- Spawned citizens in `spawn_citizen_in_state` now use robust defaults (age=25, happiness=95, health=100, savings=50000)

## Affected tests
- `test_homelessness_happiness_penalty_applied`
- `test_homelessness_shelter_capacity_respected`
- `test_homelessness_ticks_homeless_increments`
- `test_full_daily_commute_cycle_evening_departure`
- `test_full_daily_commute_cycle_morning_departure`
- `test_working_citizen_stays_at_work_before_evening`
- Plus preventive fixes to other tests in the same files

## Test plan
- [ ] All integration tests pass in CI (no simulation logic changed)
- [ ] Previously flaky tests should now be stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)