### PR TITLE
Implement Saveable for TrafficGrid (SAVE-036)

### DIFF
--- a/crates/simulation/src/integration_tests/traffic_grid_save_tests.rs
+++ b/crates/simulation/src/integration_tests/traffic_grid_save_tests.rs
@@ -1,0 +1,145 @@
+//! Integration tests for TrafficGrid save/load roundtrips.
+
+use crate::test_harness::TestCity;
+use crate::traffic::TrafficGrid;
+use crate::SaveableRegistry;
+
+// ====================================================================
+// Roundtrip helper
+// ====================================================================
+
+fn roundtrip(city: &mut TestCity) {
+    let world = city.world_mut();
+    let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+
+    let extensions = registry.save_all(world);
+    registry.reset_all(world);
+    registry.load_all(world, &extensions);
+
+    world.insert_resource(registry);
+}
+
+// ====================================================================
+// Basic roundtrip
+// ====================================================================
+
+#[test]
+fn test_traffic_grid_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut grid = world.resource_mut::<TrafficGrid>();
+        grid.set(10, 10, 5);
+        grid.set(100, 200, 42);
+        grid.set(50, 50, u16::MAX);
+    }
+
+    roundtrip(&mut city);
+
+    let grid = city.resource::<TrafficGrid>();
+    assert_eq!(grid.get(10, 10), 5);
+    assert_eq!(grid.get(100, 200), 42);
+    assert_eq!(grid.get(50, 50), u16::MAX);
+    assert_eq!(grid.get(0, 0), 0);
+}
+
+// ====================================================================
+// Default grid skips saving (returns None)
+// ====================================================================
+
+#[test]
+fn test_traffic_grid_default_skips_save() {
+    use crate::Saveable;
+
+    assert!(TrafficGrid::default().save_to_bytes().is_none());
+}
+
+// ====================================================================
+// Reset clears traffic data (no stale data)
+// ====================================================================
+
+#[test]
+fn test_traffic_grid_reset_clears_data() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut grid = world.resource_mut::<TrafficGrid>();
+        grid.set(10, 10, 99);
+    }
+
+    // Reset via registry
+    {
+        let world = city.world_mut();
+        let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+        registry.reset_all(world);
+        world.insert_resource(registry);
+    }
+
+    let grid = city.resource::<TrafficGrid>();
+    assert_eq!(grid.get(10, 10), 0, "stale traffic data should be cleared after reset");
+}
+
+// ====================================================================
+// Corrupted bytes fall back to default
+// ====================================================================
+
+#[test]
+fn test_traffic_grid_corrupted_bytes_fallback() {
+    use crate::Saveable;
+
+    let garbage = vec![0xFF, 0xFE, 0xFD, 0xFC, 0xFB];
+    let grid = TrafficGrid::load_from_bytes(&garbage);
+
+    assert_eq!(
+        grid.density.len(),
+        crate::config::GRID_WIDTH * crate::config::GRID_HEIGHT
+    );
+    assert!(grid.density.iter().all(|&v| v == 0));
+}
+
+// ====================================================================
+// Save key is registered
+// ====================================================================
+
+#[test]
+fn test_traffic_grid_save_key_registered() {
+    let city = TestCity::new();
+    let registry = city.resource::<SaveableRegistry>();
+    let registered: std::collections::HashSet<&str> =
+        registry.entries.iter().map(|e| e.key.as_str()).collect();
+
+    assert!(
+        registered.contains("traffic_grid"),
+        "Expected 'traffic_grid' to be registered in SaveableRegistry"
+    );
+}
+
+// ====================================================================
+// Traffic overlay functional after load (non-zero values preserved)
+// ====================================================================
+
+#[test]
+fn test_traffic_overlay_functional_after_load() {
+    let mut city = TestCity::new();
+
+    // Simulate some traffic density
+    {
+        let world = city.world_mut();
+        let mut grid = world.resource_mut::<TrafficGrid>();
+        grid.set(20, 20, 15);
+        grid.set(30, 30, 20);
+    }
+
+    roundtrip(&mut city);
+
+    // Verify congestion_level works correctly after load
+    let grid = city.resource::<TrafficGrid>();
+    let congestion = grid.congestion_level(20, 20);
+    assert!(congestion > 0.0, "traffic overlay should show congestion after load");
+    assert!((congestion - 15.0 / 20.0).abs() < 0.01);
+
+    let congestion_30 = grid.congestion_level(30, 30);
+    assert!((congestion_30 - 1.0).abs() < 0.01, "20/20 should be fully congested");
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -17,6 +17,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
     app.add_plugins(citizen_spawner::CitizenSpawnerPlugin);
     app.add_plugins(movement::MovementPlugin);
     app.add_plugins(traffic::TrafficPlugin);
+    app.add_plugins(traffic_grid_save::TrafficGridSavePlugin);
     app.add_plugins(bicycle_lanes::BicycleLanesPlugin);
 
     // Happiness and services

--- a/crates/simulation/src/saveable_keys.rs
+++ b/crates/simulation/src/saveable_keys.rs
@@ -71,6 +71,7 @@ pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
     "social_services",
     "stormwater_grid",
     "superblock_state",
+    "traffic_grid",
     "traffic_los",
     "traffic_los_state",
     "telecom",

--- a/crates/simulation/src/traffic_grid_save.rs
+++ b/crates/simulation/src/traffic_grid_save.rs
@@ -1,0 +1,45 @@
+//! Saveable implementation for `TrafficGrid`.
+//!
+//! Traffic density is recomputed every 5 ticks, but persisting it avoids a
+//! blank traffic overlay immediately after load. The grid stores `Vec<u16>`
+//! encoded via `bitcode`.
+
+use bevy::prelude::*;
+
+use crate::traffic::TrafficGrid;
+use crate::Saveable;
+
+impl Saveable for TrafficGrid {
+    const SAVE_KEY: &'static str = "traffic_grid";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.density.iter().all(|&v| v == 0) {
+            return None;
+        }
+        Some(bitcode::encode(&self.density))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        let expected = crate::config::GRID_WIDTH * crate::config::GRID_HEIGHT;
+        let density = match bitcode::decode::<Vec<u16>>(bytes) {
+            Ok(v) if v.len() == expected => v,
+            _ => vec![0; expected],
+        };
+        Self {
+            density,
+            width: crate::config::GRID_WIDTH,
+            height: crate::config::GRID_HEIGHT,
+        }
+    }
+}
+
+/// Plugin that registers `TrafficGrid` with the `SaveableRegistry`.
+pub struct TrafficGridSavePlugin;
+
+impl Plugin for TrafficGridSavePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<crate::SaveableRegistry>();
+        let mut registry = app.world_mut().resource_mut::<crate::SaveableRegistry>();
+        registry.register::<TrafficGrid>();
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `Saveable` for `TrafficGrid` so traffic density data persists across save/load cycles
- Traffic overlay is functional immediately after load — no blank overlay gap
- Reset clears all traffic data, preventing stale data from previous sessions
- Corrupted save data gracefully falls back to default (zeroed) grid

## Implementation
- New file `traffic_grid_save.rs`: `Saveable` impl encoding `Vec<u16>` density via `bitcode`
- Registered `TrafficGridSavePlugin` in `plugin_registration.rs`
- Added `traffic_grid` key to `saveable_keys.rs`

## Test plan
- [x] Roundtrip test: save traffic data, reset, load, verify values preserved
- [x] Default grid skips save (returns `None` — no unnecessary bytes in save file)
- [x] Reset clears all traffic data (no stale data)
- [x] Corrupted bytes fall back to default grid
- [x] Save key registered in `SaveableRegistry`
- [x] Traffic overlay (congestion_level) functional after load

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)