### PR TITLE
Implement Saveable for DistrictMap (SAVE-029)

### DIFF
--- a/crates/simulation/src/districts.rs
+++ b/crates/simulation/src/districts.rs
@@ -1,6 +1,7 @@
 use bevy::ecs::query::With;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
+use bitcode::{Decode, Encode};
 use std::collections::HashSet;
 
 use crate::config::{GRID_HEIGHT, GRID_WIDTH};
@@ -146,7 +147,7 @@ pub fn aggregate_districts(
 // ============================================================================
 
 /// Per-district policy overrides that players can configure.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Encode, Decode)]
 pub struct DistrictPolicies {
     /// Override tax rate for this district (None = use city-wide rate).
     pub tax_rate: Option<f32>,
@@ -159,7 +160,7 @@ pub struct DistrictPolicies {
 }
 
 /// Computed per-district statistics (updated by the district_stats system).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Encode, Decode)]
 pub struct PlayerDistrictStats {
     pub population: u32,
     pub avg_happiness: f32,
@@ -167,7 +168,7 @@ pub struct PlayerDistrictStats {
 }
 
 /// A player-created district with a name, color, cells, and policies.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct District {
     pub name: String,
     pub color: [f32; 4],
@@ -202,7 +203,7 @@ pub const DEFAULT_DISTRICTS: &[(&str, [f32; 4])] = &[
 
 /// Resource that holds all player-created districts and a grid mapping
 /// each cell to its district index.
-#[derive(Resource, Serialize, Deserialize)]
+#[derive(Resource, Serialize, Deserialize, Encode, Decode)]
 pub struct DistrictMap {
     pub districts: Vec<District>,
     /// One entry per grid cell (GRID_WIDTH * GRID_HEIGHT). None = no district.

--- a/crates/simulation/src/districts_save.rs
+++ b/crates/simulation/src/districts_save.rs
@@ -1,0 +1,67 @@
+//! Saveable implementation and save-registration plugin for `DistrictMap`.
+//!
+//! Persists player-defined district boundaries, names, policies, and cell
+//! assignments across save/load cycles.
+
+use bevy::prelude::*;
+
+use crate::districts::DistrictMap;
+use crate::Saveable;
+
+// ---------------------------------------------------------------------------
+// Saveable implementation
+// ---------------------------------------------------------------------------
+
+impl Saveable for DistrictMap {
+    const SAVE_KEY: &'static str = "district_map";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        // Skip saving if no cells are assigned to any district.
+        if self.cell_map.iter().all(|c| c.is_none()) {
+            // Also check if any district has been renamed or had policies
+            // changed from defaults.
+            let all_default = self.districts.iter().enumerate().all(|(i, d)| {
+                let default_map = DistrictMap::default();
+                if i >= default_map.districts.len() {
+                    return false; // Extra districts added
+                }
+                let dd = &default_map.districts[i];
+                d.name == dd.name
+                    && d.color == dd.color
+                    && d.cells.is_empty()
+                    && is_policies_default(&d.policies)
+            });
+            if all_default && self.districts.len() == DistrictMap::default().districts.len() {
+                return None;
+            }
+        }
+        Some(bitcode::encode(self))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
+    }
+}
+
+/// Check if district policies are at their default values.
+fn is_policies_default(p: &crate::districts::DistrictPolicies) -> bool {
+    p.tax_rate.is_none()
+        && p.speed_limit.is_none()
+        && !p.noise_ordinance
+        && !p.heavy_industry_ban
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+pub struct DistrictSavePlugin;
+
+impl Plugin for DistrictSavePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<crate::SaveableRegistry>();
+        app.world_mut()
+            .resource_mut::<crate::SaveableRegistry>()
+            .register::<DistrictMap>();
+    }
+}

--- a/crates/simulation/src/integration_tests/district_save_tests.rs
+++ b/crates/simulation/src/integration_tests/district_save_tests.rs
@@ -1,0 +1,183 @@
+//! Integration tests for DistrictMap save/load (SAVE-029).
+
+use crate::districts::DistrictMap;
+use crate::SaveableRegistry;
+use crate::Saveable;
+
+/// Test that an empty/default DistrictMap returns None from save_to_bytes
+/// (skipped when no changes have been made).
+#[test]
+fn test_district_map_save_default_returns_none() {
+    let map = DistrictMap::default();
+    assert!(
+        map.save_to_bytes().is_none(),
+        "Default DistrictMap should skip saving"
+    );
+}
+
+/// Test that a DistrictMap with cell assignments round-trips through
+/// save_to_bytes / load_from_bytes correctly.
+#[test]
+fn test_district_map_save_load_round_trip() {
+    let mut map = DistrictMap::default();
+    // Assign some cells to districts
+    map.assign_cell_to_district(10, 20, 0);
+    map.assign_cell_to_district(11, 20, 0);
+    map.assign_cell_to_district(50, 50, 1);
+    map.assign_cell_to_district(100, 100, 2);
+
+    let bytes = map
+        .save_to_bytes()
+        .expect("DistrictMap with assignments should produce bytes");
+
+    let loaded = DistrictMap::load_from_bytes(&bytes);
+
+    // Verify cell assignments are preserved
+    assert_eq!(loaded.get_district_index_at(10, 20), Some(0));
+    assert_eq!(loaded.get_district_index_at(11, 20), Some(0));
+    assert_eq!(loaded.get_district_index_at(50, 50), Some(1));
+    assert_eq!(loaded.get_district_index_at(100, 100), Some(2));
+
+    // Verify unassigned cells remain None
+    assert_eq!(loaded.get_district_index_at(0, 0), None);
+    assert_eq!(loaded.get_district_index_at(200, 200), None);
+
+    // Verify district cell sets are consistent
+    assert!(loaded.districts[0].cells.contains(&(10, 20)));
+    assert!(loaded.districts[0].cells.contains(&(11, 20)));
+    assert!(loaded.districts[1].cells.contains(&(50, 50)));
+    assert!(loaded.districts[2].cells.contains(&(100, 100)));
+}
+
+/// Test that district names are preserved across save/load.
+#[test]
+fn test_district_map_save_load_preserves_names() {
+    let mut map = DistrictMap::default();
+    map.districts[0].name = "My Custom District".to_string();
+    map.districts[1].name = "Uptown".to_string();
+    // Need at least one cell assigned so save_to_bytes doesn't skip
+    map.assign_cell_to_district(5, 5, 0);
+
+    let bytes = map.save_to_bytes().expect("Should produce bytes");
+    let loaded = DistrictMap::load_from_bytes(&bytes);
+
+    assert_eq!(loaded.districts[0].name, "My Custom District");
+    assert_eq!(loaded.districts[1].name, "Uptown");
+}
+
+/// Test that district policies are preserved across save/load.
+#[test]
+fn test_district_map_save_load_preserves_policies() {
+    let mut map = DistrictMap::default();
+    map.districts[0].policies.tax_rate = Some(0.15);
+    map.districts[0].policies.noise_ordinance = true;
+    map.districts[1].policies.heavy_industry_ban = true;
+    map.districts[2].policies.speed_limit = Some(30.0);
+
+    // Assign a cell so save doesn't skip
+    map.assign_cell_to_district(1, 1, 0);
+
+    let bytes = map.save_to_bytes().expect("Should produce bytes");
+    let loaded = DistrictMap::load_from_bytes(&bytes);
+
+    assert_eq!(loaded.districts[0].policies.tax_rate, Some(0.15));
+    assert!(loaded.districts[0].policies.noise_ordinance);
+    assert!(loaded.districts[1].policies.heavy_industry_ban);
+    assert_eq!(loaded.districts[2].policies.speed_limit, Some(30.0));
+    // Default policies should remain default
+    assert!(!loaded.districts[2].policies.noise_ordinance);
+    assert!(!loaded.districts[0].policies.heavy_industry_ban);
+}
+
+/// Test that district colors are preserved across save/load.
+#[test]
+fn test_district_map_save_load_preserves_colors() {
+    let mut map = DistrictMap::default();
+    map.districts[0].color = [1.0, 0.0, 0.0, 1.0];
+    map.assign_cell_to_district(1, 1, 0);
+
+    let bytes = map.save_to_bytes().expect("Should produce bytes");
+    let loaded = DistrictMap::load_from_bytes(&bytes);
+
+    assert_eq!(loaded.districts[0].color, [1.0, 0.0, 0.0, 1.0]);
+}
+
+/// Test that DistrictMap works correctly through the SaveableRegistry
+/// (end-to-end save/load via the registry).
+#[test]
+fn test_district_map_saveable_registry_round_trip() {
+    let mut app = bevy::app::App::new();
+    app.add_plugins(bevy::MinimalPlugins);
+    app.init_resource::<SaveableRegistry>();
+    app.init_resource::<DistrictMap>();
+
+    {
+        let mut registry = app.world_mut().resource_mut::<SaveableRegistry>();
+        registry.register::<DistrictMap>();
+    }
+
+    // Modify the district map
+    {
+        let mut map = app.world_mut().resource_mut::<DistrictMap>();
+        map.assign_cell_to_district(30, 40, 0);
+        map.assign_cell_to_district(31, 40, 0);
+        map.districts[0].name = "Test District".to_string();
+        map.districts[0].policies.tax_rate = Some(0.10);
+    }
+
+    // Save via registry
+    let extensions = {
+        let registry = app.world().resource::<SaveableRegistry>();
+        registry.save_all(app.world())
+    };
+    assert!(
+        extensions.contains_key("district_map"),
+        "district_map key should be present in extensions"
+    );
+
+    // Reset the district map
+    app.world_mut().insert_resource(DistrictMap::default());
+
+    // Verify reset
+    {
+        let map = app.world().resource::<DistrictMap>();
+        assert_eq!(map.get_district_index_at(30, 40), None);
+        assert_eq!(map.districts[0].name, "Downtown");
+    }
+
+    // Load via registry
+    {
+        let registry = app
+            .world_mut()
+            .remove_resource::<SaveableRegistry>()
+            .unwrap();
+        registry.load_all(app.world_mut(), &extensions);
+        app.world_mut().insert_resource(registry);
+    }
+
+    // Verify restored state
+    {
+        let map = app.world().resource::<DistrictMap>();
+        assert_eq!(map.get_district_index_at(30, 40), Some(0));
+        assert_eq!(map.get_district_index_at(31, 40), Some(0));
+        assert_eq!(map.districts[0].name, "Test District");
+        assert_eq!(map.districts[0].policies.tax_rate, Some(0.10));
+        assert!(map.districts[0].cells.contains(&(30, 40)));
+        assert!(map.districts[0].cells.contains(&(31, 40)));
+    }
+}
+
+/// Test that the SAVE_KEY constant matches what we expect.
+#[test]
+fn test_district_map_save_key() {
+    assert_eq!(DistrictMap::SAVE_KEY, "district_map");
+}
+
+/// Test that loading from empty/garbage bytes returns a valid default.
+#[test]
+fn test_district_map_load_from_invalid_bytes_returns_default() {
+    let loaded = DistrictMap::load_from_bytes(&[0xFF, 0xFE, 0xFD]);
+    // Should return default without panicking
+    assert_eq!(loaded.districts.len(), 8); // DEFAULT_DISTRICTS count
+    assert!(loaded.cell_map.iter().all(|c| c.is_none()));
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -41,6 +41,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
     app.add_plugins(garbage::GarbagePlugin);
     app.add_plugins(districts::DistrictsPlugin);
     app.add_plugins(district_policies::DistrictPoliciesPlugin);
+    app.add_plugins(districts_save::DistrictSavePlugin);
     app.add_plugins(superblock::SuperblockPlugin);
     app.add_plugins(neighborhood_quality::NeighborhoodQualityPlugin);
     app.add_plugins(lifecycle::LifecyclePlugin);

--- a/crates/simulation/src/saveable_keys.rs
+++ b/crates/simulation/src/saveable_keys.rs
@@ -27,6 +27,7 @@ pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
     "dismissed_advisor_tips",
     "disease_state",
     "district_policies",
+    "district_map",
     "education_pipeline",
     "energy_dispatch",
     "energy_grid",


### PR DESCRIPTION
## Summary
- Implement `Saveable` trait for `DistrictMap` so player-defined district boundaries, names, policies, and cell assignments persist across save/load cycles
- Add `bitcode::Encode`/`Decode` derives to `DistrictMap`, `District`, `DistrictPolicies`, and `PlayerDistrictStats`
- Create `districts_save.rs` with the `Saveable` implementation and `DistrictSavePlugin` for registry registration
- Add `"district_map"` key to `saveable_keys.rs`

## Test plan
- [x] `test_district_map_save_default_returns_none` — verifies default map skips saving
- [x] `test_district_map_save_load_round_trip` — verifies cell assignments survive encode/decode
- [x] `test_district_map_save_load_preserves_names` — verifies district names persist
- [x] `test_district_map_save_load_preserves_policies` — verifies policy settings persist
- [x] `test_district_map_save_load_preserves_colors` — verifies district colors persist
- [x] `test_district_map_saveable_registry_round_trip` — end-to-end test through SaveableRegistry
- [x] `test_district_map_save_key` — verifies SAVE_KEY constant
- [x] `test_district_map_load_from_invalid_bytes_returns_default` — verifies graceful fallback

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)