### PR TITLE
Implement Saveable for ActiveDisaster (SAVE-038)

### DIFF
--- a/crates/simulation/src/disaster_save.rs
+++ b/crates/simulation/src/disaster_save.rs
@@ -1,0 +1,49 @@
+//! Saveable implementation for `ActiveDisaster` so in-progress disasters
+//! persist across save/load cycles.
+
+use bevy::prelude::*;
+
+use crate::disasters::{ActiveDisaster, DisasterInstance};
+use crate::Saveable;
+
+impl Saveable for ActiveDisaster {
+    const SAVE_KEY: &'static str = "active_disaster";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        // Skip saving if no disaster is active (default state).
+        let instance = self.current.as_ref()?;
+        Some(bitcode::encode(instance))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        match bitcode::decode::<DisasterInstance>(bytes) {
+            Ok(instance) => Self {
+                current: Some(instance),
+            },
+            Err(e) => {
+                warn!(
+                    "Saveable active_disaster: failed to decode {} bytes, \
+                     falling back to no active disaster: {}",
+                    bytes.len(),
+                    e
+                );
+                Self::default()
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+pub struct DisasterSavePlugin;
+
+impl Plugin for DisasterSavePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<crate::SaveableRegistry>();
+        app.world_mut()
+            .resource_mut::<crate::SaveableRegistry>()
+            .register::<ActiveDisaster>();
+    }
+}

--- a/crates/simulation/src/disasters.rs
+++ b/crates/simulation/src/disasters.rs
@@ -11,7 +11,7 @@ use crate::TestSafetyNet;
 // Types
 // =============================================================================
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize, bitcode::Encode, bitcode::Decode)]
 pub enum DisasterType {
     Tornado,
     Earthquake,
@@ -28,6 +28,7 @@ impl DisasterType {
     }
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, bitcode::Encode, bitcode::Decode)]
 pub struct DisasterInstance {
     pub disaster_type: DisasterType,
     pub center_x: usize,

--- a/crates/simulation/src/integration_tests/disaster_save_tests.rs
+++ b/crates/simulation/src/integration_tests/disaster_save_tests.rs
@@ -1,0 +1,198 @@
+//! Integration tests for ActiveDisaster save/load roundtrips.
+
+use crate::disasters::{ActiveDisaster, DisasterInstance, DisasterType};
+use crate::test_harness::TestCity;
+use crate::Saveable;
+use crate::SaveableRegistry;
+
+// ====================================================================
+// Roundtrip helper
+// ====================================================================
+
+fn roundtrip(city: &mut TestCity) {
+    let world = city.world_mut();
+    let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+    let extensions = registry.save_all(world);
+    registry.reset_all(world);
+    registry.load_all(world, &extensions);
+    world.insert_resource(registry);
+}
+
+// ====================================================================
+// Tornado roundtrip
+// ====================================================================
+
+#[test]
+fn test_active_disaster_tornado_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut active = world.resource_mut::<ActiveDisaster>();
+        active.current = Some(DisasterInstance {
+            disaster_type: DisasterType::Tornado,
+            center_x: 100,
+            center_y: 150,
+            radius: 5,
+            ticks_remaining: 30,
+            damage_applied: true,
+        });
+    }
+
+    roundtrip(&mut city);
+
+    let active = city.resource::<ActiveDisaster>();
+    let d = active.current.as_ref().expect("disaster should persist after load");
+    assert_eq!(d.disaster_type, DisasterType::Tornado);
+    assert_eq!(d.center_x, 100);
+    assert_eq!(d.center_y, 150);
+    assert_eq!(d.radius, 5);
+    assert_eq!(d.ticks_remaining, 30);
+    assert!(d.damage_applied);
+}
+
+// ====================================================================
+// Earthquake roundtrip
+// ====================================================================
+
+#[test]
+fn test_active_disaster_earthquake_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut active = world.resource_mut::<ActiveDisaster>();
+        active.current = Some(DisasterInstance {
+            disaster_type: DisasterType::Earthquake,
+            center_x: 50,
+            center_y: 75,
+            radius: 10,
+            ticks_remaining: 15,
+            damage_applied: false,
+        });
+    }
+
+    roundtrip(&mut city);
+
+    let active = city.resource::<ActiveDisaster>();
+    let d = active.current.as_ref().expect("earthquake should persist");
+    assert_eq!(d.disaster_type, DisasterType::Earthquake);
+    assert_eq!(d.center_x, 50);
+    assert_eq!(d.center_y, 75);
+    assert_eq!(d.radius, 10);
+    assert_eq!(d.ticks_remaining, 15);
+    assert!(!d.damage_applied);
+}
+
+// ====================================================================
+// Flood roundtrip
+// ====================================================================
+
+#[test]
+fn test_active_disaster_flood_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut active = world.resource_mut::<ActiveDisaster>();
+        active.current = Some(DisasterInstance {
+            disaster_type: DisasterType::Flood,
+            center_x: 200,
+            center_y: 200,
+            radius: 8,
+            ticks_remaining: 80,
+            damage_applied: true,
+        });
+    }
+
+    roundtrip(&mut city);
+
+    let active = city.resource::<ActiveDisaster>();
+    let d = active.current.as_ref().expect("flood should persist");
+    assert_eq!(d.disaster_type, DisasterType::Flood);
+    assert_eq!(d.center_x, 200);
+    assert_eq!(d.center_y, 200);
+    assert_eq!(d.radius, 8);
+    assert_eq!(d.ticks_remaining, 80);
+    assert!(d.damage_applied);
+}
+
+// ====================================================================
+// No disaster (default) skips save
+// ====================================================================
+
+#[test]
+fn test_active_disaster_default_skips_save() {
+    let default = ActiveDisaster::default();
+    assert!(default.save_to_bytes().is_none());
+}
+
+// ====================================================================
+// Reset clears disaster
+// ====================================================================
+
+#[test]
+fn test_active_disaster_reset_clears() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut active = world.resource_mut::<ActiveDisaster>();
+        active.current = Some(DisasterInstance {
+            disaster_type: DisasterType::Tornado,
+            center_x: 10,
+            center_y: 20,
+            radius: 5,
+            ticks_remaining: 40,
+            damage_applied: false,
+        });
+    }
+
+    // Save, reset, and verify reset clears the disaster.
+    {
+        let world = city.world_mut();
+        let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+        let _extensions = registry.save_all(world);
+        registry.reset_all(world);
+
+        let active = world.resource::<ActiveDisaster>();
+        assert!(
+            active.current.is_none(),
+            "reset should clear active disaster"
+        );
+
+        world.insert_resource(registry);
+    }
+}
+
+// ====================================================================
+// Key is registered
+// ====================================================================
+
+#[test]
+fn test_active_disaster_save_key_registered() {
+    let city = TestCity::new();
+    let registry = city.resource::<SaveableRegistry>();
+    let registered: std::collections::HashSet<&str> =
+        registry.entries.iter().map(|e| e.key.as_str()).collect();
+
+    assert!(
+        registered.contains("active_disaster"),
+        "active_disaster key should be registered in SaveableRegistry"
+    );
+}
+
+// ====================================================================
+// Corrupted bytes fall back to default
+// ====================================================================
+
+#[test]
+fn test_active_disaster_corrupted_bytes_fallback() {
+    let garbage = vec![0xFF, 0xFE, 0xFD, 0xFC, 0xFB];
+    let loaded = ActiveDisaster::load_from_bytes(&garbage);
+    // Corrupted bytes should fall back to default (no active disaster).
+    assert!(
+        loaded.current.is_none(),
+        "corrupted bytes should result in no active disaster"
+    );
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -152,6 +152,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
     app.add_plugins(fire::FirePlugin);
     app.add_plugins(forest_fire::ForestFirePlugin);
     app.add_plugins(disasters::DisastersPlugin);
+    app.add_plugins(disaster_save::DisasterSavePlugin);
 
     // Citizens and population
     app.add_plugins(life_simulation::LifeSimulationPlugin);

--- a/crates/simulation/src/saveable_keys.rs
+++ b/crates/simulation/src/saveable_keys.rs
@@ -11,6 +11,7 @@ use crate::SaveableRegistry;
 /// When you add a new `Saveable` type, add its key here. The startup assertion
 /// will remind you if you forget to register it.
 pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
+    "active_disaster",
     "blueprint_library",
     "bicycle_lanes",
     "bus_transit",


### PR DESCRIPTION
## Summary
- Implements `Saveable` for `ActiveDisaster` so in-progress disasters persist across save/load cycles
- Adds `serde::Serialize/Deserialize` and `bitcode::Encode/Decode` derives to `DisasterType` and `DisasterInstance`
- Creates `disaster_save.rs` module with `DisasterSavePlugin` that registers with `SaveableRegistry`
- Preserves disaster type, position, radius, remaining ticks, and damage state through save/load

## Test plan
- [x] Integration test: tornado disaster roundtrips through save/load
- [x] Integration test: earthquake disaster roundtrips through save/load
- [x] Integration test: flood disaster roundtrips through save/load
- [x] Integration test: default (no disaster) skips saving
- [x] Integration test: reset clears active disaster
- [x] Integration test: save key is registered in SaveableRegistry
- [x] Integration test: corrupted bytes fall back to default (no disaster)

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)