### PR TITLE
Implement Saveable for HeatingGrid (SAVE-040)

### DIFF
--- a/crates/simulation/src/heating_save.rs
+++ b/crates/simulation/src/heating_save.rs
@@ -1,0 +1,45 @@
+//! Saveable implementation for HeatingGrid.
+//!
+//! Persists heating network coverage across save/load cycles so the
+//! heating overlay matches pre-save state without waiting for a full
+//! recomputation tick.
+
+use bevy::prelude::*;
+
+use crate::heating::HeatingGrid;
+use crate::Saveable;
+
+impl Saveable for HeatingGrid {
+    const SAVE_KEY: &'static str = "heating_grid";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.levels.iter().all(|&v| v == 0) {
+            return None;
+        }
+        Some(bitcode::encode(&self.levels))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        let expected = crate::config::GRID_WIDTH * crate::config::GRID_HEIGHT;
+        let levels = match bitcode::decode::<Vec<u8>>(bytes) {
+            Ok(v) if v.len() == expected => v,
+            _ => vec![0; expected],
+        };
+        Self {
+            levels,
+            width: crate::config::GRID_WIDTH,
+            height: crate::config::GRID_HEIGHT,
+        }
+    }
+}
+
+/// Plugin that registers `HeatingGrid` with the saveable registry.
+pub struct HeatingSavePlugin;
+
+impl Plugin for HeatingSavePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<crate::SaveableRegistry>();
+        let mut registry = app.world_mut().resource_mut::<crate::SaveableRegistry>();
+        registry.register::<HeatingGrid>();
+    }
+}

--- a/crates/simulation/src/integration_tests/heating_save_tests.rs
+++ b/crates/simulation/src/integration_tests/heating_save_tests.rs
@@ -1,0 +1,113 @@
+//! Integration tests for SAVE-040: Serialize HeatingGrid.
+//!
+//! Verifies that heating network coverage persists across save/load cycles
+//! so the heating overlay matches its pre-save state.
+
+use crate::config::{GRID_HEIGHT, GRID_WIDTH};
+use crate::heating::HeatingGrid;
+use crate::Saveable;
+
+// ---------------------------------------------------------------------------
+// Round-trip: non-trivial heating grid survives save/load
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_heating_grid_save_load_round_trip() {
+    let mut grid = HeatingGrid::default();
+    assert_eq!(grid.levels.len(), GRID_WIDTH * GRID_HEIGHT);
+
+    // Set some non-trivial heating values
+    grid.set(10, 10, 255);
+    grid.set(11, 10, 200);
+    grid.set(12, 10, 150);
+    grid.set(13, 10, 100);
+    grid.set(14, 10, 50);
+    grid.set(10, 11, 180);
+    grid.set(0, 0, 42);
+    grid.set(GRID_WIDTH - 1, GRID_HEIGHT - 1, 99);
+
+    // Serialize
+    let bytes = grid
+        .save_to_bytes()
+        .expect("non-zero grid should produce Some bytes");
+
+    // Deserialize
+    let restored = HeatingGrid::load_from_bytes(&bytes);
+
+    assert_eq!(restored.width, GRID_WIDTH);
+    assert_eq!(restored.height, GRID_HEIGHT);
+    assert_eq!(restored.levels.len(), GRID_WIDTH * GRID_HEIGHT);
+
+    // Verify all cells match
+    for y in 0..GRID_HEIGHT {
+        for x in 0..GRID_WIDTH {
+            assert_eq!(
+                restored.get(x, y),
+                grid.get(x, y),
+                "mismatch at ({}, {}): expected {}, got {}",
+                x,
+                y,
+                grid.get(x, y),
+                restored.get(x, y),
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Default (all-zero) grid returns None on save
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_heating_grid_default_returns_none_on_save() {
+    let grid = HeatingGrid::default();
+    assert!(
+        grid.save_to_bytes().is_none(),
+        "all-zero heating grid should return None (skip saving)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Corrupt / wrong-length bytes fall back to default
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_heating_grid_load_from_corrupt_bytes_returns_default() {
+    let corrupt = vec![0xFF, 0xFE, 0xFD];
+    let restored = HeatingGrid::load_from_bytes(&corrupt);
+
+    assert_eq!(restored.width, GRID_WIDTH);
+    assert_eq!(restored.height, GRID_HEIGHT);
+    assert_eq!(restored.levels.len(), GRID_WIDTH * GRID_HEIGHT);
+    assert!(
+        restored.levels.iter().all(|&v| v == 0),
+        "corrupt bytes should produce an all-zero default grid"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Wrong-length valid decode falls back to default
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_heating_grid_load_from_wrong_length_returns_default() {
+    // Encode a smaller vector -- valid bitcode but wrong grid size
+    let small_vec: Vec<u8> = vec![1, 2, 3, 4, 5];
+    let bytes = bitcode::encode(&small_vec);
+
+    let restored = HeatingGrid::load_from_bytes(&bytes);
+    assert_eq!(restored.levels.len(), GRID_WIDTH * GRID_HEIGHT);
+    assert!(
+        restored.levels.iter().all(|&v| v == 0),
+        "wrong-length decode should produce an all-zero default grid"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Save key is correct
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_heating_grid_save_key() {
+    assert_eq!(HeatingGrid::SAVE_KEY, "heating_grid");
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -208,4 +208,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
     app.add_plugins(social_services::SocialServicesPlugin);
     // Wind-aware Gaussian plume pollution dispersion (SVC-021)
     app.add_plugins(wind_pollution::WindPollutionPlugin);
+
+    // Heating grid save/load (SAVE-040)
+    app.add_plugins(heating_save::HeatingSavePlugin);
 }

--- a/crates/simulation/src/saveable_keys.rs
+++ b/crates/simulation/src/saveable_keys.rs
@@ -40,6 +40,7 @@ pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
     "gas_power",
     "groundwater_grid",
     "heat_mitigation",
+    "heating_grid",
     "heating_service",
     "historic_preservation",
     "hotel_demand",


### PR DESCRIPTION
## Summary
- Implement `Saveable` for `HeatingGrid` so heating network coverage persists across save/load cycles
- Add `heating_save.rs` with bitcode-based serialization (matching `env_grid_save.rs` pattern)
- Register `HeatingSavePlugin` in `plugin_registration.rs` and add key to `saveable_keys.rs`
- Add integration tests: round-trip fidelity, default-skip optimization, corrupt/wrong-length fallback

## Test plan
- [ ] `test_heating_grid_save_load_round_trip` — non-trivial grid survives encode/decode
- [ ] `test_heating_grid_default_returns_none_on_save` — all-zero grid skips save
- [ ] `test_heating_grid_load_from_corrupt_bytes_returns_default` — corrupt bytes fall back to default
- [ ] `test_heating_grid_load_from_wrong_length_returns_default` — wrong-size decode falls back
- [ ] `test_heating_grid_save_key` — key matches expected constant

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)