### PR TITLE
POLL-019: Complete Noise Source Type Table (#635)

### DIFF
--- a/crates/simulation/src/integration_tests/noise_sources_tests.rs
+++ b/crates/simulation/src/integration_tests/noise_sources_tests.rs
@@ -1,0 +1,284 @@
+//! Integration tests for POLL-019: Complete Noise Source Type Table
+//!
+//! Verifies that the 17-source noise emission table correctly integrates
+//! with the simulation, including activity-pattern modulation based on
+//! time of day.
+
+use crate::noise::NoisePollutionGrid;
+use crate::noise_sources::{
+    effective_db, lookup_source, NoiseSourceTableRes, NoiseSourceType,
+};
+use crate::services::ServiceType;
+use crate::test_harness::TestCity;
+use crate::utilities::UtilityType;
+use crate::wind::WindState;
+
+// ====================================================================
+// Table completeness
+// ====================================================================
+
+#[test]
+fn test_noise_source_table_resource_exists() {
+    let city = TestCity::new();
+    city.assert_resource_exists::<NoiseSourceTableRes>();
+}
+
+#[test]
+fn test_noise_source_table_has_all_17_entries() {
+    let city = TestCity::new();
+    let table = city.resource::<NoiseSourceTableRes>();
+    assert_eq!(table.entries.len(), 17);
+}
+
+// ====================================================================
+// Fire station generates noise (new source not in base system)
+// ====================================================================
+
+#[test]
+fn test_fire_station_generates_noise_during_day() {
+    let mut city = TestCity::new()
+        .with_service(128, 128, ServiceType::FireStation)
+        .with_time(12.0);
+
+    {
+        let world = city.world_mut();
+        world.resource_mut::<WindState>().speed = 0.0;
+    }
+
+    city.tick_slow_cycles(2);
+
+    let noise = city.resource::<NoisePollutionGrid>().get(128, 128);
+    assert!(
+        noise > 0,
+        "fire station should generate noise at source, got {}",
+        noise
+    );
+}
+
+#[test]
+fn test_fire_station_noise_always_active() {
+    // Fire station is Always active, so it should generate noise at night too
+    let mut city = TestCity::new()
+        .with_service(128, 128, ServiceType::FireStation)
+        .with_time(2.0); // 2 AM
+
+    {
+        let world = city.world_mut();
+        world.resource_mut::<WindState>().speed = 0.0;
+    }
+
+    city.tick_slow_cycles(2);
+
+    let noise = city.resource::<NoisePollutionGrid>().get(128, 128);
+    assert!(
+        noise > 0,
+        "fire station should generate noise at night (Always), got {}",
+        noise
+    );
+}
+
+// ====================================================================
+// Power plant generates noise
+// ====================================================================
+
+#[test]
+fn test_power_plant_generates_noise() {
+    let mut city = TestCity::new()
+        .with_utility(128, 128, UtilityType::PowerPlant)
+        .with_time(12.0);
+
+    {
+        let world = city.world_mut();
+        world.resource_mut::<WindState>().speed = 0.0;
+    }
+
+    city.tick_slow_cycles(2);
+
+    let noise = city.resource::<NoisePollutionGrid>().get(128, 128);
+    assert!(
+        noise > 0,
+        "power plant should generate noise, got {}",
+        noise
+    );
+}
+
+// ====================================================================
+// School generates noise only during daytime
+// ====================================================================
+
+#[test]
+fn test_school_noisy_during_day() {
+    let mut city = TestCity::new()
+        .with_service(128, 128, ServiceType::ElementarySchool)
+        .with_time(10.0); // 10 AM school hours
+
+    {
+        let world = city.world_mut();
+        world.resource_mut::<WindState>().speed = 0.0;
+    }
+
+    city.tick_slow_cycles(2);
+
+    let noise = city.resource::<NoisePollutionGrid>().get(128, 128);
+    assert!(
+        noise > 0,
+        "school should generate noise during day, got {}",
+        noise
+    );
+}
+
+#[test]
+fn test_school_quiet_at_night() {
+    let mut city = TestCity::new()
+        .with_service(128, 128, ServiceType::ElementarySchool)
+        .with_time(23.0); // 11 PM
+
+    {
+        let world = city.world_mut();
+        world.resource_mut::<WindState>().speed = 0.0;
+    }
+
+    city.tick_slow_cycles(2);
+
+    // School is Daytime only -- effective_db returns 0 at night
+    let eff = effective_db(NoiseSourceType::School, 23.0);
+    assert!(
+        eff < f32::EPSILON,
+        "school effective dB at night should be 0, got {}",
+        eff
+    );
+    // Noise at the cell should not include school contribution
+    let noise = city.resource::<NoisePollutionGrid>().get(128, 128);
+    assert!(
+        noise < 10,
+        "school cell at night should be quiet, got {}",
+        noise
+    );
+}
+
+// ====================================================================
+// Park does not emit noise (35 dB is background ambient, not pollution)
+// ====================================================================
+
+#[test]
+fn test_park_does_not_emit_noise_pollution() {
+    let mut city = TestCity::new()
+        .with_service(128, 128, ServiceType::SmallPark)
+        .with_time(12.0);
+
+    {
+        let world = city.world_mut();
+        world.resource_mut::<WindState>().speed = 0.0;
+    }
+
+    city.tick_slow_cycles(2);
+
+    // Parks are in the reference table at 35 dB (background ambient),
+    // but they do not propagate noise pollution into the grid.
+    let noise = city.resource::<NoisePollutionGrid>().get(128, 128);
+    assert!(
+        noise == 0,
+        "park should not generate noise pollution, got {}",
+        noise
+    );
+}
+
+// ====================================================================
+// Train station generates noise (24h)
+// ====================================================================
+
+#[test]
+fn test_train_station_generates_noise() {
+    let mut city = TestCity::new()
+        .with_service(128, 128, ServiceType::TrainStation)
+        .with_time(3.0); // 3 AM -- train station is Always active
+
+    {
+        let world = city.world_mut();
+        world.resource_mut::<WindState>().speed = 0.0;
+    }
+
+    city.tick_slow_cycles(2);
+
+    let noise = city.resource::<NoisePollutionGrid>().get(128, 128);
+    assert!(
+        noise > 0,
+        "train station should generate noise at 3 AM, got {}",
+        noise
+    );
+}
+
+// ====================================================================
+// Activity pattern correctness via effective_db
+// ====================================================================
+
+#[test]
+fn test_nightclub_only_active_at_night() {
+    assert!(effective_db(NoiseSourceType::Nightclub, 0.0) > 0.0);
+    assert!(effective_db(NoiseSourceType::Nightclub, 3.0) > 0.0);
+    assert!(effective_db(NoiseSourceType::Nightclub, 23.0) > 0.0);
+    assert!((effective_db(NoiseSourceType::Nightclub, 12.0)).abs() < f32::EPSILON);
+    assert!((effective_db(NoiseSourceType::Nightclub, 8.0)).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_construction_only_active_during_day() {
+    assert!(effective_db(NoiseSourceType::Construction, 8.0) > 0.0);
+    assert!(effective_db(NoiseSourceType::Construction, 14.0) > 0.0);
+    assert!((effective_db(NoiseSourceType::Construction, 23.0)).abs() < f32::EPSILON);
+    assert!((effective_db(NoiseSourceType::Construction, 3.0)).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_stadium_active_during_events() {
+    assert!(effective_db(NoiseSourceType::Stadium, 20.0) > 0.0);
+    assert!((effective_db(NoiseSourceType::Stadium, 8.0)).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_highway_always_active() {
+    for h in [0.0, 6.0, 12.0, 18.0, 23.0] {
+        assert!(
+            effective_db(NoiseSourceType::Highway, h) > 0.0,
+            "highway should be active at hour {}",
+            h
+        );
+    }
+}
+
+// ====================================================================
+// All 17 source types have correct dB in table
+// ====================================================================
+
+#[test]
+fn test_all_17_source_levels_match_spec() {
+    let spec: &[(NoiseSourceType, f32)] = &[
+        (NoiseSourceType::Highway, 75.0),
+        (NoiseSourceType::Arterial, 70.0),
+        (NoiseSourceType::LocalRoad, 55.0),
+        (NoiseSourceType::RailCorridor, 80.0),
+        (NoiseSourceType::Airport, 105.0),
+        (NoiseSourceType::Construction, 90.0),
+        (NoiseSourceType::HeavyIndustry, 85.0),
+        (NoiseSourceType::LightIndustry, 70.0),
+        (NoiseSourceType::CommercialHvac, 60.0),
+        (NoiseSourceType::Nightclub, 95.0),
+        (NoiseSourceType::FireStation, 80.0),
+        (NoiseSourceType::PowerPlant, 75.0),
+        (NoiseSourceType::Stadium, 95.0),
+        (NoiseSourceType::School, 70.0),
+        (NoiseSourceType::Park, 35.0),
+        (NoiseSourceType::ParkingStructure, 65.0),
+        (NoiseSourceType::TrainStation, 75.0),
+    ];
+    for (st, expected_db) in spec {
+        let entry = lookup_source(*st).expect(&format!("missing {:?}", st));
+        assert!(
+            (entry.db_level - expected_db).abs() < f32::EPSILON,
+            "{:?}: expected {} dB, got {}",
+            st,
+            expected_db,
+            entry.db_level
+        );
+    }
+}

--- a/crates/simulation/src/noise_sources.rs
+++ b/crates/simulation/src/noise_sources.rs
@@ -1,0 +1,374 @@
+//! POLL-019: Complete Noise Source Type Table
+//!
+//! Defines a 17-source noise emission table with dB levels and activity
+//! patterns. Inactive sources produce no noise outside their time window.
+
+use bevy::prelude::*;
+
+use crate::config::{GRID_HEIGHT, GRID_WIDTH};
+use crate::noise::{attenuated_db, db_to_grid_u8, max_radius, NoisePollutionGrid};
+use crate::time_of_day::GameClock;
+
+// ---------------------------------------------------------------------------
+// Activity patterns
+// ---------------------------------------------------------------------------
+
+/// When a noise source is active (produces noise).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActivityPattern {
+    /// Active 06:00-22:00
+    Daytime,
+    /// Active 22:00-06:00
+    Nighttime,
+    /// Active 24 hours
+    Always,
+    /// Active during events (evening hours 18:00-23:00)
+    EventDriven,
+}
+
+impl ActivityPattern {
+    pub fn is_active(self, hour: f32) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Daytime => (6.0..22.0).contains(&hour),
+            Self::Nighttime => !(6.0..22.0).contains(&hour),
+            Self::EventDriven => (18.0..23.0).contains(&hour),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Noise source definition
+// ---------------------------------------------------------------------------
+
+/// A single entry in the noise source type table.
+#[derive(Debug, Clone, Copy)]
+pub struct NoiseSourceEntry {
+    pub source_type: NoiseSourceType,
+    pub db_level: f32,
+    pub activity: ActivityPattern,
+}
+
+/// All 17 noise source types from the specification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NoiseSourceType {
+    Highway,
+    Arterial,
+    LocalRoad,
+    RailCorridor,
+    Airport,
+    Construction,
+    HeavyIndustry,
+    LightIndustry,
+    CommercialHvac,
+    Nightclub,
+    FireStation,
+    PowerPlant,
+    Stadium,
+    School,
+    Park,
+    ParkingStructure,
+    TrainStation,
+}
+
+// ---------------------------------------------------------------------------
+// Source table
+// ---------------------------------------------------------------------------
+
+/// The full 17-source noise emission table.
+pub const NOISE_SOURCE_TABLE: [NoiseSourceEntry; 17] = [
+    NoiseSourceEntry { source_type: NoiseSourceType::Highway, db_level: 75.0, activity: ActivityPattern::Always },
+    NoiseSourceEntry { source_type: NoiseSourceType::Arterial, db_level: 70.0, activity: ActivityPattern::Always },
+    NoiseSourceEntry { source_type: NoiseSourceType::LocalRoad, db_level: 55.0, activity: ActivityPattern::Always },
+    NoiseSourceEntry { source_type: NoiseSourceType::RailCorridor, db_level: 80.0, activity: ActivityPattern::Always },
+    NoiseSourceEntry { source_type: NoiseSourceType::Airport, db_level: 105.0, activity: ActivityPattern::Always },
+    NoiseSourceEntry { source_type: NoiseSourceType::Construction, db_level: 90.0, activity: ActivityPattern::Daytime },
+    NoiseSourceEntry { source_type: NoiseSourceType::HeavyIndustry, db_level: 85.0, activity: ActivityPattern::Always },
+    NoiseSourceEntry { source_type: NoiseSourceType::LightIndustry, db_level: 70.0, activity: ActivityPattern::Daytime },
+    NoiseSourceEntry { source_type: NoiseSourceType::CommercialHvac, db_level: 60.0, activity: ActivityPattern::Daytime },
+    NoiseSourceEntry { source_type: NoiseSourceType::Nightclub, db_level: 95.0, activity: ActivityPattern::Nighttime },
+    NoiseSourceEntry { source_type: NoiseSourceType::FireStation, db_level: 80.0, activity: ActivityPattern::Always },
+    NoiseSourceEntry { source_type: NoiseSourceType::PowerPlant, db_level: 75.0, activity: ActivityPattern::Always },
+    NoiseSourceEntry { source_type: NoiseSourceType::Stadium, db_level: 95.0, activity: ActivityPattern::EventDriven },
+    NoiseSourceEntry { source_type: NoiseSourceType::School, db_level: 70.0, activity: ActivityPattern::Daytime },
+    NoiseSourceEntry { source_type: NoiseSourceType::Park, db_level: 35.0, activity: ActivityPattern::Daytime },
+    NoiseSourceEntry { source_type: NoiseSourceType::ParkingStructure, db_level: 65.0, activity: ActivityPattern::Daytime },
+    NoiseSourceEntry { source_type: NoiseSourceType::TrainStation, db_level: 75.0, activity: ActivityPattern::Always },
+];
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+/// Look up a noise source entry by type.
+pub fn lookup_source(source_type: NoiseSourceType) -> Option<&'static NoiseSourceEntry> {
+    NOISE_SOURCE_TABLE
+        .iter()
+        .find(|e| e.source_type == source_type)
+}
+
+/// Effective dB for a source type at the given hour. Returns 0.0 if inactive.
+pub fn effective_db(source_type: NoiseSourceType, hour: f32) -> f32 {
+    match lookup_source(source_type) {
+        Some(entry) if entry.activity.is_active(hour) => entry.db_level,
+        _ => 0.0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+
+/// Runtime-accessible noise source table resource.
+#[derive(Resource, Debug)]
+pub struct NoiseSourceTableRes {
+    pub entries: &'static [NoiseSourceEntry; 17],
+}
+
+impl Default for NoiseSourceTableRes {
+    fn default() -> Self {
+        Self { entries: &NOISE_SOURCE_TABLE }
+    }
+}
+
+impl NoiseSourceTableRes {
+    pub fn effective_db(&self, source_type: NoiseSourceType, hour: f32) -> f32 {
+        effective_db(source_type, hour)
+    }
+
+    pub fn active_sources(&self, hour: f32) -> Vec<&NoiseSourceEntry> {
+        self.entries.iter().filter(|e| e.activity.is_active(hour)).collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Propagation helper (uses public API from noise module)
+// ---------------------------------------------------------------------------
+
+fn propagate(noise: &mut NoisePollutionGrid, sx: usize, sy: usize, source_db: f32) {
+    let radius = max_radius(source_db);
+    for dy in -radius..=radius {
+        for dx in -radius..=radius {
+            let nx = sx as i32 + dx;
+            let ny = sy as i32 + dy;
+            if nx < 0 || ny < 0 || nx as usize >= GRID_WIDTH || ny as usize >= GRID_HEIGHT {
+                continue;
+            }
+            let dist = ((dx * dx + dy * dy) as f32).sqrt();
+            let db = attenuated_db(source_db, dist);
+            if db > 0.0 {
+                let val = db_to_grid_u8(db);
+                if val > 0 {
+                    let idx = ny as usize * noise.width + nx as usize;
+                    noise.levels[idx] = noise.levels[idx].saturating_add(val).min(100);
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// System
+// ---------------------------------------------------------------------------
+
+/// Adds noise from sources not covered by the base noise system (fire
+/// stations, power plants, schools, train stations, parks) with activity-
+/// pattern awareness based on time of day.
+pub fn apply_noise_source_table(
+    slow_timer: Res<crate::SlowTickTimer>,
+    clock: Res<GameClock>,
+    mut noise: ResMut<NoisePollutionGrid>,
+    services: Query<&crate::services::ServiceBuilding>,
+    utilities: Query<&crate::utilities::UtilitySource>,
+    _table: Res<NoiseSourceTableRes>,
+) {
+    if !slow_timer.should_run() {
+        return;
+    }
+
+    let hour = clock.hour;
+
+    for service in &services {
+        let source_type = match service.service_type {
+            crate::services::ServiceType::FireStation
+            | crate::services::ServiceType::FireHouse
+            | crate::services::ServiceType::FireHQ => NoiseSourceType::FireStation,
+            crate::services::ServiceType::TrainStation => NoiseSourceType::TrainStation,
+            crate::services::ServiceType::ElementarySchool
+            | crate::services::ServiceType::HighSchool
+            | crate::services::ServiceType::Kindergarten => NoiseSourceType::School,
+            // Parks at 35 dB represent background ambient noise, not pollution;
+            // they are in the reference table but not emitted in the grid.
+            // Stadium and airports handled by base noise system
+            _ => continue,
+        };
+
+        let db = effective_db(source_type, hour);
+        if db > 0.0 {
+            propagate(&mut noise, service.grid_x, service.grid_y, db);
+        }
+    }
+
+    for utility in &utilities {
+        let source_type = match utility.utility_type {
+            crate::utilities::UtilityType::PowerPlant
+            | crate::utilities::UtilityType::NuclearPlant
+            | crate::utilities::UtilityType::Geothermal
+            | crate::utilities::UtilityType::HydroDam => NoiseSourceType::PowerPlant,
+            _ => continue,
+        };
+
+        let db = effective_db(source_type, hour);
+        if db > 0.0 {
+            propagate(&mut noise, utility.grid_x, utility.grid_y, db);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+pub struct NoiseSourcesPlugin;
+
+impl Plugin for NoiseSourcesPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<NoiseSourceTableRes>().add_systems(
+            FixedUpdate,
+            apply_noise_source_table
+                .after(crate::noise::update_noise_pollution)
+                .in_set(crate::SimulationSet::Simulation),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_table_has_17_entries() {
+        assert_eq!(NOISE_SOURCE_TABLE.len(), 17);
+    }
+
+    #[test]
+    fn test_source_db_levels() {
+        let cases: &[(NoiseSourceType, f32)] = &[
+            (NoiseSourceType::Highway, 75.0),
+            (NoiseSourceType::Arterial, 70.0),
+            (NoiseSourceType::LocalRoad, 55.0),
+            (NoiseSourceType::RailCorridor, 80.0),
+            (NoiseSourceType::Airport, 105.0),
+            (NoiseSourceType::Construction, 90.0),
+            (NoiseSourceType::HeavyIndustry, 85.0),
+            (NoiseSourceType::LightIndustry, 70.0),
+            (NoiseSourceType::CommercialHvac, 60.0),
+            (NoiseSourceType::Nightclub, 95.0),
+            (NoiseSourceType::FireStation, 80.0),
+            (NoiseSourceType::PowerPlant, 75.0),
+            (NoiseSourceType::Stadium, 95.0),
+            (NoiseSourceType::School, 70.0),
+            (NoiseSourceType::Park, 35.0),
+            (NoiseSourceType::ParkingStructure, 65.0),
+            (NoiseSourceType::TrainStation, 75.0),
+        ];
+        for (st, expected) in cases {
+            let e = lookup_source(*st).unwrap();
+            assert!((e.db_level - expected).abs() < f32::EPSILON, "{:?}", st);
+        }
+    }
+
+    #[test]
+    fn test_source_activity_patterns() {
+        let cases: &[(NoiseSourceType, ActivityPattern)] = &[
+            (NoiseSourceType::Highway, ActivityPattern::Always),
+            (NoiseSourceType::Construction, ActivityPattern::Daytime),
+            (NoiseSourceType::Nightclub, ActivityPattern::Nighttime),
+            (NoiseSourceType::Stadium, ActivityPattern::EventDriven),
+            (NoiseSourceType::School, ActivityPattern::Daytime),
+            (NoiseSourceType::Park, ActivityPattern::Daytime),
+            (NoiseSourceType::FireStation, ActivityPattern::Always),
+            (NoiseSourceType::PowerPlant, ActivityPattern::Always),
+            (NoiseSourceType::TrainStation, ActivityPattern::Always),
+        ];
+        for (st, expected) in cases {
+            let e = lookup_source(*st).unwrap();
+            assert_eq!(e.activity, *expected, "{:?}", st);
+        }
+    }
+
+    #[test]
+    fn test_daytime_boundaries() {
+        assert!(!ActivityPattern::Daytime.is_active(5.9));
+        assert!(ActivityPattern::Daytime.is_active(6.0));
+        assert!(ActivityPattern::Daytime.is_active(21.9));
+        assert!(!ActivityPattern::Daytime.is_active(22.0));
+    }
+
+    #[test]
+    fn test_nighttime_boundaries() {
+        assert!(ActivityPattern::Nighttime.is_active(0.0));
+        assert!(ActivityPattern::Nighttime.is_active(5.9));
+        assert!(!ActivityPattern::Nighttime.is_active(6.0));
+        assert!(!ActivityPattern::Nighttime.is_active(21.9));
+        assert!(ActivityPattern::Nighttime.is_active(22.0));
+    }
+
+    #[test]
+    fn test_always_every_hour() {
+        for h in 0..24 {
+            assert!(ActivityPattern::Always.is_active(h as f32));
+        }
+    }
+
+    #[test]
+    fn test_event_driven_boundaries() {
+        assert!(!ActivityPattern::EventDriven.is_active(17.9));
+        assert!(ActivityPattern::EventDriven.is_active(18.0));
+        assert!(ActivityPattern::EventDriven.is_active(22.9));
+        assert!(!ActivityPattern::EventDriven.is_active(23.0));
+    }
+
+    #[test]
+    fn test_effective_db_active_vs_inactive() {
+        assert!((effective_db(NoiseSourceType::Highway, 12.0) - 75.0).abs() < f32::EPSILON);
+        assert!((effective_db(NoiseSourceType::Nightclub, 12.0)).abs() < f32::EPSILON);
+        assert!((effective_db(NoiseSourceType::Nightclub, 0.0) - 95.0).abs() < f32::EPSILON);
+        assert!((effective_db(NoiseSourceType::Construction, 23.0)).abs() < f32::EPSILON);
+        assert!((effective_db(NoiseSourceType::Construction, 10.0) - 90.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_active_sources_count_at_noon() {
+        let table = NoiseSourceTableRes::default();
+        // Always(9) + Daytime(6) = 15
+        assert_eq!(table.active_sources(12.0).len(), 15);
+    }
+
+    #[test]
+    fn test_active_sources_count_at_midnight() {
+        let table = NoiseSourceTableRes::default();
+        // Always(9) + Nighttime(1) = 10
+        assert_eq!(table.active_sources(0.0).len(), 10);
+    }
+
+    #[test]
+    fn test_all_source_types_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for entry in &NOISE_SOURCE_TABLE {
+            assert!(seen.insert(entry.source_type), "dup: {:?}", entry.source_type);
+        }
+    }
+
+    #[test]
+    fn test_all_db_levels_positive() {
+        for entry in &NOISE_SOURCE_TABLE {
+            assert!(entry.db_level > 0.0, "{:?}", entry.source_type);
+        }
+    }
+}
+// POLL-019

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -323,4 +323,6 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
 
     // Airport area-source air pollution (POLL-016)
     app.add_plugins(airport_pollution::AirportPollutionPlugin);
+    // Complete Noise Source Type Table (POLL-019)
+    app.add_plugins(noise_sources::NoiseSourcesPlugin);
 }


### PR DESCRIPTION
## Summary
- Add full 17-source noise emission table with dB levels and activity patterns
- Activity patterns: Daytime (06-22), Nighttime (22-06), Always (24h), Event-driven (18-23)
- Sources inactive outside their time window produce zero noise
- New noise contributions for fire stations, power plants, schools, and train stations
- Parks listed in reference table at 35 dB (ambient) but not emitted as noise pollution
- Integration tests verifying source levels, activity patterns, and time-of-day modulation

Closes #635

## Test plan
- [x] Unit tests: all 17 source types have correct dB levels
- [x] Unit tests: activity pattern boundaries (Daytime, Nighttime, Always, EventDriven)
- [x] Unit tests: effective_db returns 0 for inactive sources
- [x] Integration test: fire station generates noise (Always active)
- [x] Integration test: school noisy during day, quiet at night
- [x] Integration test: power plant generates noise
- [x] Integration test: park does not emit noise pollution
- [x] Integration test: train station generates noise at 3 AM

🤖 Generated with [Claude Code](https://claude.com/claude-code)