### PR TITLE
SAVE-030: Save/load performance benchmark at scale

### DIFF
--- a/crates/save/Cargo.toml
+++ b/crates/save/Cargo.toml
@@ -12,6 +12,10 @@ xxhash-rust = { workspace = true }
 lz4_flex = { workspace = true }
 rendering = { path = "../rendering" }
 
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+lz4_flex = { workspace = true }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = [
     "Window",
@@ -36,6 +40,18 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 futures-channel = "0.3"
 flate2 = "1.1"
+
+# Desktop-only: winit needs a native windowing backend for benchmarks (TestCity uses a Bevy App)
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+bevy = { workspace = true, features = ["x11"] }
+
+[[bench]]
+name = "save_bench"
+harness = false
+
+[[bench]]
+name = "save_snapshot_bench"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/save/benches/save_bench.rs
+++ b/crates/save/benches/save_bench.rs
@@ -1,0 +1,348 @@
+//! Save/load performance benchmarks at scale (SAVE-030).
+//!
+//! Measures serialization and deserialization performance for save files at
+//! different city scales: 10K, 50K, 100K, and 500K citizens.
+//!
+//! Run with: `cargo bench -p save --bench save_bench`
+//!
+//! Performance budget (from issue #726):
+//!   - Snapshot (ECS -> SaveData): <16ms
+//!   - Encode (bitcode): <500ms
+//!   - Full save (encode + compress + write): <1s
+//!   - Full load (read + decompress + decode): <3s
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::collections::BTreeMap;
+
+use save::serialization::{
+    SaveBudget, SaveBuilding, SaveCell, SaveCitizen, SaveClock, SaveData, SaveDemand, SaveGrid,
+    SaveRoadNetwork, CURRENT_SAVE_VERSION,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers: build synthetic SaveData at various scales
+// ---------------------------------------------------------------------------
+
+const GRID_W: usize = 256;
+const GRID_H: usize = 256;
+
+/// Build a synthetic SaveData with the given citizen count and proportional
+/// buildings/services/utilities. Grid is 256x256 with ~20% road coverage.
+fn build_synthetic_save(citizen_count: usize) -> SaveData {
+    let cells: Vec<SaveCell> = (0..GRID_W * GRID_H)
+        .map(|i| {
+            let x = i % GRID_W;
+            let y = i / GRID_W;
+            let is_road = x % 4 == 0 || y % 4 == 0;
+            SaveCell {
+                elevation: 10.0 + (x as f32 * 0.01) + (y as f32 * 0.02),
+                cell_type: u8::from(is_road),
+                zone: if is_road { 0 } else { ((x + y) % 5) as u8 },
+                road_type: u8::from(is_road),
+                has_power: true,
+                has_water: x < 200 && y < 200,
+            }
+        })
+        .collect();
+
+    let road_positions: Vec<(usize, usize)> = (0..GRID_W * GRID_H)
+        .filter_map(|i| {
+            let x = i % GRID_W;
+            let y = i / GRID_W;
+            if x % 4 == 0 || y % 4 == 0 {
+                Some((x, y))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let building_count = citizen_count / 10;
+    let buildings: Vec<SaveBuilding> = (0..building_count)
+        .map(|i| SaveBuilding {
+            zone_type: ((i % 4) + 1) as u8,
+            level: ((i % 3) + 1) as u8,
+            grid_x: (i * 3) % GRID_W,
+            grid_y: (i * 7) % GRID_H,
+            capacity: 12,
+            occupants: (i % 12) as u32,
+            commercial_capacity: 0,
+            commercial_occupants: 0,
+            residential_capacity: 0,
+            residential_occupants: 0,
+        })
+        .collect();
+
+    let citizens: Vec<SaveCitizen> = (0..citizen_count)
+        .map(|i| build_synthetic_citizen(i))
+        .collect();
+
+    SaveData {
+        version: CURRENT_SAVE_VERSION,
+        grid: SaveGrid {
+            cells,
+            width: GRID_W,
+            height: GRID_H,
+        },
+        roads: SaveRoadNetwork { road_positions },
+        clock: SaveClock {
+            day: 42,
+            hour: 14.5,
+            speed: 1.0,
+        },
+        budget: SaveBudget {
+            treasury: 500_000.0,
+            tax_rate: 0.10,
+            last_collection_day: 41,
+        },
+        demand: SaveDemand {
+            residential: 0.6,
+            commercial: 0.4,
+            industrial: 0.3,
+            office: 0.2,
+            vacancy_residential: 0.05,
+            vacancy_commercial: 0.08,
+            vacancy_industrial: 0.12,
+            vacancy_office: 0.10,
+        },
+        buildings,
+        citizens,
+        utility_sources: vec![],
+        service_buildings: vec![],
+        road_segments: None,
+        policies: None,
+        weather: None,
+        unlock_state: None,
+        extended_budget: None,
+        loan_book: None,
+        lifecycle_timer: None,
+        virtual_population: None,
+        life_sim_timer: None,
+        stormwater_grid: None,
+        water_sources: None,
+        degree_days: None,
+        construction_modifiers: None,
+        recycling_state: None,
+        wind_damage_state: None,
+        uhi_grid: None,
+        drought_state: None,
+        heat_wave_state: None,
+        composting_state: None,
+        cold_snap_state: None,
+        water_treatment_state: None,
+        groundwater_depletion_state: None,
+        wastewater_state: None,
+        hazardous_waste_state: None,
+        storm_drainage_state: None,
+        landfill_capacity_state: None,
+        flood_state: None,
+        reservoir_state: None,
+        landfill_gas_state: None,
+        cso_state: None,
+        water_conservation_state: None,
+        fog_state: None,
+        urban_growth_boundary: None,
+        snow_state: None,
+        agriculture_state: None,
+        extensions: BTreeMap::new(),
+    }
+}
+
+fn build_synthetic_citizen(i: usize) -> SaveCitizen {
+    SaveCitizen {
+        age: 20 + (i % 60) as u8,
+        happiness: 50.0 + (i % 50) as f32,
+        education: (i % 4) as u8,
+        state: (i % 10) as u8,
+        home_x: (i * 3) % GRID_W,
+        home_y: (i * 7) % GRID_H,
+        work_x: (i * 5 + 10) % GRID_W,
+        work_y: (i * 11 + 20) % GRID_H,
+        path_waypoints: vec![
+            ((i * 3 + 1) % GRID_W, (i * 7 + 1) % GRID_H),
+            ((i * 3 + 2) % GRID_W, (i * 7 + 2) % GRID_H),
+            ((i * 5 + 10) % GRID_W, (i * 11 + 20) % GRID_H),
+        ],
+        path_current_index: 0,
+        velocity_x: 0.5,
+        velocity_y: -0.3,
+        pos_x: ((i * 3) % GRID_W) as f32 * 16.0 + 8.0,
+        pos_y: ((i * 7) % GRID_H) as f32 * 16.0 + 8.0,
+        gender: (i % 2) as u8,
+        health: 70.0 + (i % 30) as f32,
+        salary: 2000.0 + (i % 5000) as f32,
+        savings: 5000.0 + (i % 20000) as f32,
+        ambition: 0.3 + (i % 7) as f32 * 0.1,
+        sociability: 0.4 + (i % 6) as f32 * 0.1,
+        materialism: 0.2 + (i % 8) as f32 * 0.1,
+        resilience: 0.5 + (i % 5) as f32 * 0.1,
+        need_hunger: 60.0 + (i % 40) as f32,
+        need_energy: 50.0 + (i % 50) as f32,
+        need_social: 40.0 + (i % 60) as f32,
+        need_fun: 30.0 + (i % 70) as f32,
+        need_comfort: 50.0 + (i % 50) as f32,
+        activity_timer: (i % 100) as u32,
+        family_partner: if i % 3 == 0 { (i + 1) as u32 } else { u32::MAX },
+        family_children: if i % 5 == 0 {
+            vec![(i + 2) as u32]
+        } else {
+            vec![]
+        },
+        family_parent: u32::MAX,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. BITCODE ENCODE (SaveData -> bytes)
+// ---------------------------------------------------------------------------
+
+fn bench_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("save_encode");
+    group.sample_size(10);
+
+    for &count in &[10_000usize, 50_000, 100_000, 500_000] {
+        let save = build_synthetic_save(count);
+        group.bench_with_input(
+            BenchmarkId::new("bitcode_encode", format!("{count}_citizens")),
+            &save,
+            |b, save| {
+                b.iter(|| black_box(save.encode()));
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// 2. BITCODE DECODE (bytes -> SaveData)
+// ---------------------------------------------------------------------------
+
+fn bench_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("save_decode");
+    group.sample_size(10);
+
+    for &count in &[10_000usize, 50_000, 100_000, 500_000] {
+        let save = build_synthetic_save(count);
+        let encoded = save.encode();
+        group.bench_with_input(
+            BenchmarkId::new("bitcode_decode", format!("{count}_citizens")),
+            &encoded,
+            |b, bytes| {
+                b.iter(|| black_box(SaveData::decode(bytes).unwrap()));
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// 3. LZ4 COMPRESSION
+// ---------------------------------------------------------------------------
+
+fn bench_lz4_compress(c: &mut Criterion) {
+    let mut group = c.benchmark_group("save_lz4_compress");
+    group.sample_size(10);
+
+    for &count in &[10_000usize, 50_000, 100_000, 500_000] {
+        let save = build_synthetic_save(count);
+        let encoded = save.encode();
+        group.bench_with_input(
+            BenchmarkId::new("lz4_compress", format!("{count}_citizens")),
+            &encoded,
+            |b, bytes| {
+                b.iter(|| black_box(lz4_flex::compress_prepend_size(bytes)));
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// 4. LZ4 DECOMPRESSION
+// ---------------------------------------------------------------------------
+
+fn bench_lz4_decompress(c: &mut Criterion) {
+    let mut group = c.benchmark_group("save_lz4_decompress");
+    group.sample_size(10);
+
+    for &count in &[10_000usize, 50_000, 100_000, 500_000] {
+        let save = build_synthetic_save(count);
+        let encoded = save.encode();
+        let compressed = lz4_flex::compress_prepend_size(&encoded);
+        group.bench_with_input(
+            BenchmarkId::new("lz4_decompress", format!("{count}_citizens")),
+            &compressed,
+            |b, bytes| {
+                b.iter(|| black_box(lz4_flex::decompress_size_prepended(bytes).unwrap()));
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// 5. FULL SAVE PIPELINE: encode + compress
+// ---------------------------------------------------------------------------
+
+fn bench_full_save_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("save_full_pipeline");
+    group.sample_size(10);
+
+    for &count in &[10_000usize, 50_000, 100_000, 500_000] {
+        let save = build_synthetic_save(count);
+        group.bench_with_input(
+            BenchmarkId::new("encode_and_compress", format!("{count}_citizens")),
+            &save,
+            |b, save| {
+                b.iter(|| {
+                    let encoded = save.encode();
+                    let compressed = lz4_flex::compress_prepend_size(&encoded);
+                    black_box(compressed.len())
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// 6. FULL LOAD PIPELINE: decompress + decode
+// ---------------------------------------------------------------------------
+
+fn bench_full_load_pipeline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("load_full_pipeline");
+    group.sample_size(10);
+
+    for &count in &[10_000usize, 50_000, 100_000, 500_000] {
+        let save = build_synthetic_save(count);
+        let encoded = save.encode();
+        let compressed = lz4_flex::compress_prepend_size(&encoded);
+        group.bench_with_input(
+            BenchmarkId::new("decompress_and_decode", format!("{count}_citizens")),
+            &compressed,
+            |b, bytes| {
+                b.iter(|| {
+                    let decompressed = lz4_flex::decompress_size_prepended(bytes).unwrap();
+                    let save = SaveData::decode(&decompressed).unwrap();
+                    black_box(save.citizens.len())
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Register all benchmark groups
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    benches,
+    bench_encode,
+    bench_decode,
+    bench_lz4_compress,
+    bench_lz4_decompress,
+    bench_full_save_pipeline,
+    bench_full_load_pipeline,
+);
+criterion_main!(benches);

--- a/crates/save/benches/save_snapshot_bench.rs
+++ b/crates/save/benches/save_snapshot_bench.rs
@@ -1,0 +1,348 @@
+//! Realistic save/load snapshot benchmark using the Tel Aviv map (SAVE-030).
+//!
+//! Measures the full pipeline: ECS world -> SaveData -> encode -> compress,
+//! and the reverse load pipeline, using the actual Tel Aviv map with ~10K
+//! real citizens and all simulation systems.
+//!
+//! Run with: `cargo bench -p save --bench save_snapshot_bench`
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use save::serialization::{
+    assemble_save_data, collect_disaster_stage, collect_economy_stage, collect_entity_stage,
+    collect_environment_stage, collect_grid_stage, collect_policy_stage, CitizenSaveInput,
+    SaveData,
+};
+
+use simulation::agriculture::AgricultureState;
+use simulation::budget::ExtendedBudget;
+use simulation::buildings::{Building, MixedUseBuilding};
+use simulation::citizen::{
+    CitizenDetails, CitizenStateComp, Family, HomeLocation, Needs, PathCache, Personality,
+    Position, Velocity, WorkLocation,
+};
+use simulation::cold_snap::ColdSnapState;
+use simulation::composting::CompostingState;
+use simulation::cso::SewerSystemState;
+use simulation::degree_days::DegreeDays;
+use simulation::drought::DroughtState;
+use simulation::economy::CityBudget;
+use simulation::flood_simulation::FloodState;
+use simulation::fog::FogState;
+use simulation::grid::WorldGrid;
+use simulation::groundwater_depletion::GroundwaterDepletionState;
+use simulation::hazardous_waste::HazardousWasteState;
+use simulation::heat_wave::HeatWaveState;
+use simulation::landfill_gas::LandfillGasState;
+use simulation::landfill_warning::LandfillCapacityState;
+use simulation::life_simulation::LifeSimTimer;
+use simulation::lifecycle::LifecycleTimer;
+use simulation::loans::LoanBook;
+use simulation::movement::ActivityTimer;
+use simulation::policies::Policies;
+use simulation::recycling::{RecyclingEconomics, RecyclingState};
+use simulation::reservoir::ReservoirState;
+use simulation::road_segments::RoadSegmentStore;
+use simulation::roads::RoadNetwork;
+use simulation::services::ServiceBuilding;
+use simulation::snow::{SnowGrid, SnowPlowingState};
+use simulation::storm_drainage::StormDrainageState;
+use simulation::stormwater::StormwaterGrid;
+use simulation::test_harness::TestCity;
+use simulation::time_of_day::GameClock;
+use simulation::unlocks::UnlockState;
+use simulation::urban_growth_boundary::UrbanGrowthBoundary;
+use simulation::urban_heat_island::UhiGrid;
+use simulation::utilities::UtilitySource;
+use simulation::virtual_population::VirtualPopulation;
+use simulation::wastewater::WastewaterState;
+use simulation::water_conservation::WaterConservationState;
+use simulation::water_sources::WaterSource;
+use simulation::water_treatment::WaterTreatmentState;
+use simulation::weather::{ClimateZone, ConstructionModifiers, Weather};
+use simulation::wind_damage::WindDamageState;
+use simulation::zones::ZoneDemand;
+
+use bevy::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Collect SaveData from a live ECS World
+// ---------------------------------------------------------------------------
+
+/// Collect SaveData from a live ECS world (mirrors the exclusive_save logic).
+#[allow(clippy::too_many_lines)]
+fn collect_save_from_world(world: &mut World) -> SaveData {
+    // -- Entity queries --
+    let building_data: Vec<(Building, Option<MixedUseBuilding>)> = {
+        let mut q = world.query::<(&Building, Option<&MixedUseBuilding>)>();
+        q.iter(world)
+            .map(|(b, mu)| (b.clone(), mu.cloned()))
+            .collect()
+    };
+
+    let citizen_data: Vec<CitizenSaveInput> = {
+        let mut q = world.query::<(
+            Entity,
+            &CitizenDetails,
+            &CitizenStateComp,
+            &HomeLocation,
+            &WorkLocation,
+            &PathCache,
+            &Velocity,
+            &Position,
+            &Personality,
+            &Needs,
+            &ActivityTimer,
+            &Family,
+        )>();
+        q.iter(world)
+            .map(
+                |(entity, d, state, home, work, path, vel, pos, pers, needs, timer, family)| {
+                    CitizenSaveInput {
+                        entity,
+                        details: d.clone(),
+                        state: state.0,
+                        home_x: home.grid_x,
+                        home_y: home.grid_y,
+                        work_x: work.grid_x,
+                        work_y: work.grid_y,
+                        path: path.clone(),
+                        velocity: vel.clone(),
+                        position: pos.clone(),
+                        personality: pers.clone(),
+                        needs: needs.clone(),
+                        activity_timer: timer.0,
+                        family: family.clone(),
+                    }
+                },
+            )
+            .collect()
+    };
+
+    let utility_data: Vec<UtilitySource> = {
+        let mut q = world.query::<&UtilitySource>();
+        q.iter(world).cloned().collect()
+    };
+    let service_data: Vec<(ServiceBuilding,)> = {
+        let mut q = world.query::<&ServiceBuilding>();
+        q.iter(world).map(|sb| (sb.clone(),)).collect()
+    };
+    let water_source_data: Vec<WaterSource> = {
+        let mut q = world.query::<&WaterSource>();
+        q.iter(world).cloned().collect()
+    };
+
+    // -- Resource collection stages --
+    let grid_stage = {
+        let grid = world.resource::<WorldGrid>();
+        let roads = world.resource::<RoadNetwork>();
+        let segments = world.resource::<RoadSegmentStore>();
+        let seg_ref = if segments.segments.is_empty() {
+            None
+        } else {
+            Some(segments.as_ref())
+        };
+        collect_grid_stage(grid, roads, seg_ref)
+    };
+
+    let economy_stage = {
+        let clock = world.resource::<GameClock>();
+        let budget = world.resource::<CityBudget>();
+        let demand = world.resource::<ZoneDemand>();
+        let ext = world.resource::<ExtendedBudget>();
+        let loans = world.resource::<LoanBook>();
+        collect_economy_stage(clock, budget, demand, Some(ext), Some(loans))
+    };
+
+    let entity_stage = collect_entity_stage(
+        &building_data,
+        &citizen_data,
+        &utility_data,
+        &service_data,
+        if water_source_data.is_empty() {
+            None
+        } else {
+            Some(&water_source_data)
+        },
+    );
+
+    let environment_stage = {
+        let weather = world.resource::<Weather>();
+        let climate = world.resource::<ClimateZone>();
+        let uhi = world.resource::<UhiGrid>();
+        let sw = world.resource::<StormwaterGrid>();
+        let dd = world.resource::<DegreeDays>();
+        let cm = world.resource::<ConstructionModifiers>();
+        let sg = world.resource::<SnowGrid>();
+        let sp = world.resource::<SnowPlowingState>();
+        let ag = world.resource::<AgricultureState>();
+        let fog = world.resource::<FogState>();
+        let ugb = world.resource::<UrbanGrowthBoundary>();
+        collect_environment_stage(
+            Some(weather),
+            Some(climate),
+            Some(uhi),
+            Some(sw),
+            Some(dd),
+            Some(cm),
+            Some((sg, sp)),
+            Some(ag),
+            Some(fog),
+            Some(ugb),
+        )
+    };
+
+    let disaster_stage = {
+        let dr = world.resource::<DroughtState>();
+        let hw = world.resource::<HeatWaveState>();
+        let cs = world.resource::<ColdSnapState>();
+        let fl = world.resource::<FloodState>();
+        let wd = world.resource::<WindDamageState>();
+        let rs = world.resource::<ReservoirState>();
+        let lg = world.resource::<LandfillGasState>();
+        let cso = world.resource::<SewerSystemState>();
+        let hz = world.resource::<HazardousWasteState>();
+        let ww = world.resource::<WastewaterState>();
+        let sd = world.resource::<StormDrainageState>();
+        let lc = world.resource::<LandfillCapacityState>();
+        let gw = world.resource::<GroundwaterDepletionState>();
+        let wt = world.resource::<WaterTreatmentState>();
+        let wc = world.resource::<WaterConservationState>();
+        collect_disaster_stage(
+            Some(dr),
+            Some(hw),
+            Some(cs),
+            Some(fl),
+            Some(wd),
+            Some(rs),
+            Some(lg),
+            Some(cso),
+            Some(hz),
+            Some(ww),
+            Some(sd),
+            Some(lc),
+            Some(gw),
+            Some(wt),
+            Some(wc),
+        )
+    };
+
+    let policy_stage = {
+        let pol = world.resource::<Policies>();
+        let us = world.resource::<UnlockState>();
+        let rs = world.resource::<RecyclingState>();
+        let re = world.resource::<RecyclingEconomics>();
+        let co = world.resource::<CompostingState>();
+        let lc = world.resource::<LifecycleTimer>();
+        let ls = world.resource::<LifeSimTimer>();
+        let vp = world.resource::<VirtualPopulation>();
+        collect_policy_stage(
+            Some(pol),
+            Some(us),
+            Some((rs, re)),
+            Some(co),
+            Some(lc),
+            Some(ls),
+            Some(vp),
+        )
+    };
+
+    assemble_save_data(
+        grid_stage,
+        economy_stage,
+        entity_stage,
+        environment_stage,
+        disaster_stage,
+        policy_stage,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark: Tel Aviv realistic save/load
+// ---------------------------------------------------------------------------
+
+fn bench_tel_aviv_save(c: &mut Criterion) {
+    let mut group = c.benchmark_group("save_tel_aviv");
+    group.sample_size(10);
+
+    // Build full Tel Aviv city (expensive ~1s setup).
+    let mut city = TestCity::with_tel_aviv();
+    city.tick(5);
+
+    // Collect once to get baseline data + sizes.
+    let save = collect_save_from_world(city.world_mut());
+    let citizen_count = save.citizens.len();
+    let building_count = save.buildings.len();
+    eprintln!(
+        "Tel Aviv snapshot: {} citizens, {} buildings",
+        citizen_count, building_count
+    );
+
+    // Benchmark: ECS snapshot collection (world queries -> SaveData).
+    group.bench_function("ecs_snapshot_collection", |b| {
+        b.iter(|| black_box(collect_save_from_world(city.world_mut())));
+    });
+
+    // Benchmark: bitcode encode.
+    group.bench_function("bitcode_encode", |b| {
+        b.iter(|| black_box(save.encode()));
+    });
+
+    // Benchmark: LZ4 compress.
+    let encoded = save.encode();
+    eprintln!(
+        "Encoded size: {} bytes ({:.2} MB)",
+        encoded.len(),
+        encoded.len() as f64 / 1_048_576.0
+    );
+
+    group.bench_function("lz4_compress", |b| {
+        b.iter(|| black_box(lz4_flex::compress_prepend_size(&encoded)));
+    });
+
+    let compressed = lz4_flex::compress_prepend_size(&encoded);
+    eprintln!(
+        "Compressed size: {} bytes ({:.2} MB, {:.1}% ratio)",
+        compressed.len(),
+        compressed.len() as f64 / 1_048_576.0,
+        compressed.len() as f64 / encoded.len() as f64 * 100.0
+    );
+
+    // Benchmark: full save pipeline (snapshot + encode + compress).
+    group.bench_function("full_save_pipeline", |b| {
+        b.iter(|| {
+            let s = collect_save_from_world(city.world_mut());
+            let enc = s.encode();
+            let comp = lz4_flex::compress_prepend_size(&enc);
+            black_box(comp.len())
+        });
+    });
+
+    // Benchmark: full load pipeline (decompress + decode).
+    group.bench_function("full_load_pipeline", |b| {
+        b.iter(|| {
+            let dec = lz4_flex::decompress_size_prepended(&compressed).unwrap();
+            let s = SaveData::decode(&dec).unwrap();
+            black_box(s.citizens.len())
+        });
+    });
+
+    // Benchmark: bitcode decode only.
+    group.bench_function("bitcode_decode", |b| {
+        b.iter(|| black_box(SaveData::decode(&encoded).unwrap()));
+    });
+
+    // Benchmark: LZ4 decompress only.
+    group.bench_function("lz4_decompress", |b| {
+        b.iter(|| black_box(lz4_flex::decompress_size_prepended(&compressed).unwrap()));
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Register
+// ---------------------------------------------------------------------------
+
+criterion_group!(benches, bench_tel_aviv_save);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- Add Criterion benchmarks for save/load serialization at different city scales (10K, 50K, 100K, 500K citizens)
- Measure bitcode encode/decode, LZ4 compress/decompress, and full save/load pipeline independently
- Include realistic ECS snapshot benchmark using the Tel Aviv map with ~10K citizens
- Benchmarks in `save/benches/save_bench.rs` (synthetic) and `save/benches/save_snapshot_bench.rs` (realistic)

Closes #726

## Test plan
- [ ] `cargo bench -p save --bench save_bench` compiles and runs synthetic benchmarks
- [ ] `cargo bench -p save --bench save_snapshot_bench` compiles and runs Tel Aviv snapshot benchmark
- [ ] Results include all 4 city scales (10K/50K/100K/500K)
- [ ] Serialization and deserialization measured independently
- [ ] Full save (encode+compress) and load (decompress+decode) pipelines benchmarked

🤖 Generated with [Claude Code](https://claude.com/claude-code)