### PR TITLE
Fix citizen_render LodTier overwrite on sprite spawn

### DIFF
--- a/crates/rendering/src/citizen_render.rs
+++ b/crates/rendering/src/citizen_render.rs
@@ -48,11 +48,17 @@ const MAX_SPRITES_PER_FRAME: usize = if cfg!(target_arch = "wasm32") {
     500
 };
 
+/// Spawn render components for citizens that have a simulation-assigned LOD tier.
+///
+/// The renderer consumes LOD state from the simulation — it never inserts or
+/// overwrites `LodTier`. Citizens without a `LodTier` component are skipped
+/// until the simulation's LOD assignment system has evaluated them. Abstract-tier
+/// citizens are also skipped since they don't need scene roots.
 #[allow(clippy::type_complexity)]
 pub fn spawn_citizen_sprites(
     mut commands: Commands,
     query: Query<
-        (Entity, Option<&CitizenStateComp>, Option<&LodTier>),
+        (Entity, Option<&CitizenStateComp>, &LodTier),
         (With<Citizen>, Without<CitizenSprite>),
     >,
     model_cache: Res<BuildingModelCache>,
@@ -67,7 +73,7 @@ pub fn spawn_citizen_sprites(
             break;
         }
         // Skip Abstract-tier citizens — they don't need scene roots
-        if lod == Some(&LodTier::Abstract) {
+        if *lod == LodTier::Abstract {
             continue;
         }
         let hash = entity.index() as usize;


### PR DESCRIPTION
## Summary
- Changed `spawn_citizen_sprites` query from `Option<&LodTier>` to `&LodTier` so the renderer only processes citizens that already have a simulation-assigned LOD tier
- Updated the Abstract-tier skip check from `lod == Some(&LodTier::Abstract)` to `*lod == LodTier::Abstract` to match the new non-optional type
- Added doc comment clarifying the renderer's role as a consumer (not author) of LOD state

This prevents transient LOD instability caused by the renderer spawning sprites for citizens before the simulation LOD system has evaluated them, eliminating unnecessary render churn when the LOD system subsequently reassigns tiers.

Closes #1608

## Test plan
- [ ] CI passes (build, test, clippy, fmt)
- [ ] Existing LOD-related integration tests continue to pass
- [ ] No regression in citizen sprite spawning behavior (citizens with simulation-assigned Full/Simplified tiers still get sprites; Abstract-tier citizens are still skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)