### PR TITLE
Add Bevy diagnostics and Tracy trace spans (TEST-031)

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [features]
 bench = ["simulation/bench"]
+trace = ["simulation/trace"]
 
 [dependencies]
 bevy = { workspace = true }

--- a/crates/simulation/Cargo.toml
+++ b/crates/simulation/Cargo.toml
@@ -16,6 +16,7 @@ futures-lite = "2"
 
 [features]
 bench = []
+trace = []
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/simulation/src/buildings/spawning.rs
+++ b/crates/simulation/src/buildings/spawning.rs
@@ -74,6 +74,8 @@ pub fn building_spawner(
     game_params: Res<GameParams>,
     mut rng: ResMut<SimRng>,
 ) {
+    #[cfg(feature = "trace")]
+    let _span = bevy::log::info_span!("building_spawner").entered();
     timer.0 += 1;
     if timer.0 < game_params.building.spawn_interval_ticks {
         return;

--- a/crates/simulation/src/diagnostics.rs
+++ b/crates/simulation/src/diagnostics.rs
@@ -1,0 +1,49 @@
+//! Bevy diagnostics and tracing integration for development profiling.
+//!
+//! # Debug-build diagnostics
+//!
+//! In debug builds (`cfg(debug_assertions)`), this plugin automatically adds:
+//! - `FrameTimeDiagnosticsPlugin` — tracks frame time, FPS, and frame count
+//! - `EntityCountDiagnosticsPlugin` — tracks total ECS entity count
+//!
+//! These metrics are available via Bevy's `DiagnosticsStore` resource and can
+//! be displayed in UI overlays or logged to the console.
+//!
+//! # Tracy integration
+//!
+//! Critical simulation systems are instrumented with `bevy::log::info_span!`
+//! trace spans that appear as regions in Tracy or any `tracing`-compatible
+//! profiler. To enable Tracy capture:
+//!
+//! 1. Add the `trace_tracy` feature to Bevy in your workspace Cargo.toml:
+//!    ```toml
+//!    bevy = { version = "0.15", features = ["trace_tracy"] }
+//!    ```
+//! 2. Build with the `trace` feature flag:
+//!    ```sh
+//!    cargo run --features trace
+//!    ```
+//! 3. Open the Tracy profiler (<https://github.com/wolfpld/tracy>) and connect
+//!    to the running application. The following spans will appear:
+//!    - `update_happiness` — per-tick citizen happiness recalculation
+//!    - `move_citizens` — per-tick citizen movement along paths
+//!    - `building_spawner` — zone-demand-driven building placement
+//!    - `update_traffic` — traffic density grid recalculation
+//!
+//! Without the `trace` feature, the `info_span!` calls compile to no-ops and
+//! have zero runtime cost.
+
+use bevy::prelude::*;
+
+pub struct DiagnosticsPlugin;
+
+impl Plugin for DiagnosticsPlugin {
+    fn build(&self, app: &mut App) {
+        // Add diagnostic plugins only in debug builds to avoid overhead in release.
+        #[cfg(debug_assertions)]
+        {
+            app.add_plugins(bevy::diagnostic::FrameTimeDiagnosticsPlugin);
+            app.add_plugins(bevy::diagnostic::EntityCountDiagnosticsPlugin);
+        }
+    }
+}

--- a/crates/simulation/src/happiness/systems.rs
+++ b/crates/simulation/src/happiness/systems.rs
@@ -58,6 +58,8 @@ pub fn update_happiness(
         With<Citizen>,
     >,
 ) {
+    #[cfg(feature = "trace")]
+    let _span = bevy::log::info_span!("update_happiness").entered();
     let road_condition = &extras.road_condition;
     let death_care_grid = &extras.death_care_grid;
     let heating_grid = &extras.heating_grid;

--- a/crates/simulation/src/movement/pathfinding.rs
+++ b/crates/simulation/src/movement/pathfinding.rs
@@ -217,6 +217,8 @@ pub fn move_citizens(
         With<Citizen>,
     >,
 ) {
+    #[cfg(feature = "trace")]
+    let _span = bevy::log::info_span!("move_citizens").entered();
     if clock.paused {
         return;
     }

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -249,4 +249,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
 
     // Play time tracking for save metadata (SAVE-020)
     app.add_plugins(play_time::PlayTimePlugin);
+
+    // Bevy diagnostics and trace spans (TEST-031)
+    app.add_plugins(diagnostics::DiagnosticsPlugin);
 }

--- a/crates/simulation/src/traffic.rs
+++ b/crates/simulation/src/traffic.rs
@@ -65,6 +65,8 @@ pub fn update_traffic_density(
     mut traffic: ResMut<TrafficGrid>,
     citizens: Query<(&CitizenStateComp, &PathCache), With<Citizen>>,
 ) {
+    #[cfg(feature = "trace")]
+    let _span = bevy::log::info_span!("update_traffic").entered();
     if !tick.0.is_multiple_of(5) {
         return;
     }


### PR DESCRIPTION
## Summary
- Add `FrameTimeDiagnosticsPlugin` and `EntityCountDiagnosticsPlugin` gated behind `#[cfg(debug_assertions)]` for dev-build profiling
- Define `trace` feature flag in `simulation` and `app` Cargo.toml files
- Add `info_span!` trace instrumentation (gated behind `#[cfg(feature = "trace")]`) to four critical systems: `update_happiness`, `move_citizens`, `building_spawner`, `update_traffic`
- Document Tracy integration steps in the `diagnostics` module doc comments

## Test plan
- [ ] Verify `cargo build --workspace` compiles without the `trace` feature (default path)
- [ ] Verify `cargo build --workspace --features trace` compiles with trace spans enabled
- [ ] Verify `cargo test --workspace` passes (no runtime impact without feature)
- [ ] Verify diagnostic plugins are registered in debug builds via `DiagnosticsPlugin`
- [ ] Verify trace spans appear in Tracy when built with `trace` + `trace_tracy` features

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)