### PR TITLE
Add F5/F9 quick save/load to quicksave.bin

### DIFF
--- a/crates/save/src/exclusive_save.rs
+++ b/crates/save/src/exclusive_save.rs
@@ -8,6 +8,8 @@ use simulation::citizen::Citizen;
 use simulation::play_time::PlayTime;
 
 use crate::save_error::SaveError;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::save_plugin::PendingSavePath;
 use crate::save_stages::{
     assemble_save_data, collect_disaster_stage, collect_economy_stage, collect_entity_stage,
     collect_environment_stage, collect_grid_stage, collect_policy_stage,
@@ -177,7 +179,12 @@ fn exclusive_save_inner(world: &mut World) -> Result<(), SaveError> {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let path = crate::save_plugin::save_file_path();
+        // Use the override path if set, otherwise fall back to default.
+        let path = world
+            .resource_mut::<PendingSavePath>()
+            .0
+            .take()
+            .unwrap_or_else(crate::save_plugin::save_file_path);
         crate::atomic_write::atomic_write(&path, &bytes)?;
         info!("Saved {} bytes to {}", bytes.len(), path);
     }

--- a/crates/save/src/lib.rs
+++ b/crates/save/src/lib.rs
@@ -34,5 +34,8 @@ pub use crash_recovery::CrashRecoveryState;
 pub use file_header::read_metadata_only;
 pub use save_error::SaveError;
 pub use save_metadata::SaveMetadata;
-pub use save_plugin::{LoadGameEvent, NewGameEvent, SaveGameEvent, SavePlugin};
+pub use save_plugin::{LoadGameEvent, NewGameEvent, PendingSavePath, SaveGameEvent, SavePlugin};
 pub use saveable_ext::SaveableAppExt;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use save_plugin::quicksave_file_path;

--- a/crates/simulation/src/keybindings/bindings.rs
+++ b/crates/simulation/src/keybindings/bindings.rs
@@ -199,10 +199,10 @@ impl Default for KeyBindings {
             toggle_charts: KeyBinding::simple(KeyCode::KeyC),
             toggle_advisor: KeyBinding::simple(KeyCode::KeyA),
             toggle_policies: KeyBinding::simple(KeyCode::KeyP),
-            toggle_settings: KeyBinding::simple(KeyCode::F9),
+            toggle_settings: KeyBinding::simple(KeyCode::F10),
             toggle_search: KeyBinding::ctrl(KeyCode::KeyF),
-            quick_save: KeyBinding::ctrl(KeyCode::KeyS),
-            quick_load: KeyBinding::ctrl(KeyCode::KeyL),
+            quick_save: KeyBinding::simple(KeyCode::F5),
+            quick_load: KeyBinding::simple(KeyCode::F9),
             new_game: KeyBinding::ctrl(KeyCode::KeyN),
             screenshot: KeyBinding::simple(KeyCode::F12),
         }

--- a/crates/ui/src/info_panel/keybinds.rs
+++ b/crates/ui/src/info_panel/keybinds.rs
@@ -36,15 +36,18 @@ pub fn panel_keybinds(
     // Budget panel is accessible via the toolbar UI.
 }
 
-/// Keyboard shortcuts for quick save (Ctrl+S), quick load (Ctrl+L), and new game (Ctrl+N).
+/// Keyboard shortcuts for quick save (F5) and quick load (F9) to `quicksave.bin`,
+/// plus new game (Ctrl+N).
 /// Skipped when egui wants keyboard input (e.g. a text field is focused).
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, unused_mut, unused_variables)]
 pub fn quick_save_load_keybinds(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut contexts: EguiContexts,
     mut save_events: EventWriter<save::SaveGameEvent>,
     mut load_events: EventWriter<save::LoadGameEvent>,
     mut new_game_events: EventWriter<save::NewGameEvent>,
+    mut notifications: EventWriter<simulation::notifications::NotificationEvent>,
+    mut path_override: ResMut<save::PendingSavePath>,
     bindings: Res<simulation::keybindings::KeyBindings>,
 ) {
     if contexts.ctx_mut().wants_keyboard_input() {
@@ -52,12 +55,40 @@ pub fn quick_save_load_keybinds(
     }
 
     if bindings.quick_save.just_pressed(&keyboard) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            path_override.0 = Some(save::quicksave_file_path());
+        }
         save_events.send(save::SaveGameEvent);
+        notifications.send(simulation::notifications::NotificationEvent {
+            text: "Quick saved".to_string(),
+            priority: simulation::notifications::NotificationPriority::Info,
+            location: None,
+        });
     }
     if bindings.quick_load.just_pressed(&keyboard) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let qs_path = save::quicksave_file_path();
+            if !std::path::Path::new(&qs_path).exists() {
+                notifications.send(simulation::notifications::NotificationEvent {
+                    text: "No quicksave found".to_string(),
+                    priority: simulation::notifications::NotificationPriority::Warning,
+                    location: None,
+                });
+                return;
+            }
+            path_override.0 = Some(qs_path);
+        }
         load_events.send(save::LoadGameEvent);
+        notifications.send(simulation::notifications::NotificationEvent {
+            text: "Quick loaded".to_string(),
+            priority: simulation::notifications::NotificationPriority::Info,
+            location: None,
+        });
     }
     if bindings.new_game.just_pressed(&keyboard) {
         new_game_events.send(save::NewGameEvent);
     }
 }
+// quicksave: F5/F9 (issue #720)

--- a/crates/ui/src/settings_panel.rs
+++ b/crates/ui/src/settings_panel.rs
@@ -1,7 +1,7 @@
 //! Settings panel UI (UX-039 Colorblind Accessibility).
 //!
 //! Provides an egui window with colorblind mode selection and other
-//! accessibility settings. Toggled via the F9 key.
+//! accessibility settings. Toggled via the F10 key.
 
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts};
@@ -22,7 +22,7 @@ pub struct SettingsPanelVisible(pub bool);
 // Systems
 // =============================================================================
 
-/// Toggles the settings panel with F9.
+/// Toggles the settings panel with F10.
 pub fn settings_panel_keybind(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut visible: ResMut<SettingsPanelVisible>,


### PR DESCRIPTION
## Summary
- **F5** saves to dedicated `quicksave.bin` with "Quick saved" notification
- **F9** loads from `quicksave.bin` with "Quick loaded" notification; warns "No quicksave found" if file doesn't exist
- Toolbar Save/Load buttons unchanged (still use `megacity_save.bin`)
- Settings panel keybinding moved from F9 to F10
- Adds `PendingSavePath` resource for per-operation save path override

## Implementation
- `PendingSavePath` resource in save crate allows the quicksave system to override the save/load file path without modifying `SaveGameEvent`/`LoadGameEvent` event structs
- Default keybindings updated: `quick_save` = F5, `quick_load` = F9, `toggle_settings` = F10
- Status messages use the existing `NotificationEvent` system

## Test plan
- [ ] Press F5 -- game saves to `quicksave.bin`, "Quick saved" notification appears
- [ ] Press F9 -- game loads from `quicksave.bin`, "Quick loaded" notification appears
- [ ] Press F9 with no `quicksave.bin` -- "No quicksave found" warning appears, no crash
- [ ] Toolbar Save/Load buttons still use `megacity_save.bin`
- [ ] F10 opens settings panel (previously F9)
- [ ] Autosave still works (uses default path)

Closes #720

Generated with [Claude Code](https://claude.com/claude-code)