### PR TITLE
PLAY-004: Tutorial Only Triggers on New Game (#1701)

### DIFF
--- a/crates/save/src/exclusive_new_game.rs
+++ b/crates/save/src/exclusive_new_game.rs
@@ -43,9 +43,17 @@ pub(crate) fn exclusive_new_game(world: &mut World) {
         }
     }
 
+    // -- Stage 5: Activate tutorial for new games --
+    {
+        let mut tutorial = world.resource_mut::<simulation::tutorial::TutorialState>();
+        tutorial.active = true;
+        tutorial.current_step = simulation::tutorial::TutorialStep::Welcome;
+        tutorial.completed = false;
+    }
+
     println!("New game started — blank map with $50,000 treasury");
 
-    // -- Stage 5: Transition back to Idle --
+    // -- Stage 6: Transition back to Idle --
     world
         .resource_mut::<NextState<SaveLoadState>>()
         .set(SaveLoadState::Idle);

--- a/crates/simulation/src/integration_tests/tutorial_trigger_tests.rs
+++ b/crates/simulation/src/integration_tests/tutorial_trigger_tests.rs
@@ -1,0 +1,59 @@
+//! Integration tests for tutorial trigger behavior (issue #1701).
+//!
+//! Verifies that the tutorial only activates on New Game, not on default
+//! resource initialization or save/load round-trips.
+
+use crate::test_harness::TestCity;
+use crate::tutorial::{TutorialState, TutorialStep};
+
+#[test]
+fn test_tutorial_default_is_inactive() {
+    let state = TutorialState::default();
+    assert!(!state.active, "Default TutorialState must be inactive");
+    assert!(!state.completed);
+    assert_eq!(state.current_step, TutorialStep::Welcome);
+}
+
+#[test]
+fn test_tutorial_skip_works() {
+    let mut state = TutorialState::default();
+    state.active = true; // simulate new-game activation
+    state.skip();
+    assert!(!state.active);
+    assert!(state.completed);
+    assert_eq!(state.current_step, TutorialStep::Completed);
+}
+
+#[test]
+fn test_tutorial_advance_from_active() {
+    let mut state = TutorialState::default();
+    state.active = true; // simulate new-game activation
+    assert!(state.advance());
+    assert_eq!(state.current_step, TutorialStep::PlaceRoad);
+    assert!(state.active);
+    assert!(!state.completed);
+}
+
+#[test]
+fn test_tutorial_saveable_roundtrip_preserves_state() {
+    use crate::Saveable;
+
+    let mut state = TutorialState::default();
+    state.active = true;
+    state.advance(); // PlaceRoad
+    state.advance(); // ZoneResidential
+
+    let bytes = state.save_to_bytes().expect("in-progress should save");
+    let restored = TutorialState::load_from_bytes(&bytes);
+    assert_eq!(restored.current_step, TutorialStep::ZoneResidential);
+    assert!(restored.active);
+    assert!(!restored.completed);
+}
+
+#[test]
+fn test_tutorial_inactive_in_test_city() {
+    let city = TestCity::new();
+    let tutorial = city.resource::<TutorialState>();
+    assert!(!tutorial.active, "TestCity tutorial should be inactive");
+    assert!(tutorial.completed, "TestCity tutorial should be completed");
+}

--- a/crates/simulation/src/test_harness/mod.rs
+++ b/crates/simulation/src/test_harness/mod.rs
@@ -68,9 +68,9 @@ impl TestCity {
         app.update();
 
         // After the first update, the tutorial starts active by default
-        // (TutorialState::default() has active=true) which causes
-        // `check_tutorial_progress` to pause the GameClock.
-        // Force both back to a clean state for testing.
+        // Ensure tutorial is definitely inactive (belt-and-suspenders)
+        // so `check_tutorial_progress` never pauses the GameClock.
+        // Force both to clean state for testing.
         if let Some(mut tutorial) = app.world_mut().get_resource_mut::<TutorialState>() {
             tutorial.completed = true;
             tutorial.active = false;

--- a/crates/simulation/src/tutorial.rs
+++ b/crates/simulation/src/tutorial.rs
@@ -188,7 +188,7 @@ impl Default for TutorialState {
         Self {
             current_step: TutorialStep::Welcome,
             completed: false,
-            active: true, // Tutorial triggers on first game start
+            active: false, // Only activated explicitly on New Game
             paused_by_tutorial: false,
         }
     }
@@ -371,7 +371,7 @@ mod tests {
         let state = TutorialState::default();
         assert_eq!(state.current_step, TutorialStep::Welcome);
         assert!(!state.completed);
-        assert!(state.active);
+        assert!(!state.active);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change `TutorialState::default()` to `active: false` (was `true`)
- Explicitly activate tutorial in the New Game exclusive system (Stage 5)
- Tutorial no longer appears when loading existing saves
- Integration tests for tutorial trigger behavior

Closes #1701

## Test plan
- [ ] Default state has tutorial inactive
- [ ] New Game activates tutorial
- [ ] Loading a save does not activate tutorial
- [ ] Skip still works
- [ ] Save/load round-trip preserves tutorial state

🤖 Generated with [Claude Code](https://claude.com/claude-code)