### PR TITLE
Add energy dashboard UI panel (POWER-019)

### DIFF
--- a/crates/ui/src/energy_dashboard/mod.rs
+++ b/crates/ui/src/energy_dashboard/mod.rs
@@ -1,0 +1,32 @@
+//! Energy Dashboard UI Panel (POWER-019).
+//!
+//! Displays a comprehensive energy dashboard showing:
+//! - Total demand (MW), total supply (MW), reserve margin (%)
+//! - Blackout status indicator (green/yellow/red)
+//! - Current electricity price ($/kWh) with time-of-use period
+//! - Generation mix: bar showing MW from each plant type (coal, gas, wind, battery)
+//! - History graph: demand and supply over last 24 game-hours (ring buffer)
+
+mod panels;
+mod tests;
+pub mod types;
+mod ui_system;
+
+use bevy::prelude::*;
+
+pub use types::{EnergyDashboardVisible, EnergyHistory};
+pub use ui_system::{energy_dashboard_ui, record_energy_history};
+
+/// Plugin that registers the energy dashboard UI.
+pub struct EnergyDashboardPlugin;
+
+impl Plugin for EnergyDashboardPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<EnergyDashboardVisible>()
+            .init_resource::<EnergyHistory>()
+            .add_systems(
+                Update,
+                (record_energy_history, energy_dashboard_ui),
+            );
+    }
+}

--- a/crates/ui/src/energy_dashboard/panels.rs
+++ b/crates/ui/src/energy_dashboard/panels.rs
@@ -1,0 +1,255 @@
+//! Individual UI panel rendering functions for the energy dashboard.
+
+use bevy_egui::egui;
+
+use super::types::{EnergyHistory, GenerationMix, HISTORY_CAPACITY};
+
+// =============================================================================
+// Colors
+// =============================================================================
+
+const COLOR_GREEN: egui::Color32 = egui::Color32::from_rgb(80, 220, 80);
+const COLOR_YELLOW: egui::Color32 = egui::Color32::from_rgb(220, 200, 50);
+const COLOR_RED: egui::Color32 = egui::Color32::from_rgb(255, 60, 60);
+const COLOR_DEMAND: egui::Color32 = egui::Color32::from_rgb(220, 180, 80);
+const COLOR_SUPPLY: egui::Color32 = egui::Color32::from_rgb(80, 180, 220);
+const COLOR_COAL: egui::Color32 = egui::Color32::from_rgb(139, 90, 43);
+const COLOR_GAS: egui::Color32 = egui::Color32::from_rgb(100, 149, 237);
+const COLOR_WIND: egui::Color32 = egui::Color32::from_rgb(144, 238, 144);
+const COLOR_BATTERY: egui::Color32 = egui::Color32::from_rgb(186, 85, 211);
+
+// =============================================================================
+// Supply & Demand Overview
+// =============================================================================
+
+/// Renders the supply/demand/reserve overview.
+pub fn render_supply_demand(
+    ui: &mut egui::Ui,
+    demand_mw: f32,
+    supply_mw: f32,
+    reserve_margin: f32,
+) {
+    ui.heading("Supply & Demand");
+    ui.horizontal(|ui| {
+        ui.label("Total Demand:");
+        ui.colored_label(COLOR_DEMAND, format!("{:.1} MW", demand_mw));
+    });
+    ui.horizontal(|ui| {
+        ui.label("Total Supply:");
+        ui.colored_label(COLOR_SUPPLY, format!("{:.1} MW", supply_mw));
+    });
+
+    let margin_pct = reserve_margin * 100.0;
+    let margin_color = reserve_margin_color(reserve_margin);
+    ui.horizontal(|ui| {
+        ui.label("Reserve Margin:");
+        ui.colored_label(margin_color, format!("{:+.1}%", margin_pct));
+    });
+}
+
+fn reserve_margin_color(margin: f32) -> egui::Color32 {
+    if margin < 0.0 {
+        COLOR_RED
+    } else if margin < 0.10 {
+        COLOR_YELLOW
+    } else {
+        COLOR_GREEN
+    }
+}
+
+// =============================================================================
+// Blackout Status Indicator
+// =============================================================================
+
+/// Renders the blackout status indicator (green/yellow/red).
+pub fn render_blackout_status(
+    ui: &mut egui::Ui,
+    has_deficit: bool,
+    load_shed_fraction: f32,
+    blackout_cells: u32,
+) {
+    ui.heading("Grid Status");
+    let (status_text, status_color) = if !has_deficit {
+        ("NORMAL", COLOR_GREEN)
+    } else if load_shed_fraction < 0.3 {
+        ("BROWNOUT", COLOR_YELLOW)
+    } else {
+        ("BLACKOUT", COLOR_RED)
+    };
+
+    ui.horizontal(|ui| {
+        // Status indicator circle
+        let (rect, _) =
+            ui.allocate_exact_size(egui::vec2(12.0, 12.0), egui::Sense::hover());
+        ui.painter()
+            .circle_filled(rect.center(), 6.0, status_color);
+        ui.colored_label(status_color, status_text);
+    });
+
+    if has_deficit {
+        let shed_pct = load_shed_fraction * 100.0;
+        ui.horizontal(|ui| {
+            ui.label("Load Shed:");
+            ui.colored_label(COLOR_RED, format!("{:.1}%", shed_pct));
+        });
+        if blackout_cells > 0 {
+            ui.horizontal(|ui| {
+                ui.label("Affected Cells:");
+                ui.colored_label(COLOR_RED, format!("{}", blackout_cells));
+            });
+        }
+    }
+}
+
+// =============================================================================
+// Electricity Price
+// =============================================================================
+
+/// Renders the current electricity price.
+pub fn render_price(ui: &mut egui::Ui, price_per_kwh: f32, period_name: &str) {
+    ui.heading("Electricity Price");
+    ui.horizontal(|ui| {
+        ui.label("Current Price:");
+        let price_color = if price_per_kwh > 0.25 {
+            COLOR_RED
+        } else if price_per_kwh > 0.15 {
+            COLOR_YELLOW
+        } else {
+            COLOR_GREEN
+        };
+        ui.colored_label(price_color, format!("${:.3}/kWh", price_per_kwh));
+    });
+    ui.horizontal(|ui| {
+        ui.label("Period:");
+        ui.label(period_name);
+    });
+}
+
+// =============================================================================
+// Generation Mix
+// =============================================================================
+
+/// Renders the generation mix as colored horizontal bars.
+pub fn render_generation_mix(ui: &mut egui::Ui, mix: &GenerationMix) {
+    ui.heading("Generation Mix");
+    let total = mix.total();
+    if total < 0.01 {
+        ui.label("No generation");
+        return;
+    }
+
+    render_mix_bar(ui, "Coal", mix.coal_mw, total, COLOR_COAL);
+    render_mix_bar(ui, "Gas", mix.gas_mw, total, COLOR_GAS);
+    render_mix_bar(ui, "Wind", mix.wind_mw, total, COLOR_WIND);
+    render_mix_bar(ui, "Battery", mix.battery_mw, total, COLOR_BATTERY);
+}
+
+fn render_mix_bar(
+    ui: &mut egui::Ui,
+    label: &str,
+    mw: f32,
+    total: f32,
+    color: egui::Color32,
+) {
+    if mw < 0.01 {
+        return;
+    }
+    let frac = mw / total;
+    let pct = frac * 100.0;
+
+    ui.horizontal(|ui| {
+        ui.label(format!("{label}:"));
+        ui.label(format!("{:.1} MW ({:.0}%)", mw, pct));
+    });
+
+    // Draw a colored progress bar.
+    let desired_width = ui.available_width().min(280.0);
+    let (rect, _) = ui.allocate_exact_size(
+        egui::vec2(desired_width, 14.0),
+        egui::Sense::hover(),
+    );
+
+    let painter = ui.painter();
+    // Background
+    painter.rect_filled(rect, 2.0, egui::Color32::from_rgb(40, 40, 40));
+    // Filled portion
+    let filled_rect = egui::Rect::from_min_size(
+        rect.min,
+        egui::vec2(rect.width() * frac, rect.height()),
+    );
+    painter.rect_filled(filled_rect, 2.0, color);
+}
+
+// =============================================================================
+// History Graph
+// =============================================================================
+
+/// Renders a simple 24-hour demand/supply line graph.
+pub fn render_history_graph(ui: &mut egui::Ui, history: &EnergyHistory) {
+    ui.heading("24-Hour History");
+    let count = history.valid_count();
+    if count < 2 {
+        ui.label("Collecting data...");
+        return;
+    }
+
+    let demand = history.ordered_demand();
+    let supply = history.ordered_supply();
+
+    // Find the max value for scaling.
+    let max_val = demand
+        .iter()
+        .chain(supply.iter())
+        .cloned()
+        .fold(0.0_f32, f32::max)
+        .max(1.0);
+
+    let desired_width = ui.available_width().min(300.0);
+    let graph_height = 80.0;
+    let (rect, _) = ui.allocate_exact_size(
+        egui::vec2(desired_width, graph_height),
+        egui::Sense::hover(),
+    );
+
+    let painter = ui.painter();
+    // Background
+    painter.rect_filled(rect, 2.0, egui::Color32::from_rgb(30, 30, 30));
+
+    // Draw lines
+    draw_line(painter, &rect, &demand, max_val, COLOR_DEMAND);
+    draw_line(painter, &rect, &supply, max_val, COLOR_SUPPLY);
+
+    // Legend
+    ui.horizontal(|ui| {
+        ui.colored_label(COLOR_DEMAND, "Demand");
+        ui.colored_label(COLOR_SUPPLY, "Supply");
+        ui.label(format!("(max: {:.0} MW)", max_val));
+    });
+}
+
+fn draw_line(
+    painter: &egui::Painter,
+    rect: &egui::Rect,
+    data: &[f32],
+    max_val: f32,
+    color: egui::Color32,
+) {
+    if data.len() < 2 {
+        return;
+    }
+
+    let points: Vec<egui::Pos2> = data
+        .iter()
+        .enumerate()
+        .map(|(i, &val)| {
+            let x = rect.min.x
+                + (i as f32 / (HISTORY_CAPACITY - 1) as f32) * rect.width();
+            let y = rect.max.y - (val / max_val) * rect.height();
+            egui::pos2(x, y)
+        })
+        .collect();
+
+    for window in points.windows(2) {
+        painter.line_segment([window[0], window[1]], egui::Stroke::new(1.5, color));
+    }
+}

--- a/crates/ui/src/energy_dashboard/tests.rs
+++ b/crates/ui/src/energy_dashboard/tests.rs
@@ -1,0 +1,85 @@
+//! Unit tests for the energy dashboard types.
+
+#[cfg(test)]
+mod tests {
+    use crate::energy_dashboard::types::{
+        EnergyDashboardVisible, EnergyHistory, GenerationMix, HISTORY_CAPACITY,
+    };
+
+    #[test]
+    fn test_visible_default_is_hidden() {
+        let visible = EnergyDashboardVisible::default();
+        assert!(!visible.0);
+    }
+
+    #[test]
+    fn test_visible_toggle() {
+        let mut visible = EnergyDashboardVisible::default();
+        visible.0 = true;
+        assert!(visible.0);
+    }
+
+    #[test]
+    fn test_history_default_empty() {
+        let history = EnergyHistory::default();
+        assert_eq!(history.valid_count(), 0);
+        assert_eq!(history.write_idx, 0);
+        assert_eq!(history.sample_count, 0);
+    }
+
+    #[test]
+    fn test_history_push_and_count() {
+        let mut history = EnergyHistory::default();
+        history.push(10.0, 12.0);
+        assert_eq!(history.valid_count(), 1);
+        history.push(20.0, 22.0);
+        assert_eq!(history.valid_count(), 2);
+    }
+
+    #[test]
+    fn test_history_ordered_before_full() {
+        let mut history = EnergyHistory::default();
+        history.push(1.0, 10.0);
+        history.push(2.0, 20.0);
+        history.push(3.0, 30.0);
+
+        let demand = history.ordered_demand();
+        assert_eq!(demand.len(), 3);
+        assert!((demand[0] - 1.0).abs() < f32::EPSILON);
+        assert!((demand[1] - 2.0).abs() < f32::EPSILON);
+        assert!((demand[2] - 3.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_history_wraps_around() {
+        let mut history = EnergyHistory::default();
+        for i in 0..HISTORY_CAPACITY + 5 {
+            history.push(i as f32, i as f32 * 2.0);
+        }
+
+        assert_eq!(history.valid_count(), HISTORY_CAPACITY);
+        let demand = history.ordered_demand();
+        assert_eq!(demand.len(), HISTORY_CAPACITY);
+        // Oldest sample should be index 5 (since we wrote 29 samples, oldest surviving = 5)
+        assert!((demand[0] - 5.0).abs() < f32::EPSILON);
+        // Newest should be 28
+        assert!((demand[HISTORY_CAPACITY - 1] - (HISTORY_CAPACITY + 4) as f32).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_generation_mix_total() {
+        let mix = GenerationMix {
+            coal_mw: 100.0,
+            gas_mw: 200.0,
+            wind_mw: 50.0,
+            battery_mw: 10.0,
+        };
+        assert!((mix.total() - 360.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_generation_mix_default_zero() {
+        let mix = GenerationMix::default();
+        assert!((mix.total()).abs() < f32::EPSILON);
+    }
+}

--- a/crates/ui/src/energy_dashboard/types.rs
+++ b/crates/ui/src/energy_dashboard/types.rs
@@ -1,0 +1,92 @@
+//! Types and constants for the energy dashboard.
+
+use bevy::prelude::*;
+
+/// Resource controlling whether the energy dashboard window is visible.
+#[derive(Resource, Default)]
+pub struct EnergyDashboardVisible(pub bool);
+
+/// Number of history samples to keep (24 game-hours at 1 sample per game-hour).
+pub const HISTORY_CAPACITY: usize = 24;
+
+/// Ring buffer storing demand and supply history over the last 24 game-hours.
+#[derive(Resource, Debug, Clone)]
+pub struct EnergyHistory {
+    /// Demand samples in MW (oldest first when reading sequentially).
+    pub demand: Vec<f32>,
+    /// Supply samples in MW (oldest first when reading sequentially).
+    pub supply: Vec<f32>,
+    /// Write index into the ring buffer.
+    pub write_idx: usize,
+    /// Total number of samples written (may exceed capacity).
+    pub sample_count: usize,
+    /// Last game-hour at which a sample was recorded.
+    pub last_recorded_hour: u32,
+}
+
+impl Default for EnergyHistory {
+    fn default() -> Self {
+        Self {
+            demand: vec![0.0; HISTORY_CAPACITY],
+            supply: vec![0.0; HISTORY_CAPACITY],
+            write_idx: 0,
+            sample_count: 0,
+            last_recorded_hour: u32::MAX,
+        }
+    }
+}
+
+impl EnergyHistory {
+    /// Record a new demand/supply sample.
+    pub fn push(&mut self, demand: f32, supply: f32) {
+        self.demand[self.write_idx] = demand;
+        self.supply[self.write_idx] = supply;
+        self.write_idx = (self.write_idx + 1) % HISTORY_CAPACITY;
+        self.sample_count += 1;
+    }
+
+    /// Returns samples in chronological order (oldest first).
+    pub fn ordered_demand(&self) -> Vec<f32> {
+        self.ordered_samples(&self.demand)
+    }
+
+    /// Returns samples in chronological order (oldest first).
+    pub fn ordered_supply(&self) -> Vec<f32> {
+        self.ordered_samples(&self.supply)
+    }
+
+    /// Number of valid samples (capped at HISTORY_CAPACITY).
+    pub fn valid_count(&self) -> usize {
+        self.sample_count.min(HISTORY_CAPACITY)
+    }
+
+    fn ordered_samples(&self, buf: &[f32]) -> Vec<f32> {
+        let count = self.valid_count();
+        if count < HISTORY_CAPACITY {
+            // Buffer not yet full: samples are in order from index 0.
+            buf[..count].to_vec()
+        } else {
+            // Buffer full: oldest sample is at write_idx.
+            let mut result = Vec::with_capacity(HISTORY_CAPACITY);
+            result.extend_from_slice(&buf[self.write_idx..]);
+            result.extend_from_slice(&buf[..self.write_idx]);
+            result
+        }
+    }
+}
+
+/// Aggregated generation mix data by plant type for display.
+#[derive(Debug, Default, Clone)]
+pub struct GenerationMix {
+    pub coal_mw: f32,
+    pub gas_mw: f32,
+    pub wind_mw: f32,
+    pub battery_mw: f32,
+}
+
+impl GenerationMix {
+    /// Total generation across all plant types.
+    pub fn total(&self) -> f32 {
+        self.coal_mw + self.gas_mw + self.wind_mw + self.battery_mw
+    }
+}

--- a/crates/ui/src/energy_dashboard/ui_system.rs
+++ b/crates/ui/src/energy_dashboard/ui_system.rs
@@ -1,0 +1,130 @@
+//! Main energy dashboard UI system.
+
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts};
+
+use simulation::battery_storage::BatteryState;
+use simulation::coal_power::{CoalPowerState, PowerPlant, PowerPlantType};
+use simulation::energy_demand::EnergyGrid;
+use simulation::energy_dispatch::EnergyDispatchState;
+use simulation::energy_pricing::{EnergyEconomics, TimeOfUsePeriod};
+use simulation::time_of_day::GameClock;
+use simulation::wind_power::WindPowerState;
+
+use super::panels;
+use super::types::{EnergyDashboardVisible, EnergyHistory, GenerationMix};
+
+/// Records a history sample once per game-hour.
+pub fn record_energy_history(
+    clock: Res<GameClock>,
+    energy_grid: Res<EnergyGrid>,
+    mut history: ResMut<EnergyHistory>,
+) {
+    let current_hour = clock.hour as u32;
+    if current_hour == history.last_recorded_hour {
+        return;
+    }
+    history.last_recorded_hour = current_hour;
+    history.push(energy_grid.total_demand_mwh, energy_grid.total_supply_mwh);
+}
+
+/// Aggregates the generation mix from per-type state resources.
+fn build_generation_mix(
+    coal_state: &CoalPowerState,
+    wind_state: &WindPowerState,
+    battery_state: &BatteryState,
+    plants: &Query<&PowerPlant>,
+) -> GenerationMix {
+    // Gas output: sum from PowerPlant entities of type NaturalGas.
+    let gas_mw: f32 = plants
+        .iter()
+        .filter(|p| p.plant_type == PowerPlantType::NaturalGas)
+        .map(|p| p.current_output_mw)
+        .sum();
+
+    GenerationMix {
+        coal_mw: coal_state.total_output_mw,
+        gas_mw,
+        wind_mw: wind_state.total_output_mw,
+        battery_mw: battery_state.last_discharge_mwh,
+    }
+}
+
+/// Period display name.
+fn period_name(period: TimeOfUsePeriod) -> &'static str {
+    match period {
+        TimeOfUsePeriod::OffPeak => "Off-Peak",
+        TimeOfUsePeriod::MidPeak => "Mid-Peak",
+        TimeOfUsePeriod::OnPeak => "On-Peak",
+    }
+}
+
+/// Displays the energy dashboard window.
+#[allow(clippy::too_many_arguments)]
+pub fn energy_dashboard_ui(
+    mut contexts: EguiContexts,
+    visible: Res<EnergyDashboardVisible>,
+    energy_grid: Res<EnergyGrid>,
+    dispatch_state: Res<EnergyDispatchState>,
+    economics: Res<EnergyEconomics>,
+    coal_state: Res<CoalPowerState>,
+    wind_state: Res<WindPowerState>,
+    battery_state: Res<BatteryState>,
+    history: Res<EnergyHistory>,
+    plants: Query<&PowerPlant>,
+) {
+    if !visible.0 {
+        return;
+    }
+
+    let mix = build_generation_mix(
+        &coal_state,
+        &wind_state,
+        &battery_state,
+        &plants,
+    );
+
+    egui::Window::new("Energy Dashboard")
+        .default_open(true)
+        .default_width(340.0)
+        .show(contexts.ctx_mut(), |ui| {
+            ui.small("Power grid overview");
+            ui.separator();
+
+            panels::render_blackout_status(
+                ui,
+                dispatch_state.has_deficit,
+                dispatch_state.load_shed_fraction,
+                dispatch_state.blackout_cells,
+            );
+
+            ui.add_space(4.0);
+            ui.separator();
+
+            panels::render_supply_demand(
+                ui,
+                energy_grid.total_demand_mwh,
+                energy_grid.total_supply_mwh,
+                energy_grid.reserve_margin,
+            );
+
+            ui.add_space(4.0);
+            ui.separator();
+
+            panels::render_price(
+                ui,
+                economics.current_price_per_kwh,
+                period_name(economics.current_period),
+            );
+
+            ui.add_space(4.0);
+            ui.separator();
+
+            panels::render_generation_mix(ui, &mix);
+
+            ui.add_space(4.0);
+            ui.separator();
+
+            panels::render_history_graph(ui, &history);
+        });
+}

--- a/crates/ui/src/plugin_registration.rs
+++ b/crates/ui/src/plugin_registration.rs
@@ -39,7 +39,7 @@ pub(crate) fn register_ui_systems(app: &mut App) {
     app.add_plugins(box_selection::BoxSelectionUiPlugin);
     app.add_plugins(zone_brush_ui::ZoneBrushUiPlugin);
     app.add_plugins(info_panel::budget::BudgetBreakdownPlugin);
-
+    app.add_plugins(energy_dashboard::EnergyDashboardPlugin);
     // UI resources
     app.init_resource::<day_night_panel::DayNightPanelVisible>();
     app.init_resource::<milestones::Milestones>();


### PR DESCRIPTION
## Summary
- Add new `energy_dashboard` UI module with egui panel showing total demand/supply (MW), reserve margin (%), blackout status indicator (green/yellow/red), electricity price with time-of-use period, generation mix bars by plant type (coal, gas, wind, battery), and a 24-hour demand/supply history graph using a ring buffer
- Follow established water_dashboard/waste_dashboard patterns with separate types, panels, ui_system, and tests files
- Register `EnergyDashboardPlugin` in UI plugin_registration.rs

Closes #670

## Test plan
- [ ] Verify the dashboard compiles and displays correctly when toggled visible
- [ ] Verify blackout status indicator changes color based on deficit state
- [ ] Verify generation mix bars render proportionally for each plant type
- [ ] Verify 24-hour history graph accumulates and displays samples correctly
- [ ] Unit tests for `EnergyHistory` ring buffer and `GenerationMix` aggregation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)