### PR TITLE
SAVE-017: Add family relationship save/load integration tests

### DIFF
--- a/crates/simulation/src/integration_tests/family_save_tests.rs
+++ b/crates/simulation/src/integration_tests/family_save_tests.rs
@@ -12,7 +12,6 @@
 
 use bevy::prelude::*;
 
-use crate::buildings::Building;
 use crate::citizen::{
     Citizen, CitizenDetails, CitizenState, CitizenStateComp, Family, Gender, HomeLocation, Needs,
     PathCache, Personality, Position, Velocity,


### PR DESCRIPTION
## Summary
- Adds integration tests in the simulation crate verifying the invariants that the family save/load pipeline depends on
- Family serialization was already implemented in #1222 and fixed in #1263, but the simulation crate lacked integration tests verifying the entity-to-index mapping, two-pass index-to-entity resolution, and edge cases (out-of-bounds indices, u32::MAX sentinels, dangling references)
- Tests cover: bidirectional partner relationships, parent-child consistency, entity reference validity, save-side entity-to-index mapping, load-side two-pass resolution, and backward compatibility defaults

## Test plan
- [ ] All 8 new integration tests pass in `family_save_tests.rs`
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)