### PR TITLE
Add integration tests for fire spread and containment (TEST-018)

### DIFF
--- a/crates/simulation/src/integration_tests/fire_containment_tests.rs
+++ b/crates/simulation/src/integration_tests/fire_containment_tests.rs
@@ -63,15 +63,6 @@ fn is_building_on_fire(city: &mut TestCity, gx: usize, gy: usize) -> bool {
     query.iter(world).any(|(b, _)| b.grid_x == gx && b.grid_y == gy)
 }
 
-/// Get fire intensity for a building at (gx, gy), or None if not on fire.
-fn building_fire_intensity(city: &mut TestCity, gx: usize, gy: usize) -> Option<f32> {
-    let world = city.world_mut();
-    let mut query = world.query::<(&Building, &OnFire)>();
-    query
-        .iter(world)
-        .find(|(b, _)| b.grid_x == gx && b.grid_y == gy)
-        .map(|(_, f)| f.intensity)
-}
 
 // ====================================================================
 // Test 1: Fire at (50,50) with fire station — contained after 200 ticks


### PR DESCRIPTION
## Summary
- Adds `fire_containment_tests.rs` with 5 integration tests for fire spread and extinguish mechanics (TEST-018)
- Tests verify fire at (50,50) is contained with fire station coverage and spreads further without one
- Covers fire grid state updates, coverage radius verification, and comparative fire station impact

## Test Plan
- [x] `test_fire_at_50_50_contained_with_fire_station` — fire station extinguishes small fire within 200 ticks
- [x] `test_fire_at_50_50_spreads_without_fire_station` — fire persists/spreads without coverage
- [x] `test_fire_station_reduces_total_fire_spread` — comparative scenario proves fire station reduces damage
- [x] `test_fire_grid_updated_when_buildings_burn` — FireGrid resource reflects OnFire component state
- [x] `test_fire_station_coverage_radius_verification` — coverage radius correctly covers nearby but not distant buildings

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)