### PR TITLE
Add integration test: citizens spawn in completed buildings (TEST-015)

### DIFF
--- a/crates/simulation/src/integration_tests/citizen_spawn_building_tests.rs
+++ b/crates/simulation/src/integration_tests/citizen_spawn_building_tests.rs
@@ -7,7 +7,7 @@
 use bevy::prelude::*;
 
 use crate::buildings::{Building, UnderConstruction};
-use crate::citizen::{Citizen, CitizenDetails, HomeLocation, WorkLocation};
+use crate::citizen::{Citizen, HomeLocation, WorkLocation};
 use crate::grid::{RoadType, ZoneType};
 use crate::immigration::CityAttractiveness;
 use crate::test_harness::TestCity;


### PR DESCRIPTION
## Summary
- Adds `citizen_spawn_building_tests.rs` integration test for issue TEST-015
- Verifies completed ResidentialLow buildings (capacity > 0) and CommercialLow buildings exist after construction
- Confirms citizens spawn via immigration with valid `HomeLocation` and `WorkLocation` components after 50+ ticks
- Uses standard `TestCity` harness with zoned corridor pattern (road + power + water + zones)

## Test plan
- [ ] CI passes: `cargo test --workspace` compiles and runs the new tests
- [ ] `cargo clippy --workspace -- -D warnings` has no warnings
- [ ] `cargo fmt --all -- --check` passes

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)