### PR TITLE
Serialize EventJournal and ActiveCityEffects (SAVE-027)

### DIFF
--- a/crates/simulation/src/event_journal_save.rs
+++ b/crates/simulation/src/event_journal_save.rs
@@ -1,0 +1,84 @@
+//! Saveable implementations for EventJournal, ActiveCityEffects, and
+//! MilestoneTracker so that event history and active modifiers persist
+//! across save/load cycles.
+
+use bevy::prelude::*;
+
+use crate::events::{ActiveCityEffects, EventJournal, MilestoneTracker};
+use crate::Saveable;
+
+// ---------------------------------------------------------------------------
+// EventJournal
+// ---------------------------------------------------------------------------
+
+impl Saveable for EventJournal {
+    const SAVE_KEY: &'static str = "event_journal";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.events.is_empty() {
+            return None;
+        }
+        Some(bitcode::encode(self))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ActiveCityEffects
+// ---------------------------------------------------------------------------
+
+impl Saveable for ActiveCityEffects {
+    const SAVE_KEY: &'static str = "active_city_effects";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.festival_ticks == 0
+            && self.economic_boom_ticks == 0
+            && self.epidemic_ticks == 0
+        {
+            return None;
+        }
+        Some(bitcode::encode(self))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MilestoneTracker
+// ---------------------------------------------------------------------------
+
+impl Saveable for MilestoneTracker {
+    const SAVE_KEY: &'static str = "milestone_tracker";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.reached_milestones.is_empty() {
+            return None;
+        }
+        Some(bitcode::encode(self))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        crate::decode_or_warn(Self::SAVE_KEY, bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+pub struct EventJournalSavePlugin;
+
+impl Plugin for EventJournalSavePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<crate::SaveableRegistry>();
+        let mut registry = app.world_mut().resource_mut::<crate::SaveableRegistry>();
+        registry.register::<EventJournal>();
+        registry.register::<ActiveCityEffects>();
+        registry.register::<MilestoneTracker>();
+    }
+}

--- a/crates/simulation/src/events.rs
+++ b/crates/simulation/src/events.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bitcode::{Decode, Encode};
 use rand::Rng;
 
 use crate::citizen::{Citizen, CitizenDetails};
@@ -12,7 +13,7 @@ use crate::SlowTickTimer;
 // Event Types
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Encode, Decode)]
 pub enum CityEventType {
     MilestoneReached(String),   // "Reached Town (1,000 pop)"
     BuildingFire(usize, usize), // grid coords
@@ -30,7 +31,7 @@ pub enum CityEventType {
 // City Event
 // =============================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Encode, Decode)]
 pub struct CityEvent {
     pub event_type: CityEventType,
     pub day: u32,
@@ -42,7 +43,7 @@ pub struct CityEvent {
 // Event Journal Resource
 // =============================================================================
 
-#[derive(Resource)]
+#[derive(Resource, Encode, Decode)]
 pub struct EventJournal {
     pub events: Vec<CityEvent>,
     pub max_events: usize,
@@ -72,7 +73,7 @@ impl EventJournal {
 // Active City Effects Resource
 // =============================================================================
 
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Encode, Decode)]
 pub struct ActiveCityEffects {
     pub festival_ticks: u32,
     pub economic_boom_ticks: u32,
@@ -96,7 +97,7 @@ const POPULATION_MILESTONES: &[(u32, &str)] = &[
 ];
 
 /// Tracks which population milestones have already been logged to the journal.
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Encode, Decode)]
 pub struct MilestoneTracker {
     pub reached_milestones: Vec<u32>,
 }

--- a/crates/simulation/src/integration_tests/event_journal_save_tests.rs
+++ b/crates/simulation/src/integration_tests/event_journal_save_tests.rs
@@ -1,0 +1,315 @@
+//! Integration tests for EventJournal, ActiveCityEffects, and MilestoneTracker
+//! save/load roundtrips (SAVE-027).
+
+use crate::events::{
+    ActiveCityEffects, CityEvent, CityEventType, EventJournal, MilestoneTracker,
+};
+use crate::test_harness::TestCity;
+use crate::SaveableRegistry;
+
+// ====================================================================
+// Roundtrip helper
+// ====================================================================
+
+/// Save all registered saveables, reset them, then restore from the saved
+/// bytes. Operates entirely through `world_mut()`.
+fn roundtrip(city: &mut TestCity) {
+    let world = city.world_mut();
+    let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+    let extensions = registry.save_all(world);
+    registry.reset_all(world);
+    registry.load_all(world, &extensions);
+    world.insert_resource(registry);
+}
+
+// ====================================================================
+// EventJournal roundtrip tests
+// ====================================================================
+
+#[test]
+fn test_event_journal_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut journal = world.resource_mut::<EventJournal>();
+        journal.push(CityEvent {
+            event_type: CityEventType::Festival,
+            day: 1,
+            hour: 10.0,
+            description: "Festival on day 1".to_string(),
+        });
+        journal.push(CityEvent {
+            event_type: CityEventType::BudgetCrisis,
+            day: 2,
+            hour: 14.5,
+            description: "Budget crisis on day 2".to_string(),
+        });
+        journal.push(CityEvent {
+            event_type: CityEventType::MilestoneReached("Town".to_string()),
+            day: 3,
+            hour: 8.0,
+            description: "Reached Town".to_string(),
+        });
+    }
+
+    roundtrip(&mut city);
+
+    let journal = city.resource::<EventJournal>();
+    assert_eq!(journal.events.len(), 3, "All 3 events should survive roundtrip");
+    assert_eq!(journal.events[0].day, 1);
+    assert_eq!(journal.events[1].day, 2);
+    assert_eq!(journal.events[2].day, 3);
+    assert_eq!(journal.events[0].description, "Festival on day 1");
+    assert_eq!(journal.events[1].description, "Budget crisis on day 2");
+    assert_eq!(journal.events[2].description, "Reached Town");
+}
+
+#[test]
+fn test_event_journal_empty_skips_save() {
+    let mut city = TestCity::new();
+
+    // Journal is empty by default; save should produce None for the key
+    let world = city.world_mut();
+    let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+    let extensions = registry.save_all(world);
+    world.insert_resource(registry);
+
+    assert!(
+        !extensions.contains_key("event_journal"),
+        "Empty journal should not produce save data"
+    );
+}
+
+#[test]
+fn test_event_journal_preserves_event_types() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut journal = world.resource_mut::<EventJournal>();
+        journal.push(CityEvent {
+            event_type: CityEventType::BuildingFire(10, 20),
+            day: 5,
+            hour: 3.0,
+            description: "Fire!".to_string(),
+        });
+        journal.push(CityEvent {
+            event_type: CityEventType::EconomicBoom,
+            day: 6,
+            hour: 12.0,
+            description: "Boom!".to_string(),
+        });
+        journal.push(CityEvent {
+            event_type: CityEventType::Epidemic,
+            day: 7,
+            hour: 0.0,
+            description: "Epidemic!".to_string(),
+        });
+        journal.push(CityEvent {
+            event_type: CityEventType::DisasterStrike("Tornado".to_string()),
+            day: 8,
+            hour: 6.0,
+            description: "Tornado!".to_string(),
+        });
+        journal.push(CityEvent {
+            event_type: CityEventType::ResourceDepleted("Oil".to_string()),
+            day: 9,
+            hour: 9.0,
+            description: "Oil depleted".to_string(),
+        });
+    }
+
+    roundtrip(&mut city);
+
+    let journal = city.resource::<EventJournal>();
+    assert_eq!(journal.events.len(), 5);
+    assert!(matches!(journal.events[0].event_type, CityEventType::BuildingFire(10, 20)));
+    assert!(matches!(journal.events[1].event_type, CityEventType::EconomicBoom));
+    assert!(matches!(journal.events[2].event_type, CityEventType::Epidemic));
+    assert!(matches!(
+        journal.events[3].event_type,
+        CityEventType::DisasterStrike(ref s) if s == "Tornado"
+    ));
+    assert!(matches!(
+        journal.events[4].event_type,
+        CityEventType::ResourceDepleted(ref s) if s == "Oil"
+    ));
+}
+
+#[test]
+fn test_event_journal_max_events_preserved() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut journal = world.resource_mut::<EventJournal>();
+        journal.max_events = 50;
+        journal.push(CityEvent {
+            event_type: CityEventType::Festival,
+            day: 1,
+            hour: 0.0,
+            description: "Test".to_string(),
+        });
+    }
+
+    roundtrip(&mut city);
+
+    let journal = city.resource::<EventJournal>();
+    assert_eq!(journal.max_events, 50, "max_events should roundtrip");
+}
+
+// ====================================================================
+// ActiveCityEffects roundtrip tests
+// ====================================================================
+
+#[test]
+fn test_active_city_effects_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut effects = world.resource_mut::<ActiveCityEffects>();
+        effects.festival_ticks = 7;
+        effects.economic_boom_ticks = 15;
+        effects.epidemic_ticks = 3;
+    }
+
+    roundtrip(&mut city);
+
+    let effects = city.resource::<ActiveCityEffects>();
+    assert_eq!(effects.festival_ticks, 7);
+    assert_eq!(effects.economic_boom_ticks, 15);
+    assert_eq!(effects.epidemic_ticks, 3);
+}
+
+#[test]
+fn test_active_city_effects_default_skips_save() {
+    let mut city = TestCity::new();
+
+    let world = city.world_mut();
+    let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+    let extensions = registry.save_all(world);
+    world.insert_resource(registry);
+
+    assert!(
+        !extensions.contains_key("active_city_effects"),
+        "Default effects (all zeros) should not produce save data"
+    );
+}
+
+// ====================================================================
+// MilestoneTracker roundtrip tests
+// ====================================================================
+
+#[test]
+fn test_milestone_tracker_save_load_roundtrip() {
+    let mut city = TestCity::new();
+
+    {
+        let world = city.world_mut();
+        let mut tracker = world.resource_mut::<MilestoneTracker>();
+        tracker.reached_milestones.push(1_000);
+        tracker.reached_milestones.push(5_000);
+        tracker.reached_milestones.push(10_000);
+    }
+
+    roundtrip(&mut city);
+
+    let tracker = city.resource::<MilestoneTracker>();
+    assert_eq!(tracker.reached_milestones.len(), 3);
+    assert!(tracker.reached_milestones.contains(&1_000));
+    assert!(tracker.reached_milestones.contains(&5_000));
+    assert!(tracker.reached_milestones.contains(&10_000));
+}
+
+#[test]
+fn test_milestone_tracker_empty_skips_save() {
+    let mut city = TestCity::new();
+
+    let world = city.world_mut();
+    let registry = world.remove_resource::<SaveableRegistry>().unwrap();
+    let extensions = registry.save_all(world);
+    world.insert_resource(registry);
+
+    assert!(
+        !extensions.contains_key("milestone_tracker"),
+        "Empty milestone tracker should not produce save data"
+    );
+}
+
+#[test]
+fn test_milestone_tracker_prevents_re_trigger_after_load() {
+    use crate::virtual_population::VirtualPopulation;
+
+    let mut city = TestCity::new();
+
+    // Simulate reaching a milestone
+    {
+        let world = city.world_mut();
+        world.resource_mut::<VirtualPopulation>().total_virtual = 1_500;
+    }
+    city.tick_slow_cycle();
+
+    let events_before = {
+        let journal = city.resource::<EventJournal>();
+        journal
+            .events
+            .iter()
+            .filter(|e| matches!(e.event_type, CityEventType::MilestoneReached(_)))
+            .count()
+    };
+
+    // Roundtrip
+    roundtrip(&mut city);
+
+    // Tick again — milestone should NOT re-fire
+    city.tick_slow_cycle();
+
+    let events_after = {
+        let journal = city.resource::<EventJournal>();
+        journal
+            .events
+            .iter()
+            .filter(|e| matches!(e.event_type, CityEventType::MilestoneReached(_)))
+            .count()
+    };
+
+    assert_eq!(
+        events_before, events_after,
+        "Milestones should not re-trigger after save/load"
+    );
+}
+
+// ====================================================================
+// Event history visible after load
+// ====================================================================
+
+#[test]
+fn test_event_history_visible_after_load() {
+    let mut city = TestCity::new();
+
+    // Add some events
+    {
+        let world = city.world_mut();
+        let mut journal = world.resource_mut::<EventJournal>();
+        for i in 0..5 {
+            journal.push(CityEvent {
+                event_type: CityEventType::NewPolicy(format!("Policy {}", i)),
+                day: i,
+                hour: 12.0,
+                description: format!("Enacted Policy {}", i),
+            });
+        }
+    }
+
+    roundtrip(&mut city);
+
+    // Verify all events are accessible
+    let journal = city.resource::<EventJournal>();
+    assert_eq!(journal.events.len(), 5);
+    for (i, event) in journal.events.iter().enumerate() {
+        assert_eq!(event.day, i as u32);
+        assert_eq!(event.description, format!("Enacted Policy {}", i));
+    }
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -147,6 +147,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
     app.add_plugins(production::ProductionPlugin);
     app.add_plugins(market::MarketPlugin);
     app.add_plugins(events::EventsPlugin);
+    app.add_plugins(event_journal_save::EventJournalSavePlugin);
     app.add_plugins(notifications::NotificationsPlugin);
     app.add_plugins(specialization::SpecializationPlugin);
     app.add_plugins(advisors::AdvisorsPlugin);

--- a/crates/simulation/src/saveable_keys.rs
+++ b/crates/simulation/src/saveable_keys.rs
@@ -12,6 +12,7 @@ use crate::SaveableRegistry;
 /// will remind you if you forget to register it.
 pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
     "blueprint_library",
+    "active_city_effects",
     "bicycle_lanes",
     "bus_transit",
     "chart_history",
@@ -30,6 +31,7 @@ pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
     "education_pipeline",
     "energy_dispatch",
     "energy_grid",
+    "event_journal",
     "far_transfer",
     "fire_tiers",
     "flood_protection",
@@ -49,6 +51,7 @@ pub const EXPECTED_SAVEABLE_KEYS: &[&str] = &[
     "landfill_state",
     "localization",
     "metro_transit",
+    "milestone_tracker",
     "mode_share_stats",
     "multi_select",
     "neighborhood_quality",


### PR DESCRIPTION
## Summary
- Implement `Saveable` for `EventJournal`, `ActiveCityEffects`, and `MilestoneTracker` so event history and active temporary modifiers persist across save/load cycles
- Add `bitcode::Encode`/`Decode` derives to `CityEventType`, `CityEvent`, `EventJournal`, `ActiveCityEffects`, and `MilestoneTracker`
- Register all three types with the `SaveableRegistry` via a new `EventJournalSavePlugin`
- Add save keys to `saveable_keys.rs` validation list

## Test plan
- [x] EventJournal roundtrips correctly with all event types preserved
- [x] ActiveCityEffects roundtrips with non-zero tick values
- [x] MilestoneTracker roundtrips and prevents milestone re-triggering after load
- [x] Empty/default state skips save (returns None) for all three types
- [x] Event history is accessible after load

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)