### PR TITLE
SAVE-013: Add rotating autosave slots with configurable interval

### DIFF
--- a/crates/simulation/src/autosave.rs
+++ b/crates/simulation/src/autosave.rs
@@ -1,9 +1,9 @@
-//! SAVE-002: Autosave with Configurable Interval.
+//! SAVE-013: Rotating Autosave Slots with Configurable Interval.
 //!
 //! Provides periodic autosave that saves game state without player action.
-//! Configurable interval (default 5 minutes), with 3 rotating save slots
-//! (autosave_1, autosave_2, autosave_3). Settings persist across saves via
-//! the `Saveable` trait.
+//! Configurable interval (default 5 minutes, range 1-30 min), with 3 rotating
+//! save slots (`autosave_1.bin`, `autosave_2.bin`, `autosave_3.bin`). Settings
+//! persist across saves via the `Saveable` trait.
 //!
 //! The simulation crate owns the timer and configuration. When the timer
 //! fires, `AutosavePending` is set, and the save crate's bridge system
@@ -22,22 +22,52 @@ use crate::SlowTickTimer;
 /// Number of rotating autosave slots.
 pub const AUTOSAVE_SLOT_COUNT: u8 = 3;
 
-/// Default autosave interval in slow-tick cycles.
+/// Default autosave interval in minutes.
+pub const DEFAULT_INTERVAL_MINUTES: f32 = 5.0;
+
+/// Minimum configurable interval in minutes.
+pub const MIN_INTERVAL_MINUTES: f32 = 1.0;
+
+/// Maximum configurable interval in minutes.
+pub const MAX_INTERVAL_MINUTES: f32 = 30.0;
+
+/// Default autosave interval in slow-tick cycles (kept for backward compat).
 /// Each slow tick is ~100 fixed-update ticks (~10 seconds at 10 Hz).
 /// 30 slow cycles = ~300 seconds = 5 minutes of game time.
 pub const DEFAULT_INTERVAL_SLOW_TICKS: u32 = 30;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Converts a minutes value to the equivalent number of slow-tick cycles.
+///
+/// Each slow tick cycle is `SlowTickTimer::INTERVAL` fixed-update ticks
+/// at ~10 Hz, so each slow tick is approximately 10 seconds.
+pub fn minutes_to_slow_ticks(minutes: f32) -> u32 {
+    let seconds = minutes * 60.0;
+    let seconds_per_slow_tick = SlowTickTimer::INTERVAL as f32 * 0.1;
+    (seconds / seconds_per_slow_tick).round().max(1.0) as u32
+}
 
 // =============================================================================
 // Resources
 // =============================================================================
 
 /// Player-configurable autosave settings.
+///
+/// Provides `interval_minutes` (1-30 min, clamped) as the primary user-facing
+/// setting. The internal `interval_slow_ticks` is derived from it. The config
+/// tracks which of the 3 rotating slots will be written next, ensuring the
+/// player always has at least 2 intact autosaves if the latest is corrupted.
 #[derive(Resource, Debug, Clone, bitcode::Encode, bitcode::Decode)]
 pub struct AutosaveConfig {
     /// Whether autosave is enabled.
     pub enabled: bool,
-    /// Interval in slow-tick cycles between autosaves.
-    /// Each slow-tick cycle is `SlowTickTimer::INTERVAL` fixed-update ticks.
+    /// User-facing interval in minutes (clamped to 1.0-30.0).
+    pub interval_minutes: f32,
+    /// Interval in slow-tick cycles between autosaves (derived from
+    /// `interval_minutes`). Kept in sync by `set_interval_minutes()`.
     pub interval_slow_ticks: u32,
     /// The next slot index to write to (0, 1, or 2).
     pub current_slot: u8,
@@ -47,6 +77,7 @@ impl Default for AutosaveConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            interval_minutes: DEFAULT_INTERVAL_MINUTES,
             interval_slow_ticks: DEFAULT_INTERVAL_SLOW_TICKS,
             current_slot: 0,
         }
@@ -68,6 +99,24 @@ impl AutosaveConfig {
     pub fn interval_seconds(&self) -> f32 {
         self.interval_slow_ticks as f32 * SlowTickTimer::INTERVAL as f32 * 0.1
     }
+
+    /// Sets the autosave interval in minutes, clamped to the valid range
+    /// (`MIN_INTERVAL_MINUTES`..=`MAX_INTERVAL_MINUTES`), and updates the
+    /// derived `interval_slow_ticks` field.
+    pub fn set_interval_minutes(&mut self, minutes: f32) {
+        self.interval_minutes = minutes.clamp(MIN_INTERVAL_MINUTES, MAX_INTERVAL_MINUTES);
+        self.interval_slow_ticks = minutes_to_slow_ticks(self.interval_minutes);
+    }
+
+    /// Returns the total number of rotating autosave slots.
+    pub fn slot_count(&self) -> u8 {
+        AUTOSAVE_SLOT_COUNT
+    }
+
+    /// Returns filenames for all autosave slots.
+    pub fn all_slot_filenames(&self) -> Vec<String> {
+        (0..AUTOSAVE_SLOT_COUNT).map(slot_filename).collect()
+    }
 }
 
 /// Returns the save filename for a given slot index.
@@ -80,6 +129,18 @@ pub fn slot_filename(slot: u8) -> String {
 pub struct AutosaveTimer {
     /// Number of slow-tick cycles since the last autosave.
     pub counter: u32,
+}
+
+/// Tracks the elapsed game time of the last autosave.
+///
+/// This is a runtime-only resource (not serialized) that records the
+/// `Time::elapsed_secs_f64()` at the moment an autosave is triggered.
+/// Useful for UI display (e.g., "last autosave: 2 minutes ago").
+#[derive(Resource, Default)]
+pub struct AutosaveLastSaveTime {
+    /// Elapsed game time (seconds) when the last autosave was triggered,
+    /// or `None` if no autosave has occurred this session.
+    pub elapsed_secs: Option<f64>,
 }
 
 /// Flag resource indicating that an autosave should be performed.
@@ -124,6 +185,8 @@ pub fn autosave_tick_system(
     config: Res<AutosaveConfig>,
     mut timer: ResMut<AutosaveTimer>,
     mut pending: ResMut<AutosavePending>,
+    mut last_save_time: ResMut<AutosaveLastSaveTime>,
+    time: Res<Time>,
 ) {
     // Only process on slow-tick boundaries.
     if !slow_timer.should_run() {
@@ -140,6 +203,7 @@ pub fn autosave_tick_system(
     if timer.counter >= config.interval_slow_ticks {
         timer.counter = 0;
         pending.pending = true;
+        last_save_time.elapsed_secs = Some(time.elapsed_secs_f64());
     }
 }
 
@@ -173,10 +237,9 @@ impl Plugin for AutosavePlugin {
         app.init_resource::<AutosaveConfig>()
             .init_resource::<AutosaveTimer>()
             .init_resource::<AutosavePending>()
+            .init_resource::<AutosaveLastSaveTime>()
             .add_systems(
                 FixedUpdate,
-                // Order-independent: only reads game state and writes AutosaveState
-                // (private resource); triggers save on timer expiry.
                 autosave_tick_system.in_set(crate::SimulationSet::PostSim),
             )
             .add_systems(Update, autosave_notification_system);
@@ -201,6 +264,7 @@ mod tests {
     fn test_default_config() {
         let config = AutosaveConfig::default();
         assert!(config.enabled);
+        assert_eq!(config.interval_minutes, DEFAULT_INTERVAL_MINUTES);
         assert_eq!(config.interval_slow_ticks, DEFAULT_INTERVAL_SLOW_TICKS);
         assert_eq!(config.current_slot, 0);
     }
@@ -245,13 +309,77 @@ mod tests {
     fn test_saveable_roundtrip() {
         let config = AutosaveConfig {
             enabled: false,
+            interval_minutes: 10.0,
             interval_slow_ticks: 60,
             current_slot: 2,
         };
         let bytes = config.save_to_bytes().unwrap();
         let loaded = AutosaveConfig::load_from_bytes(&bytes);
         assert!(!loaded.enabled);
+        assert_eq!(loaded.interval_minutes, 10.0);
         assert_eq!(loaded.interval_slow_ticks, 60);
         assert_eq!(loaded.current_slot, 2);
+    }
+
+    #[test]
+    fn test_set_interval_minutes_clamps_low() {
+        let mut config = AutosaveConfig::default();
+        config.set_interval_minutes(0.5);
+        assert_eq!(config.interval_minutes, MIN_INTERVAL_MINUTES);
+        assert_eq!(
+            config.interval_slow_ticks,
+            minutes_to_slow_ticks(MIN_INTERVAL_MINUTES)
+        );
+    }
+
+    #[test]
+    fn test_set_interval_minutes_clamps_high() {
+        let mut config = AutosaveConfig::default();
+        config.set_interval_minutes(60.0);
+        assert_eq!(config.interval_minutes, MAX_INTERVAL_MINUTES);
+        assert_eq!(
+            config.interval_slow_ticks,
+            minutes_to_slow_ticks(MAX_INTERVAL_MINUTES)
+        );
+    }
+
+    #[test]
+    fn test_set_interval_minutes_valid() {
+        let mut config = AutosaveConfig::default();
+        config.set_interval_minutes(10.0);
+        assert_eq!(config.interval_minutes, 10.0);
+        assert_eq!(config.interval_slow_ticks, minutes_to_slow_ticks(10.0));
+    }
+
+    #[test]
+    fn test_minutes_to_slow_ticks() {
+        // 5 minutes = 300 seconds, each slow tick = 10 seconds => 30 ticks
+        assert_eq!(minutes_to_slow_ticks(5.0), 30);
+        // 1 minute = 60 seconds => 6 ticks
+        assert_eq!(minutes_to_slow_ticks(1.0), 6);
+        // 30 minutes = 1800 seconds => 180 ticks
+        assert_eq!(minutes_to_slow_ticks(30.0), 180);
+    }
+
+    #[test]
+    fn test_slot_count() {
+        let config = AutosaveConfig::default();
+        assert_eq!(config.slot_count(), 3);
+    }
+
+    #[test]
+    fn test_all_slot_filenames() {
+        let config = AutosaveConfig::default();
+        let filenames = config.all_slot_filenames();
+        assert_eq!(filenames.len(), 3);
+        assert_eq!(filenames[0], "megacity_autosave_1.bin");
+        assert_eq!(filenames[1], "megacity_autosave_2.bin");
+        assert_eq!(filenames[2], "megacity_autosave_3.bin");
+    }
+
+    #[test]
+    fn test_last_save_time_default() {
+        let last = AutosaveLastSaveTime::default();
+        assert!(last.elapsed_secs.is_none());
     }
 }

--- a/crates/simulation/src/integration_tests/autosave_rotating_slots_tests.rs
+++ b/crates/simulation/src/integration_tests/autosave_rotating_slots_tests.rs
@@ -1,0 +1,280 @@
+//! Integration tests for SAVE-013: Rotating Autosave Slots.
+//!
+//! Tests the `interval_minutes` config, slot rotation across multiple
+//! autosave cycles, `AutosaveLastSaveTime` tracking, and clamping behavior.
+
+use crate::autosave::{
+    AutosaveConfig, AutosaveLastSaveTime, AutosavePending, AutosaveTimer,
+    DEFAULT_INTERVAL_MINUTES, MAX_INTERVAL_MINUTES, MIN_INTERVAL_MINUTES,
+};
+use crate::test_harness::TestCity;
+
+// =============================================================================
+// interval_minutes integration tests
+// =============================================================================
+
+#[test]
+fn test_autosave_default_interval_minutes() {
+    let city = TestCity::new();
+    let config = city.resource::<AutosaveConfig>();
+    assert_eq!(
+        config.interval_minutes, DEFAULT_INTERVAL_MINUTES,
+        "Default interval_minutes should be {}",
+        DEFAULT_INTERVAL_MINUTES
+    );
+}
+
+#[test]
+fn test_autosave_set_interval_minutes_updates_slow_ticks() {
+    let mut city = TestCity::new();
+
+    city.world_mut()
+        .resource_mut::<AutosaveConfig>()
+        .set_interval_minutes(10.0);
+
+    let config = city.resource::<AutosaveConfig>();
+    assert_eq!(config.interval_minutes, 10.0);
+    // 10 min = 600 sec, each slow tick = 10 sec => 60 ticks
+    assert_eq!(config.interval_slow_ticks, 60);
+}
+
+#[test]
+fn test_autosave_set_interval_clamps_below_minimum() {
+    let mut city = TestCity::new();
+
+    city.world_mut()
+        .resource_mut::<AutosaveConfig>()
+        .set_interval_minutes(0.1);
+
+    let config = city.resource::<AutosaveConfig>();
+    assert_eq!(
+        config.interval_minutes, MIN_INTERVAL_MINUTES,
+        "Interval should be clamped to minimum"
+    );
+}
+
+#[test]
+fn test_autosave_set_interval_clamps_above_maximum() {
+    let mut city = TestCity::new();
+
+    city.world_mut()
+        .resource_mut::<AutosaveConfig>()
+        .set_interval_minutes(99.0);
+
+    let config = city.resource::<AutosaveConfig>();
+    assert_eq!(
+        config.interval_minutes, MAX_INTERVAL_MINUTES,
+        "Interval should be clamped to maximum"
+    );
+}
+
+#[test]
+fn test_autosave_short_interval_triggers_quickly() {
+    let mut city = TestCity::new();
+
+    // Set 1-minute interval (6 slow ticks).
+    city.world_mut()
+        .resource_mut::<AutosaveConfig>()
+        .set_interval_minutes(1.0);
+
+    let interval = city.resource::<AutosaveConfig>().interval_slow_ticks;
+    assert_eq!(interval, 6, "1 minute should be 6 slow ticks");
+
+    city.tick_slow_cycles(interval);
+
+    let pending = city.resource::<AutosavePending>();
+    assert!(
+        pending.pending,
+        "Autosave should trigger after 1-minute interval"
+    );
+}
+
+// =============================================================================
+// Rotating slot cycling over multiple autosave rounds
+// =============================================================================
+
+#[test]
+fn test_autosave_full_rotation_cycle() {
+    let mut city = TestCity::new();
+
+    // Use a short interval for fast testing.
+    city.world_mut()
+        .resource_mut::<AutosaveConfig>()
+        .interval_slow_ticks = 2;
+
+    // Cycle through all 3 slots and verify filenames.
+    let expected_files = [
+        "megacity_autosave_1.bin",
+        "megacity_autosave_2.bin",
+        "megacity_autosave_3.bin",
+    ];
+
+    for (i, expected_file) in expected_files.iter().enumerate() {
+        let filename = city.resource::<AutosaveConfig>().current_slot_filename();
+        assert_eq!(
+            &filename, expected_file,
+            "Slot {} should produce filename {}",
+            i, expected_file
+        );
+
+        // Trigger autosave.
+        city.tick_slow_cycles(2);
+        assert!(
+            city.resource::<AutosavePending>().pending,
+            "Autosave round {} should trigger pending",
+            i
+        );
+
+        // Simulate the save bridge: clear pending and advance slot.
+        city.world_mut().resource_mut::<AutosavePending>().pending = false;
+        city.world_mut()
+            .resource_mut::<AutosaveConfig>()
+            .advance_slot();
+    }
+
+    // After 3 advances, slot should wrap back to 0.
+    let config = city.resource::<AutosaveConfig>();
+    assert_eq!(
+        config.current_slot, 0,
+        "Slot should wrap back to 0 after full rotation"
+    );
+    assert_eq!(
+        config.current_slot_filename(),
+        "megacity_autosave_1.bin",
+        "Wrapped slot filename should match slot 1"
+    );
+}
+
+// =============================================================================
+// Two-good-autosaves invariant
+// =============================================================================
+
+#[test]
+fn test_two_good_autosaves_invariant() {
+    // With 3 rotating slots, at any point after the first 2 autosaves,
+    // the player has at least 2 older (completed) autosaves while the
+    // newest one is being written. This test verifies the slot indices
+    // cycle correctly to ensure this property.
+    let mut config = AutosaveConfig::default();
+
+    // Simulate 6 autosave rounds and track which slots were written.
+    let mut written_slots: Vec<u8> = Vec::new();
+
+    for _ in 0..6 {
+        written_slots.push(config.current_slot);
+        config.advance_slot();
+    }
+
+    // Verify the pattern: 0, 1, 2, 0, 1, 2
+    assert_eq!(written_slots, vec![0, 1, 2, 0, 1, 2]);
+
+    // At round 3 (writing slot 0), slots 1 and 2 are intact.
+    // At round 4 (writing slot 1), slots 2 and 0 are intact.
+    // At round 5 (writing slot 2), slots 0 and 1 are intact.
+    // This confirms the 2-good-autosaves invariant.
+}
+
+// =============================================================================
+// AutosaveLastSaveTime tracking
+// =============================================================================
+
+#[test]
+fn test_last_save_time_initially_none() {
+    let city = TestCity::new();
+    let last = city.resource::<AutosaveLastSaveTime>();
+    assert!(
+        last.elapsed_secs.is_none(),
+        "Last save time should be None before any autosave"
+    );
+}
+
+#[test]
+fn test_last_save_time_set_after_autosave() {
+    let mut city = TestCity::new();
+
+    // Set short interval.
+    city.world_mut()
+        .resource_mut::<AutosaveConfig>()
+        .interval_slow_ticks = 2;
+
+    city.tick_slow_cycles(2);
+
+    let last = city.resource::<AutosaveLastSaveTime>();
+    assert!(
+        last.elapsed_secs.is_some(),
+        "Last save time should be recorded after autosave triggers"
+    );
+}
+
+// =============================================================================
+// Slot count and filenames
+// =============================================================================
+
+#[test]
+fn test_slot_count_returns_three() {
+    let city = TestCity::new();
+    let config = city.resource::<AutosaveConfig>();
+    assert_eq!(config.slot_count(), 3, "Should have 3 rotating autosave slots");
+}
+
+#[test]
+fn test_all_slot_filenames_returns_three_unique() {
+    let config = AutosaveConfig::default();
+    let filenames = config.all_slot_filenames();
+    assert_eq!(filenames.len(), 3);
+
+    // Verify uniqueness.
+    let mut unique = filenames.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        3,
+        "All 3 autosave slot filenames must be unique"
+    );
+}
+
+// =============================================================================
+// Enable/disable with interval_minutes
+// =============================================================================
+
+#[test]
+fn test_autosave_re_enable_with_custom_interval() {
+    let mut city = TestCity::new();
+
+    // Disable, change interval, re-enable.
+    {
+        let mut config = city.world_mut().resource_mut::<AutosaveConfig>();
+        config.enabled = false;
+        config.set_interval_minutes(2.0);
+    }
+
+    // Run some cycles while disabled — should not trigger.
+    city.tick_slow_cycles(20);
+    assert!(
+        !city.resource::<AutosavePending>().pending,
+        "Should not trigger while disabled"
+    );
+
+    // Re-enable.
+    city.world_mut()
+        .resource_mut::<AutosaveConfig>()
+        .enabled = true;
+
+    // 2 minutes = 12 slow ticks.
+    let interval = city.resource::<AutosaveConfig>().interval_slow_ticks;
+    assert_eq!(interval, 12);
+
+    city.tick_slow_cycles(interval);
+    assert!(
+        city.resource::<AutosavePending>().pending,
+        "Should trigger after re-enable and interval elapses"
+    );
+}
+
+#[test]
+fn test_autosave_timer_resource_exists() {
+    let city = TestCity::new();
+    let timer = city.resource::<AutosaveTimer>();
+    assert_eq!(timer.counter, 0, "Timer should start at 0");
+}


### PR DESCRIPTION
## Summary
- Add user-facing `interval_minutes` field (1-30 min, clamped) to `AutosaveConfig` with `set_interval_minutes()` method that automatically derives `interval_slow_ticks`
- Add `AutosaveLastSaveTime` resource to track elapsed game time at each autosave trigger for UI display ("last autosave: 2 minutes ago")
- Add helper methods `slot_count()`, `all_slot_filenames()`, and `minutes_to_slow_ticks()` converter
- 3 rotating slots (`autosave_1.bin`, `autosave_2.bin`, `autosave_3.bin`) ensure the player always has at least 2 intact autosaves if the latest write is corrupted

Closes #709

## Test plan
- [x] Unit tests for `interval_minutes` clamping (below min, above max, valid values)
- [x] Unit tests for `minutes_to_slow_ticks()` conversion (1, 5, 30 minutes)
- [x] Unit tests for `slot_count()`, `all_slot_filenames()`, saveable roundtrip with new field
- [x] Integration tests for `set_interval_minutes` updating `interval_slow_ticks` in TestCity
- [x] Integration tests for short interval (1 min = 6 slow ticks) triggering correctly
- [x] Integration tests for full 3-slot rotation cycle with filename verification
- [x] Integration tests for two-good-autosaves invariant across 6 rounds
- [x] Integration tests for `AutosaveLastSaveTime` being set after autosave trigger
- [x] Integration tests for disable/re-enable with custom interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)