### PR TITLE
Implement Saveable for VirtualPopulation (SAVE-021)

### DIFF
--- a/crates/simulation/src/integration_tests/virtual_population_save_tests.rs
+++ b/crates/simulation/src/integration_tests/virtual_population_save_tests.rs
@@ -1,0 +1,160 @@
+//! Integration tests for VirtualPopulation save/load roundtrip (SAVE-021, Issue #717).
+//!
+//! Verifies that `VirtualPopulation` state — total count, employment stats,
+//! per-district statistics, and dynamic citizen cap — survives a save/load cycle.
+
+use crate::test_harness::TestCity;
+use crate::virtual_population::VirtualPopulation;
+use crate::SaveableRegistry;
+
+// ====================================================================
+// Roundtrip helper
+// ====================================================================
+
+/// Save all registered saveables, reset them, then restore from the saved
+/// bytes. Operates entirely through `world_mut()`.
+fn roundtrip(city: &mut TestCity) {
+    let world = city.world_mut();
+    let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+
+    let extensions = registry.save_all(world);
+    registry.reset_all(world);
+    registry.load_all(world, &extensions);
+
+    world.insert_resource(registry);
+}
+
+// ====================================================================
+// Tests
+// ====================================================================
+
+#[test]
+fn test_virtual_population_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    // Set up non-default virtual population state
+    {
+        let world = city.world_mut();
+        let mut vp = world.resource_mut::<VirtualPopulation>();
+        vp.add_virtual_citizen(0, 25, true, 80.0, 1200.0, 0.15);
+        vp.add_virtual_citizen(0, 40, false, 60.0, 0.0, 0.0);
+        vp.add_virtual_citizen(1, 70, false, 50.0, 0.0, 0.0);
+    }
+
+    // Snapshot before save
+    let (total_before, employed_before, districts_before) = {
+        let vp = city.resource::<VirtualPopulation>();
+        (
+            vp.total_virtual,
+            vp.virtual_employed,
+            vp.district_stats.clone(),
+        )
+    };
+
+    assert_eq!(total_before, 3);
+    assert_eq!(employed_before, 1);
+    assert_eq!(districts_before.len(), 2);
+
+    // Roundtrip through save/load
+    roundtrip(&mut city);
+
+    // Verify state survived
+    let vp = city.resource::<VirtualPopulation>();
+    assert_eq!(vp.total_virtual, total_before, "total_virtual lost on roundtrip");
+    assert_eq!(
+        vp.virtual_employed, employed_before,
+        "virtual_employed lost on roundtrip"
+    );
+    assert_eq!(
+        vp.district_stats.len(),
+        districts_before.len(),
+        "district_stats length mismatch"
+    );
+    assert_eq!(vp.district_stats[0].population, 2);
+    assert_eq!(vp.district_stats[0].employed, 1);
+    assert_eq!(vp.district_stats[1].population, 1);
+    assert!((vp.district_stats[0].avg_happiness - 70.0).abs() < 0.01);
+}
+
+#[test]
+fn test_virtual_population_default_on_missing_key() {
+    // Simulates loading an old save that has no virtual_population key:
+    // roundtrip with an empty (default) VirtualPopulation should yield default.
+    let mut city = TestCity::new();
+
+    // Leave VirtualPopulation at default (0 virtual citizens)
+    roundtrip(&mut city);
+
+    let vp = city.resource::<VirtualPopulation>();
+    assert_eq!(vp.total_virtual, 0);
+    assert_eq!(vp.virtual_employed, 0);
+    assert!(vp.district_stats.is_empty());
+}
+
+#[test]
+fn test_virtual_population_large_count_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut vp = world.resource_mut::<VirtualPopulation>();
+        // Simulate a city with 500K virtual population across 10 districts
+        for district in 0..10 {
+            for i in 0..1000 {
+                let age = (20 + (i % 50)) as u8;
+                let employed = i % 3 != 0;
+                let happiness = 40.0 + (i % 60) as f32;
+                let salary = if employed { 800.0 + (i % 500) as f32 } else { 0.0 };
+                vp.add_virtual_citizen(district, age, employed, happiness, salary, 0.1);
+            }
+        }
+        // Also set a non-default cap
+        vp.max_real_citizens = 100_000;
+    }
+
+    let total_before = city.resource::<VirtualPopulation>().total_virtual;
+    let cap_before = city.resource::<VirtualPopulation>().max_real_citizens;
+    assert_eq!(total_before, 10_000);
+    assert_eq!(cap_before, 100_000);
+
+    roundtrip(&mut city);
+
+    let vp = city.resource::<VirtualPopulation>();
+    assert_eq!(vp.total_virtual, total_before, "large population lost on roundtrip");
+    assert_eq!(
+        vp.max_real_citizens, cap_before,
+        "max_real_citizens lost on roundtrip"
+    );
+    assert_eq!(vp.district_stats.len(), 10);
+    // Each district should have 1000 citizens
+    for (i, ds) in vp.district_stats.iter().enumerate() {
+        assert_eq!(ds.population, 1000, "district {i} population mismatch");
+    }
+}
+
+#[test]
+fn test_virtual_population_reset_clears_state() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut vp = world.resource_mut::<VirtualPopulation>();
+        vp.add_virtual_citizen(0, 30, true, 70.0, 1000.0, 0.1);
+    }
+
+    // Reset via registry (simulates "new game")
+    {
+        let world = city.world_mut();
+        let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+        registry.reset_all(world);
+        world.insert_resource(registry);
+    }
+
+    let vp = city.resource::<VirtualPopulation>();
+    assert_eq!(vp.total_virtual, 0, "reset should clear total_virtual");
+    assert_eq!(vp.virtual_employed, 0, "reset should clear virtual_employed");
+    assert!(
+        vp.district_stats.is_empty(),
+        "reset should clear district_stats"
+    );
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -169,6 +169,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
     app.add_plugins(population_tiers::PopulationTiersPlugin);
     app.add_plugins(lod::LodPlugin);
     app.add_plugins(virtual_population::VirtualPopulationPlugin);
+    app.add_plugins(virtual_population_save::VirtualPopulationSavePlugin);
     app.add_plugins(urban_growth_boundary::UrbanGrowthBoundaryPlugin);
     app.add_plugins(nimby::NimbyPlugin);
     app.add_plugins(walkability::WalkabilityPlugin);

--- a/crates/simulation/src/saveable_keys.rs
+++ b/crates/simulation/src/saveable_keys.rs
@@ -83,6 +83,7 @@ pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
     "tree_grid",
     "tutorial",
     "uhi_mitigation",
+    "virtual_population",
     "walkability",
     "waste_policies",
     "water_pollution_grid",

--- a/crates/simulation/src/virtual_population.rs
+++ b/crates/simulation/src/virtual_population.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bitcode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 /// Hard ceiling on real (ECS) citizens — never exceed this regardless of FPS.
@@ -9,7 +10,7 @@ pub const MIN_REAL_CITIZENS: u32 = 10_000;
 pub const DEFAULT_REAL_CITIZEN_CAP: u32 = 50_000;
 
 /// Per-district virtual population statistics.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Encode, Decode)]
 pub struct DistrictStats {
     pub population: u32,
     pub employed: u32,
@@ -25,7 +26,7 @@ pub struct DistrictStats {
     pub service_demand: f32,
 }
 
-#[derive(Resource, Debug, Clone, Serialize, Deserialize)]
+#[derive(Resource, Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct VirtualPopulation {
     pub total_virtual: u32,
     pub virtual_employed: u32,

--- a/crates/simulation/src/virtual_population_save.rs
+++ b/crates/simulation/src/virtual_population_save.rs
@@ -1,0 +1,45 @@
+//! Saveable implementation for `VirtualPopulation`.
+//!
+//! Persists the virtual population count, employment stats, and per-district
+//! statistics through save/load cycles. Old saves that lack this key will
+//! default to `VirtualPopulation::default()` (count = 0), preserving backward
+//! compatibility.
+
+use bevy::prelude::*;
+
+use crate::virtual_population::VirtualPopulation;
+use crate::Saveable;
+
+impl Saveable for VirtualPopulation {
+    const SAVE_KEY: &'static str = "virtual_population";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        // Skip saving if there are no virtual citizens and cap is at default
+        if self.total_virtual == 0
+            && self.virtual_employed == 0
+            && self.district_stats.is_empty()
+        {
+            return None;
+        }
+        Some(bitcode::encode(self))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin — registers VirtualPopulation with the SaveableRegistry
+// ---------------------------------------------------------------------------
+
+pub struct VirtualPopulationSavePlugin;
+
+impl Plugin for VirtualPopulationSavePlugin {
+    fn build(&self, app: &mut App) {
+        let mut registry = app
+            .world_mut()
+            .get_resource_or_insert_with(crate::SaveableRegistry::default);
+        registry.register::<VirtualPopulation>();
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `Saveable` trait for `VirtualPopulation` so that virtual population count, employment stats, per-district statistics, and dynamic citizen cap all persist through save/load cycles
- Add `bitcode::Encode`/`Decode` derives to `VirtualPopulation` and `DistrictStats` structs
- Register `VirtualPopulationSavePlugin` in `plugin_registration.rs` and add the `"virtual_population"` key to `saveable_keys.rs`
- Old saves without this key gracefully default to `VirtualPopulation::default()` (count = 0)

## Test plan
- [x] `test_virtual_population_save_load_roundtrip` — verifies total count, employment, and district stats survive roundtrip
- [x] `test_virtual_population_default_on_missing_key` — verifies old saves gracefully default to zero
- [x] `test_virtual_population_large_count_roundtrip` — verifies 10K virtual citizens across 10 districts roundtrip correctly, including `max_real_citizens` cap
- [x] `test_virtual_population_reset_clears_state` — verifies registry reset returns to default state

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)