### PR TITLE
SAVE-003: Add citizen gender save/load roundtrip tests

### DIFF
--- a/crates/simulation/src/integration_tests/citizen_gender_save_tests.rs
+++ b/crates/simulation/src/integration_tests/citizen_gender_save_tests.rs
@@ -62,7 +62,7 @@ fn spawn_citizen_with_gender(
             salary: 3500.0,
             savings: 7000.0,
         },
-        Personality::default(),
+        Personality { ambition: 0.5, sociability: 0.5, materialism: 0.5, resilience: 0.5 },
         Needs::default(),
         Family::default(),
         ActivityTimer::default(),


### PR DESCRIPTION
## Summary
- Adds integration tests verifying citizen gender correctly roundtrips through the `SaveableRegistry` save/load cycle
- Tests cover Male roundtrip, Female roundtrip, mixed genders, multiple consecutive cycles, serde fidelity, and the u8 codec mapping
- Validates backward compatibility: old saves without a `gender` field default to `0` (Male) via `#[serde(default)]`

The save path (`entity_stage.rs`) and load path (`spawn_entities.rs`) already correctly serialize/deserialize gender. This PR adds focused test coverage to prevent regressions.

Closes #697

## Test plan
- [ ] `test_citizen_gender_male_roundtrip_saveable_registry` — Male gender survives SaveableRegistry roundtrip
- [ ] `test_citizen_gender_female_roundtrip_saveable_registry` — Female gender survives SaveableRegistry roundtrip
- [ ] `test_citizen_gender_mixed_roundtrip` — Both genders survive in a single roundtrip
- [ ] `test_citizen_gender_survives_multiple_roundtrips` — Gender stable across 5 consecutive save/load cycles
- [ ] `test_citizen_details_gender_serde_roundtrip` — Gender survives CitizenDetails serde JSON roundtrip
- [ ] `test_gender_u8_codec_mapping` — u8 mapping matches save/load codec, unknown values default to Male

🤖 Generated with [Claude Code](https://claude.com/claude-code)