### PR TITLE
PLAY-003: New Game Uses Procedural Terrain Generation (#1700)

### DIFF
--- a/crates/save/src/exclusive_new_game.rs
+++ b/crates/save/src/exclusive_new_game.rs
@@ -1,9 +1,21 @@
 use bevy::prelude::*;
+use simulation::terrain_generation::{generate_procedural_terrain, TerrainConfig};
 use simulation::SaveLoadState;
 use simulation::SaveableRegistry;
 
 use crate::despawn::despawn_all_game_entities;
 use crate::reset_resources::reset_all_resources;
+
+/// Default number of hydraulic erosion iterations for new games.
+const NEW_GAME_EROSION_ITERATIONS: u32 = 10_000;
+
+/// Generate a random seed from the current system time.
+fn random_seed() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(42)
+}
 
 /// Exclusive system that resets the world for a new game.  Entity despawns
 /// are immediate (no deferred Commands).
@@ -22,26 +34,20 @@ pub(crate) fn exclusive_new_game(world: &mut World) {
     registry.reset_all(world);
     world.insert_resource(registry);
 
-    // -- Stage 4: Generate starter terrain --
-    {
-        let (width, height) = {
-            let grid = world.resource::<simulation::grid::WorldGrid>();
-            (grid.width, grid.height)
-        };
+    // -- Stage 4: Generate procedural terrain --
+    let seed = random_seed();
+    let biome_grid = {
         let mut grid = world.resource_mut::<simulation::grid::WorldGrid>();
-        for y in 0..height {
-            for x in 0..width {
-                let cell = grid.get_mut(x, y);
-                if x < 10 {
-                    cell.cell_type = simulation::grid::CellType::Water;
-                    cell.elevation = 0.3;
-                } else {
-                    cell.cell_type = simulation::grid::CellType::Grass;
-                    cell.elevation = 0.5;
-                }
-            }
-        }
-    }
+        generate_procedural_terrain(&mut grid, seed, NEW_GAME_EROSION_ITERATIONS)
+    };
+    world.insert_resource(biome_grid);
+
+    // Store the terrain configuration so it persists through saves.
+    world.insert_resource(TerrainConfig {
+        seed,
+        erosion_iterations: NEW_GAME_EROSION_ITERATIONS,
+        generated: true,
+    });
 
     // -- Stage 5: Activate tutorial for new games --
     {
@@ -51,7 +57,7 @@ pub(crate) fn exclusive_new_game(world: &mut World) {
         tutorial.completed = false;
     }
 
-    println!("New game started — blank map with $50,000 treasury");
+    println!("New game started — procedural terrain (seed {seed}) with $50,000 treasury");
 
     // -- Stage 6: Transition back to Idle --
     world

--- a/crates/simulation/src/integration_tests/terrain_newgame_tests.rs
+++ b/crates/simulation/src/integration_tests/terrain_newgame_tests.rs
@@ -1,0 +1,186 @@
+//! PLAY-003: Integration tests for New Game procedural terrain generation.
+//!
+//! Verifies that `generate_procedural_terrain` with the new-game default
+//! erosion iterations (10,000) produces playable, varied, deterministic maps.
+
+use crate::config::{GRID_HEIGHT, GRID_WIDTH};
+use crate::grid::{CellType, WorldGrid};
+use crate::terrain_generation::{generate_procedural_terrain, TerrainConfig};
+
+/// Default erosion iterations used by the new game flow.
+const NEW_GAME_EROSION_ITERATIONS: u32 = 10_000;
+
+// -----------------------------------------------------------------------
+// Terrain variety tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_newgame_terrain_has_varied_elevations() {
+    let mut grid = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+    let _biomes = generate_procedural_terrain(&mut grid, 42, NEW_GAME_EROSION_ITERATIONS);
+
+    // Collect unique elevations (quantized to 2 decimal places)
+    let mut unique = std::collections::HashSet::new();
+    for cell in &grid.cells {
+        let key = (cell.elevation * 100.0) as i32;
+        unique.insert(key);
+    }
+
+    assert!(
+        unique.len() > 10,
+        "expected varied elevations, found only {} distinct levels",
+        unique.len()
+    );
+}
+
+#[test]
+fn test_newgame_terrain_not_flat() {
+    let mut grid = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+    let _biomes = generate_procedural_terrain(&mut grid, 42, NEW_GAME_EROSION_ITERATIONS);
+
+    let n = grid.cells.len() as f32;
+    let mean = grid.cells.iter().map(|c| c.elevation).sum::<f32>() / n;
+    let variance = grid
+        .cells
+        .iter()
+        .map(|c| (c.elevation - mean).powi(2))
+        .sum::<f32>()
+        / n;
+    let stddev = variance.sqrt();
+
+    // A flat map (all 0.5) has stddev 0. Procedural terrain should be well above that.
+    assert!(
+        stddev > 0.05,
+        "terrain is too flat: stddev = {stddev} (expected > 0.05)"
+    );
+}
+
+// -----------------------------------------------------------------------
+// Water and land distribution tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_newgame_terrain_has_water_and_land() {
+    let mut grid = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+    let _biomes = generate_procedural_terrain(&mut grid, 42, NEW_GAME_EROSION_ITERATIONS);
+
+    let water = grid
+        .cells
+        .iter()
+        .filter(|c| c.cell_type == CellType::Water)
+        .count();
+    let land = grid
+        .cells
+        .iter()
+        .filter(|c| c.cell_type != CellType::Water)
+        .count();
+
+    assert!(water > 0, "terrain should have water cells");
+    assert!(land > 0, "terrain should have land cells");
+
+    let total = grid.cells.len();
+    let water_pct = water as f32 / total as f32;
+    let land_pct = land as f32 / total as f32;
+
+    // Water should be between 5% and 70% (realistic, playable maps)
+    assert!(
+        water_pct > 0.05,
+        "too little water: {water_pct:.1}% (expected > 5%)"
+    );
+    assert!(
+        land_pct > 0.30,
+        "too little land: {land_pct:.1}% (expected > 30%)"
+    );
+}
+
+#[test]
+fn test_newgame_terrain_multiple_seeds_all_have_water_and_land() {
+    for seed in [1_u64, 99, 256, 1000, 54321] {
+        let mut grid = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+        let _biomes = generate_procedural_terrain(&mut grid, seed, NEW_GAME_EROSION_ITERATIONS);
+
+        let water = grid
+            .cells
+            .iter()
+            .filter(|c| c.cell_type == CellType::Water)
+            .count();
+        let land = grid.cells.len() - water;
+
+        assert!(
+            water > 0,
+            "seed {seed}: terrain should have water cells"
+        );
+        assert!(
+            land > grid.cells.len() * 3 / 10,
+            "seed {seed}: too little land ({land} cells, need at least 30%)"
+        );
+    }
+}
+
+// -----------------------------------------------------------------------
+// Determinism tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_newgame_same_seed_produces_identical_terrain() {
+    let mut grid1 = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+    let mut grid2 = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+
+    let biomes1 = generate_procedural_terrain(&mut grid1, 12345, NEW_GAME_EROSION_ITERATIONS);
+    let biomes2 = generate_procedural_terrain(&mut grid2, 12345, NEW_GAME_EROSION_ITERATIONS);
+
+    // Check every cell matches
+    for i in 0..grid1.cells.len() {
+        assert_eq!(
+            grid1.cells[i].elevation, grid2.cells[i].elevation,
+            "elevation mismatch at cell {i}"
+        );
+        assert_eq!(
+            grid1.cells[i].cell_type, grid2.cells[i].cell_type,
+            "cell type mismatch at cell {i}"
+        );
+    }
+    assert_eq!(
+        biomes1.biomes, biomes2.biomes,
+        "biome grids should be identical for the same seed"
+    );
+}
+
+#[test]
+fn test_newgame_different_seeds_produce_different_terrain() {
+    let mut grid1 = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+    let mut grid2 = WorldGrid::new(GRID_WIDTH, GRID_HEIGHT);
+
+    let _biomes1 = generate_procedural_terrain(&mut grid1, 111, NEW_GAME_EROSION_ITERATIONS);
+    let _biomes2 = generate_procedural_terrain(&mut grid2, 222, NEW_GAME_EROSION_ITERATIONS);
+
+    let diff_count = grid1
+        .cells
+        .iter()
+        .zip(grid2.cells.iter())
+        .filter(|(a, b)| (a.elevation - b.elevation).abs() > 0.01)
+        .count();
+
+    assert!(
+        diff_count > 1000,
+        "different seeds should produce substantially different terrain \
+         (only {diff_count} cells differ)"
+    );
+}
+
+// -----------------------------------------------------------------------
+// TerrainConfig resource state test
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_newgame_terrain_config_marks_generated() {
+    let config = TerrainConfig {
+        seed: 42,
+        erosion_iterations: NEW_GAME_EROSION_ITERATIONS,
+        generated: true,
+    };
+
+    // After new game, the config should be marked as generated
+    assert!(config.generated);
+    assert_eq!(config.erosion_iterations, NEW_GAME_EROSION_ITERATIONS);
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded flat map in New Game with procedural terrain generation
- Random seed from system clock for unique terrain each playthrough
- Uses existing `generate_procedural_terrain()` pipeline (fBm noise + hydraulic erosion + rivers + biomes)
- Stores `TerrainConfig` and `BiomeGrid` as resources for save/load persistence
- Integration tests for terrain variety, water/land distribution, and determinism

Closes #1700

## Test plan
- [ ] New game produces varied terrain (not flat)
- [ ] Terrain has both water and land cells
- [ ] Same seed produces identical terrain (deterministic)
- [ ] Multiple seeds all produce playable maps (>30% land)
- [ ] Different seeds produce substantially different terrain

🤖 Generated with [Claude Code](https://claude.com/claude-code)