### PR TITLE
SAVE-032: Serialize Advisor Panel State

### DIFF
--- a/crates/simulation/src/advisors/mod.rs
+++ b/crates/simulation/src/advisors/mod.rs
@@ -118,6 +118,25 @@ impl crate::Saveable for DismissedAdvisorTips {
 }
 
 // ---------------------------------------------------------------------------
+// Saveable implementation for AdvisorPanel
+// ---------------------------------------------------------------------------
+
+impl crate::Saveable for AdvisorPanel {
+    const SAVE_KEY: &'static str = "advisor_panel";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.messages.is_empty() {
+            return None;
+        }
+        Some(bitcode::encode(self))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
 
@@ -139,6 +158,9 @@ impl Plugin for AdvisorsPlugin {
         app.world_mut()
             .resource_mut::<crate::SaveableRegistry>()
             .register::<DismissedAdvisorTips>();
+        app.world_mut()
+            .resource_mut::<crate::SaveableRegistry>()
+            .register::<AdvisorPanel>();
     }
 }
 

--- a/crates/simulation/src/advisors/types.rs
+++ b/crates/simulation/src/advisors/types.rs
@@ -19,7 +19,7 @@ use crate::zones::ZoneDemand;
 // ---------------------------------------------------------------------------
 
 /// Categories of city advisors, each monitoring a different domain.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, bitcode::Encode, bitcode::Decode)]
 pub enum AdvisorType {
     Finance,
     Infrastructure,
@@ -178,7 +178,7 @@ impl TipId {
 }
 
 /// A single advisor message displayed in the advisor panel.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, bitcode::Encode, bitcode::Decode)]
 pub struct AdvisorMessage {
     pub advisor_type: AdvisorType,
     pub tip_id: TipId,
@@ -205,7 +205,7 @@ pub(crate) const EXPIRY_TICKS: u64 = 500;
 pub(crate) const ADVISOR_INTERVAL: u64 = 200;
 
 /// Resource that holds the current set of advisor messages shown to the player.
-#[derive(Resource, Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Resource, Debug, Clone, Default, Serialize, Deserialize, bitcode::Encode, bitcode::Decode)]
 pub struct AdvisorPanel {
     pub messages: Vec<AdvisorMessage>,
 }

--- a/crates/simulation/src/integration_tests/advisor_save_tests.rs
+++ b/crates/simulation/src/integration_tests/advisor_save_tests.rs
@@ -1,0 +1,195 @@
+//! Integration tests for advisor panel save/load roundtrips.
+//!
+//! Verifies that `DismissedAdvisorTips` and `AdvisorPanel` state
+//! persists correctly across save/load cycles.
+
+use crate::advisors::{
+    AdvisorMessage, AdvisorPanel, AdvisorType, DismissedAdvisorTips, TipId,
+};
+use crate::test_harness::TestCity;
+use crate::SaveableRegistry;
+
+// ====================================================================
+// Roundtrip helper
+// ====================================================================
+
+fn roundtrip(city: &mut TestCity) {
+    let world = city.world_mut();
+    let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+
+    let extensions = registry.save_all(world);
+
+    registry.reset_all(world);
+    registry.load_all(world, &extensions);
+
+    world.insert_resource(registry);
+}
+
+// ====================================================================
+// DismissedAdvisorTips roundtrip
+// ====================================================================
+
+#[test]
+fn test_dismissed_advisor_tips_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut dismissed = world.resource_mut::<DismissedAdvisorTips>();
+        dismissed.dismiss(TipId::BudgetDeficit);
+        dismissed.dismiss(TipId::CrimeCritical);
+        dismissed.dismiss(TipId::TrafficCongestion);
+    }
+
+    roundtrip(&mut city);
+
+    let dismissed = city.resource::<DismissedAdvisorTips>();
+    assert!(dismissed.is_dismissed(TipId::BudgetDeficit));
+    assert!(dismissed.is_dismissed(TipId::CrimeCritical));
+    assert!(dismissed.is_dismissed(TipId::TrafficCongestion));
+    assert!(!dismissed.is_dismissed(TipId::TreasuryCritical));
+}
+
+#[test]
+fn test_dismissed_tips_empty_skips_save() {
+    let mut city = TestCity::new();
+
+    // With no dismissed tips, save_to_bytes should return None.
+    let dismissed = city.resource::<DismissedAdvisorTips>();
+    assert!(dismissed.dismissed.is_empty());
+
+    roundtrip(&mut city);
+
+    let dismissed = city.resource::<DismissedAdvisorTips>();
+    assert!(dismissed.dismissed.is_empty());
+}
+
+// ====================================================================
+// AdvisorPanel roundtrip
+// ====================================================================
+
+#[test]
+fn test_advisor_panel_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut panel = world.resource_mut::<AdvisorPanel>();
+        panel.messages.push(AdvisorMessage {
+            advisor_type: AdvisorType::Finance,
+            tip_id: TipId::TreasuryCritical,
+            message: "Treasury is critically low!".to_string(),
+            priority: 5,
+            suggestion: "Raise taxes or cut spending.".to_string(),
+            tick_created: 200,
+            location: None,
+        });
+        panel.messages.push(AdvisorMessage {
+            advisor_type: AdvisorType::Safety,
+            tip_id: TipId::CrimeCritical,
+            message: "Crime is out of control!".to_string(),
+            priority: 4,
+            suggestion: "Build more police stations.".to_string(),
+            tick_created: 400,
+            location: Some((128, 64)),
+        });
+    }
+
+    roundtrip(&mut city);
+
+    let panel = city.resource::<AdvisorPanel>();
+    assert_eq!(panel.messages.len(), 2);
+
+    assert_eq!(panel.messages[0].advisor_type, AdvisorType::Finance);
+    assert_eq!(panel.messages[0].tip_id, TipId::TreasuryCritical);
+    assert_eq!(panel.messages[0].message, "Treasury is critically low!");
+    assert_eq!(panel.messages[0].priority, 5);
+    assert_eq!(panel.messages[0].tick_created, 200);
+    assert_eq!(panel.messages[0].location, None);
+
+    assert_eq!(panel.messages[1].advisor_type, AdvisorType::Safety);
+    assert_eq!(panel.messages[1].tip_id, TipId::CrimeCritical);
+    assert_eq!(panel.messages[1].location, Some((128, 64)));
+}
+
+#[test]
+fn test_advisor_panel_empty_skips_save() {
+    let mut city = TestCity::new();
+
+    let panel = city.resource::<AdvisorPanel>();
+    assert!(panel.messages.is_empty());
+
+    roundtrip(&mut city);
+
+    let panel = city.resource::<AdvisorPanel>();
+    assert!(panel.messages.is_empty());
+}
+
+#[test]
+fn test_advisor_panel_no_duplicates_after_load() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut panel = world.resource_mut::<AdvisorPanel>();
+        panel.messages.push(AdvisorMessage {
+            advisor_type: AdvisorType::Housing,
+            tip_id: TipId::HomelessCritical,
+            message: "Homelessness is critical.".to_string(),
+            priority: 4,
+            suggestion: "Zone more residential.".to_string(),
+            tick_created: 100,
+            location: None,
+        });
+    }
+
+    // Roundtrip twice to ensure no duplication occurs.
+    roundtrip(&mut city);
+    roundtrip(&mut city);
+
+    let panel = city.resource::<AdvisorPanel>();
+    assert_eq!(panel.messages.len(), 1);
+    assert_eq!(panel.messages[0].tip_id, TipId::HomelessCritical);
+}
+
+// ====================================================================
+// Combined: dismissed tips + panel history
+// ====================================================================
+
+#[test]
+fn test_advisor_save_load_combined() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+
+        let mut dismissed = world.resource_mut::<DismissedAdvisorTips>();
+        dismissed.dismiss(TipId::PollutionHigh);
+        dismissed.dismiss(TipId::EducationLow);
+
+        let mut panel = world.resource_mut::<AdvisorPanel>();
+        panel.messages.push(AdvisorMessage {
+            advisor_type: AdvisorType::Environment,
+            tip_id: TipId::PollutionRising,
+            message: "Pollution is rising.".to_string(),
+            priority: 3,
+            suggestion: "Plant trees.".to_string(),
+            tick_created: 300,
+            location: Some((50, 50)),
+        });
+    }
+
+    roundtrip(&mut city);
+
+    // Dismissed tips preserved.
+    let dismissed = city.resource::<DismissedAdvisorTips>();
+    assert!(dismissed.is_dismissed(TipId::PollutionHigh));
+    assert!(dismissed.is_dismissed(TipId::EducationLow));
+    assert!(!dismissed.is_dismissed(TipId::PollutionRising));
+
+    // Panel history preserved.
+    let panel = city.resource::<AdvisorPanel>();
+    assert_eq!(panel.messages.len(), 1);
+    assert_eq!(panel.messages[0].tip_id, TipId::PollutionRising);
+    assert_eq!(panel.messages[0].location, Some((50, 50)));
+}

--- a/crates/simulation/src/saveable_keys.rs
+++ b/crates/simulation/src/saveable_keys.rs
@@ -11,6 +11,7 @@ use crate::SaveableRegistry;
 /// When you add a new `Saveable` type, add its key here. The startup assertion
 /// will remind you if you forget to register it.
 pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
+    "advisor_panel",
     "blueprint_library",
     "bicycle_lanes",
     "bus_transit",


### PR DESCRIPTION
## Summary
- Implement `Saveable` for `AdvisorPanel` so advisor messages and history persist across save/load cycles
- Add `bitcode::Encode`/`bitcode::Decode` derives to `AdvisorType`, `AdvisorMessage`, and `AdvisorPanel`
- Register `AdvisorPanel` in `AdvisorsPlugin` and add key to `saveable_keys.rs`
- `DismissedAdvisorTips` was already saveable (no changes needed there)

## Changes
- **`crates/simulation/src/advisors/types.rs`**: Add `bitcode::Encode, bitcode::Decode` derives to `AdvisorType`, `AdvisorMessage`, and `AdvisorPanel`
- **`crates/simulation/src/advisors/mod.rs`**: Add `Saveable` impl for `AdvisorPanel` with bitcode encoding; register it in the plugin
- **`crates/simulation/src/saveable_keys.rs`**: Add `"advisor_panel"` key
- **`crates/simulation/src/integration_tests/advisor_save_tests.rs`**: New test file with 5 tests covering dismissed tips roundtrip, panel history roundtrip, empty state, no-duplicates after double roundtrip, and combined state

## Test plan
- [x] Dismissed advisor tips persist across save/load
- [x] Advisor panel messages (including location data) persist across save/load
- [x] Empty state roundtrips correctly (no unnecessary save bytes)
- [x] No duplicate messages after multiple save/load cycles
- [x] Combined dismissed tips + panel history preserved together

Closes #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)