### PR TITLE
PLAY-005: Tutorial UX Polish (#1702)

### DIFF
--- a/crates/simulation/src/integration_tests/tutorial_ux_tests.rs
+++ b/crates/simulation/src/integration_tests/tutorial_ux_tests.rs
@@ -1,0 +1,184 @@
+//! Unit and integration tests for tutorial UX polish (issue #1702).
+//!
+//! Covers: TutorialStep::previous(), TutorialState::go_back(),
+//! TutorialUiHint targets, and step metadata.
+
+use crate::tutorial::{TutorialState, TutorialStep};
+use crate::tutorial_hints::TutorialUiHint;
+use crate::Saveable;
+
+// ---- TutorialStep navigation ----
+
+#[test]
+fn test_tutorial_step_previous_from_welcome() {
+    assert_eq!(TutorialStep::Welcome.previous(), None);
+}
+
+#[test]
+fn test_tutorial_step_previous_from_place_road() {
+    assert_eq!(
+        TutorialStep::PlaceRoad.previous(),
+        Some(TutorialStep::Welcome)
+    );
+}
+
+#[test]
+fn test_tutorial_step_previous_from_completed() {
+    assert_eq!(
+        TutorialStep::Completed.previous(),
+        Some(TutorialStep::ManageBudget)
+    );
+}
+
+#[test]
+fn test_tutorial_step_previous_round_trip() {
+    // For every step except Welcome, prev -> next should return the same step.
+    for &step in TutorialStep::ALL.iter().skip(1) {
+        let prev = step.previous().expect("non-Welcome should have previous");
+        assert_eq!(prev.next(), Some(step));
+    }
+}
+
+// ---- TutorialState::go_back ----
+
+#[test]
+fn test_tutorial_go_back_from_zone_residential() {
+    let mut state = TutorialState::default();
+    state.active = true;
+    state.advance(); // Welcome -> PlaceRoad
+    state.advance(); // PlaceRoad -> ZoneResidential
+    assert_eq!(state.current_step, TutorialStep::ZoneResidential);
+
+    assert!(state.go_back());
+    assert_eq!(state.current_step, TutorialStep::PlaceRoad);
+
+    assert!(state.go_back());
+    assert_eq!(state.current_step, TutorialStep::Welcome);
+
+    assert!(!state.go_back()); // Cannot go before Welcome
+    assert_eq!(state.current_step, TutorialStep::Welcome);
+}
+
+#[test]
+fn test_tutorial_go_back_when_completed() {
+    let mut state = TutorialState::default();
+    state.skip();
+    assert!(!state.go_back());
+}
+
+// ---- Step metadata ----
+
+#[test]
+fn test_all_steps_have_nonempty_metadata() {
+    for &step in TutorialStep::ALL {
+        assert!(!step.title().is_empty(), "{:?} has empty title", step);
+        assert!(
+            !step.description().is_empty(),
+            "{:?} has empty description",
+            step
+        );
+        assert!(!step.hint().is_empty(), "{:?} has empty hint", step);
+    }
+}
+
+#[test]
+fn test_step_count_consistency() {
+    assert_eq!(TutorialStep::ALL.len(), 9);
+    assert_eq!(TutorialStep::total_steps(), 8);
+}
+
+#[test]
+fn test_step_indices() {
+    assert_eq!(TutorialStep::Welcome.index(), 0);
+    assert_eq!(TutorialStep::PlaceRoad.index(), 1);
+    assert_eq!(TutorialStep::Completed.index(), 8);
+}
+
+// ---- Full progression ----
+
+#[test]
+fn test_full_forward_progression() {
+    let mut state = TutorialState::default();
+    for i in 0..8 {
+        assert_eq!(state.current_step, TutorialStep::ALL[i]);
+        assert!(state.advance());
+    }
+    assert_eq!(state.current_step, TutorialStep::Completed);
+    assert!(state.completed);
+    assert!(!state.advance());
+}
+
+// ---- Saveable ----
+
+#[test]
+fn test_saveable_roundtrip_in_progress() {
+    let mut state = TutorialState::default();
+    state.advance();
+    state.advance();
+    let bytes = state.save_to_bytes().expect("should save");
+    let restored = TutorialState::load_from_bytes(&bytes);
+    assert_eq!(restored.current_step, TutorialStep::ZoneResidential);
+}
+
+#[test]
+fn test_saveable_default_returns_none() {
+    let state = TutorialState::default();
+    assert!(state.save_to_bytes().is_none());
+}
+
+#[test]
+fn test_saveable_completed_roundtrip() {
+    let mut state = TutorialState::default();
+    state.skip();
+    let bytes = state.save_to_bytes().expect("should save");
+    let restored = TutorialState::load_from_bytes(&bytes);
+    assert!(restored.completed);
+}
+
+// ---- TutorialUiHint ----
+
+#[test]
+fn test_hint_highlight_roads() {
+    let hint = TutorialUiHint::default();
+    // We test via the public fields after the system would run, but we can
+    // at least verify the default is None.
+    assert!(hint.highlight_target.is_none());
+    assert!(hint.camera_target.is_none());
+}
+
+// ---- is_manual_step ----
+
+#[test]
+fn test_manual_steps() {
+    let manual = [
+        TutorialStep::Welcome,
+        TutorialStep::ManageBudget,
+        TutorialStep::Completed,
+    ];
+    for step in manual {
+        let state = TutorialState {
+            current_step: step,
+            ..Default::default()
+        };
+        assert!(state.is_manual_step(), "{:?} should be manual", step);
+    }
+}
+
+#[test]
+fn test_non_manual_steps() {
+    let auto = [
+        TutorialStep::PlaceRoad,
+        TutorialStep::ZoneResidential,
+        TutorialStep::ZoneCommercial,
+        TutorialStep::PlacePowerPlant,
+        TutorialStep::PlaceWaterTower,
+        TutorialStep::ObserveGrowth,
+    ];
+    for step in auto {
+        let state = TutorialState {
+            current_step: step,
+            ..Default::default()
+        };
+        assert!(!state.is_manual_step(), "{:?} should not be manual", step);
+    }
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -339,4 +339,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
 
     // Audio system infrastructure (PLAY-007)
     app.add_plugins(audio_settings::AudioSettingsPlugin);
+
+    // Tutorial UX hints (PLAY-005)
+    app.add_plugins(tutorial_hints::TutorialHintsPlugin);
 }

--- a/crates/simulation/src/tutorial_hints.rs
+++ b/crates/simulation/src/tutorial_hints.rs
@@ -1,0 +1,142 @@
+use bevy::prelude::*;
+
+use crate::tutorial::{TutorialState, TutorialStep};
+
+// =============================================================================
+// Tutorial UI Hint Resource
+// =============================================================================
+
+/// Provides per-step UI hints for the tutorial overlay.
+///
+/// Updated each frame by [`update_tutorial_hints`] based on the current tutorial
+/// step. The UI crate reads these fields to draw pulsing highlights and
+/// position the camera.
+#[derive(Resource, Debug, Clone, Default)]
+pub struct TutorialUiHint {
+    /// Name of the toolbar category the player should interact with (e.g. "Roads").
+    pub highlight_target: Option<&'static str>,
+    /// World-space position the camera should auto-focus to at tutorial start.
+    pub camera_target: Option<(f32, f32)>,
+}
+
+impl TutorialUiHint {
+    /// Returns the toolbar highlight target for the given step.
+    fn target_for_step(step: TutorialStep) -> Option<&'static str> {
+        match step {
+            TutorialStep::PlaceRoad => Some("Roads"),
+            TutorialStep::ZoneResidential | TutorialStep::ZoneCommercial => Some("Zones"),
+            TutorialStep::PlacePowerPlant | TutorialStep::PlaceWaterTower => Some("Utilities"),
+            _ => None,
+        }
+    }
+
+    /// Returns an optional camera focus position for the given step.
+    /// The camera moves to the center of the map at the start of the tutorial.
+    fn camera_for_step(step: TutorialStep) -> Option<(f32, f32)> {
+        match step {
+            // Center the camera on the map for the welcome/first-build steps.
+            // 256 cells * 16.0 CELL_SIZE / 2 = 2048.0 center.
+            TutorialStep::Welcome => Some((2048.0, 2048.0)),
+            _ => None,
+        }
+    }
+}
+
+// =============================================================================
+// System
+// =============================================================================
+
+/// Updates [`TutorialUiHint`] based on the current tutorial step.
+pub fn update_tutorial_hints(tutorial: Res<TutorialState>, mut hint: ResMut<TutorialUiHint>) {
+    if !tutorial.active {
+        hint.highlight_target = None;
+        hint.camera_target = None;
+        return;
+    }
+
+    let step = tutorial.current_step;
+    hint.highlight_target = TutorialUiHint::target_for_step(step);
+    hint.camera_target = TutorialUiHint::camera_for_step(step);
+}
+
+// =============================================================================
+// Plugin
+// =============================================================================
+
+pub struct TutorialHintsPlugin;
+
+impl Plugin for TutorialHintsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<TutorialUiHint>()
+            .add_systems(Update, update_tutorial_hints);
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hint_target_for_road_step() {
+        assert_eq!(
+            TutorialUiHint::target_for_step(TutorialStep::PlaceRoad),
+            Some("Roads")
+        );
+    }
+
+    #[test]
+    fn test_hint_target_for_zone_steps() {
+        assert_eq!(
+            TutorialUiHint::target_for_step(TutorialStep::ZoneResidential),
+            Some("Zones")
+        );
+        assert_eq!(
+            TutorialUiHint::target_for_step(TutorialStep::ZoneCommercial),
+            Some("Zones")
+        );
+    }
+
+    #[test]
+    fn test_hint_target_for_utility_steps() {
+        assert_eq!(
+            TutorialUiHint::target_for_step(TutorialStep::PlacePowerPlant),
+            Some("Utilities")
+        );
+        assert_eq!(
+            TutorialUiHint::target_for_step(TutorialStep::PlaceWaterTower),
+            Some("Utilities")
+        );
+    }
+
+    #[test]
+    fn test_hint_target_none_for_welcome() {
+        assert_eq!(
+            TutorialUiHint::target_for_step(TutorialStep::Welcome),
+            None
+        );
+    }
+
+    #[test]
+    fn test_camera_target_welcome() {
+        assert_eq!(
+            TutorialUiHint::camera_for_step(TutorialStep::Welcome),
+            Some((2048.0, 2048.0))
+        );
+    }
+
+    #[test]
+    fn test_camera_target_none_for_other_steps() {
+        assert_eq!(
+            TutorialUiHint::camera_for_step(TutorialStep::PlaceRoad),
+            None
+        );
+        assert_eq!(
+            TutorialUiHint::camera_for_step(TutorialStep::Completed),
+            None
+        );
+    }
+}

--- a/crates/ui/src/plugin_registration.rs
+++ b/crates/ui/src/plugin_registration.rs
@@ -47,6 +47,7 @@ pub(crate) fn register_ui_systems(app: &mut App) {
     app.add_plugins(zone_brush_ui::ZoneBrushUiPlugin);
     app.add_plugins(info_panel::budget::BudgetBreakdownPlugin);
     app.add_plugins(energy_dashboard::EnergyDashboardPlugin);
+    app.add_plugins(tutorial_camera::TutorialCameraPlugin);
     // UI resources
     app.init_resource::<day_night_panel::DayNightPanelVisible>();
     app.init_resource::<milestones::Milestones>();

--- a/crates/ui/src/tutorial.rs
+++ b/crates/ui/src/tutorial.rs
@@ -3,12 +3,23 @@ use bevy_egui::{egui, EguiContexts};
 
 use simulation::time_of_day::GameClock;
 use simulation::tutorial::{TutorialState, TutorialStep};
+use simulation::tutorial_hints::TutorialUiHint;
 
 /// Renders the tutorial overlay window when the tutorial is active.
+///
+/// Features:
+/// - Progress indicator with step counter and progress bar
+/// - Styled step title, description, and hint text
+/// - Pulsing toolbar highlight indicator (e.g. ">>> Roads <<<")
+/// - Back / Next / Skip buttons
+/// - Rounded corner frame styling with polished colors
+#[allow(clippy::too_many_arguments)]
 pub fn tutorial_ui(
     mut contexts: EguiContexts,
     mut tutorial: ResMut<TutorialState>,
     mut clock: ResMut<GameClock>,
+    hint: Res<TutorialUiHint>,
+    time: Res<Time>,
 ) {
     if !tutorial.active {
         return;
@@ -17,113 +28,180 @@ pub fn tutorial_ui(
     let step = tutorial.current_step;
     let step_index = step.index();
     let total = TutorialStep::total_steps();
+    let elapsed = time.elapsed_secs_f64();
 
     let ctx = contexts.ctx_mut();
 
-    // Semi-transparent highlight overlay to draw attention to the tutorial window
+    // Custom frame with rounded corners and polished styling
+    let frame = egui::Frame::new()
+        .corner_radius(egui::CornerRadius::same(12))
+        .inner_margin(egui::Margin::same(16))
+        .fill(egui::Color32::from_rgba_unmultiplied(25, 30, 45, 240))
+        .stroke(egui::Stroke::new(1.0, egui::Color32::from_rgb(60, 70, 100)));
+
     egui::Window::new("Tutorial")
         .collapsible(false)
         .resizable(false)
         .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-        .default_width(420.0)
+        .default_width(440.0)
+        .frame(frame)
+        .title_bar(false)
         .show(ctx, |ui| {
-            // Progress indicator
-            if step != TutorialStep::Completed {
-                ui.horizontal(|ui| {
-                    ui.label(
-                        egui::RichText::new(format!("Step {}/{}", step_index, total))
-                            .small()
-                            .color(egui::Color32::from_rgb(160, 160, 160)),
-                    );
-
-                    // Progress bar
-                    let progress = step_index as f32 / total as f32;
-                    ui.add(
-                        egui::ProgressBar::new(progress)
-                            .desired_width(200.0)
-                            .show_percentage(),
-                    );
-                });
-                ui.separator();
-            }
-
-            // Step title
-            ui.heading(
-                egui::RichText::new(step.title())
-                    .strong()
-                    .color(egui::Color32::from_rgb(100, 200, 255)),
-            );
-            ui.add_space(8.0);
-
-            // Step description
-            ui.label(
-                egui::RichText::new(step.description())
-                    .color(egui::Color32::from_rgb(220, 220, 220)),
-            );
-            ui.add_space(8.0);
-
-            // Hint text
-            ui.label(
-                egui::RichText::new(step.hint())
-                    .italics()
-                    .color(egui::Color32::from_rgb(180, 200, 140)),
-            );
+            render_progress(ui, step, step_index, total);
+            render_title(ui, step);
+            render_description(ui, step);
+            render_hint(ui, step);
+            render_highlight_indicator(ui, &hint, elapsed);
             ui.add_space(12.0);
-
-            // Action buttons
-            ui.horizontal(|ui| {
-                // Next button for manual steps
-                if tutorial.is_manual_step() {
-                    let button_text = if step == TutorialStep::Completed {
-                        "Close"
-                    } else {
-                        "Next"
-                    };
-
-                    if ui
-                        .button(
-                            egui::RichText::new(button_text)
-                                .strong()
-                                .color(egui::Color32::from_rgb(100, 255, 100)),
-                        )
-                        .clicked()
-                    {
-                        if step == TutorialStep::Completed {
-                            tutorial.active = false;
-                        } else {
-                            // Unpause if we paused for this step
-                            if tutorial.paused_by_tutorial {
-                                clock.paused = false;
-                                tutorial.paused_by_tutorial = false;
-                            }
-                            tutorial.advance();
-                        }
-                    }
-                } else {
-                    // For auto-advancing steps, show "waiting" status
-                    ui.label(
-                        egui::RichText::new("Waiting for action...")
-                            .color(egui::Color32::from_rgb(200, 180, 100)),
-                    );
-                }
-
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    // Skip button (always available except when completed)
-                    if step != TutorialStep::Completed
-                        && ui
-                            .button(
-                                egui::RichText::new("Skip Tutorial")
-                                    .color(egui::Color32::from_rgb(180, 180, 180)),
-                            )
-                            .clicked()
-                    {
-                        // Unpause if tutorial paused the sim
-                        if tutorial.paused_by_tutorial {
-                            clock.paused = false;
-                        }
-                        tutorial.skip();
-                    }
-                });
-            });
+            render_buttons(ui, &mut tutorial, &mut clock, step);
         });
+}
+
+/// Draw the progress bar and step counter.
+fn render_progress(ui: &mut egui::Ui, step: TutorialStep, step_index: usize, total: usize) {
+    if step != TutorialStep::Completed {
+        ui.horizontal(|ui| {
+            ui.label(
+                egui::RichText::new(format!("Step {}/{}", step_index, total))
+                    .small()
+                    .color(egui::Color32::from_rgb(160, 160, 180)),
+            );
+
+            let progress = step_index as f32 / total as f32;
+            ui.add(
+                egui::ProgressBar::new(progress)
+                    .desired_width(200.0)
+                    .show_percentage(),
+            );
+        });
+        ui.add_space(4.0);
+        ui.separator();
+        ui.add_space(4.0);
+    }
+}
+
+/// Draw the step title.
+fn render_title(ui: &mut egui::Ui, step: TutorialStep) {
+    ui.heading(
+        egui::RichText::new(step.title())
+            .strong()
+            .size(18.0)
+            .color(egui::Color32::from_rgb(100, 200, 255)),
+    );
+    ui.add_space(8.0);
+}
+
+/// Draw the step description text.
+fn render_description(ui: &mut egui::Ui, step: TutorialStep) {
+    ui.label(
+        egui::RichText::new(step.description())
+            .size(14.0)
+            .color(egui::Color32::from_rgb(220, 220, 230)),
+    );
+    ui.add_space(8.0);
+}
+
+/// Draw the step hint text.
+fn render_hint(ui: &mut egui::Ui, step: TutorialStep) {
+    ui.label(
+        egui::RichText::new(step.hint())
+            .italics()
+            .size(13.0)
+            .color(egui::Color32::from_rgb(180, 210, 140)),
+    );
+}
+
+/// Draw a pulsing indicator pointing to the relevant toolbar category.
+fn render_highlight_indicator(ui: &mut egui::Ui, hint: &TutorialUiHint, elapsed: f64) {
+    if let Some(target) = hint.highlight_target {
+        ui.add_space(8.0);
+
+        // Pulsing alpha based on elapsed time
+        let pulse = ((elapsed * 3.0).sin() * 0.5 + 0.5) as f32;
+        let alpha = (140.0 + pulse * 115.0) as u8;
+        let color = egui::Color32::from_rgba_unmultiplied(255, 200, 60, alpha);
+
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new(format!(">>> {} <<<", target)).strong().size(15.0).color(color));
+        });
+    }
+}
+
+/// Draw the Back / Next / Skip buttons.
+fn render_buttons(
+    ui: &mut egui::Ui,
+    tutorial: &mut ResMut<TutorialState>,
+    clock: &mut ResMut<GameClock>,
+    step: TutorialStep,
+) {
+    ui.horizontal(|ui| {
+        // Back button (disabled on Welcome step)
+        let can_go_back = step != TutorialStep::Welcome
+            && step != TutorialStep::Completed
+            && !tutorial.completed;
+
+        if ui
+            .add_enabled(
+                can_go_back,
+                egui::Button::new(
+                    egui::RichText::new("Back")
+                        .color(egui::Color32::from_rgb(180, 180, 200)),
+                ),
+            )
+            .clicked()
+        {
+            tutorial.go_back();
+        }
+
+        // Next / Close button for manual steps
+        if tutorial.is_manual_step() {
+            let button_text = if step == TutorialStep::Completed {
+                "Close"
+            } else {
+                "Next"
+            };
+
+            if ui
+                .button(
+                    egui::RichText::new(button_text)
+                        .strong()
+                        .color(egui::Color32::from_rgb(100, 255, 100)),
+                )
+                .clicked()
+            {
+                if step == TutorialStep::Completed {
+                    tutorial.active = false;
+                } else {
+                    if tutorial.paused_by_tutorial {
+                        clock.paused = false;
+                        tutorial.paused_by_tutorial = false;
+                    }
+                    tutorial.advance();
+                }
+            }
+        } else {
+            // For auto-advancing steps, show "waiting" status
+            ui.label(
+                egui::RichText::new("Waiting for action...")
+                    .color(egui::Color32::from_rgb(200, 180, 100)),
+            );
+        }
+
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            // Skip button (always available except when completed)
+            if step != TutorialStep::Completed
+                && ui
+                    .button(
+                        egui::RichText::new("Skip Tutorial")
+                            .color(egui::Color32::from_rgb(180, 180, 180)),
+                    )
+                    .clicked()
+            {
+                if tutorial.paused_by_tutorial {
+                    clock.paused = false;
+                }
+                tutorial.skip();
+            }
+        });
+    });
 }

--- a/crates/ui/src/tutorial_camera.rs
+++ b/crates/ui/src/tutorial_camera.rs
@@ -1,0 +1,49 @@
+use bevy::prelude::*;
+
+use rendering::camera::OrbitCamera;
+use simulation::tutorial::TutorialState;
+use simulation::tutorial_hints::TutorialUiHint;
+
+/// Tracks whether the tutorial camera has already been focused.
+///
+/// Prevents repeated camera movement every frame — we only auto-focus once
+/// per camera target change.
+#[derive(Resource, Default)]
+pub struct TutorialCameraState {
+    /// The last camera target we focused on, if any.
+    last_target: Option<(f32, f32)>,
+}
+
+/// Moves the camera to the tutorial hint's camera target once per step change.
+pub fn tutorial_camera_focus(
+    tutorial: Res<TutorialState>,
+    hint: Res<TutorialUiHint>,
+    mut orbit: ResMut<OrbitCamera>,
+    mut state: ResMut<TutorialCameraState>,
+) {
+    if !tutorial.active {
+        state.last_target = None;
+        return;
+    }
+
+    if let Some((x, z)) = hint.camera_target {
+        if state.last_target != Some((x, z)) {
+            orbit.focus.x = x;
+            orbit.focus.z = z;
+            // Set a comfortable overview distance for the tutorial
+            orbit.distance = 1500.0;
+            orbit.pitch = 50.0_f32.to_radians();
+            state.last_target = Some((x, z));
+        }
+    }
+}
+
+/// Plugin that adds the tutorial camera focus system.
+pub struct TutorialCameraPlugin;
+
+impl Plugin for TutorialCameraPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<TutorialCameraState>()
+            .add_systems(Update, tutorial_camera_focus);
+    }
+}


### PR DESCRIPTION
## Summary
- Add **Back button** to navigate to previous tutorial steps (disabled on Welcome/Completed)
- Add **pulsing toolbar highlight indicator** (">>> Roads <<<") that shows which toolbar category to interact with for each step, pulsing with a golden color
- Add **camera auto-focus** that moves the orbital camera to the map center at a comfortable overview distance when the tutorial starts
- Polish **tutorial window styling**: custom Frame with rounded corners, subtle border stroke, dark translucent background, hidden title bar
- Add `TutorialUiHint` resource with per-step highlight targets and camera focus positions
- Move unit tests to `integration_tests/tutorial_ux_tests.rs` to keep `tutorial.rs` under 500-line limit

## Files Changed
- `crates/simulation/src/tutorial.rs` — Add `previous()` / `go_back()` methods, move tests out
- `crates/simulation/src/tutorial_hints.rs` — New: `TutorialUiHint` resource + `TutorialHintsPlugin`
- `crates/simulation/src/plugin_registration.rs` — Register `TutorialHintsPlugin`
- `crates/simulation/src/integration_tests/tutorial_ux_tests.rs` — New: comprehensive tests for tutorial navigation, hints, and metadata
- `crates/ui/src/tutorial.rs` — Enhanced UI with Back button, pulsing highlights, polished styling
- `crates/ui/src/tutorial_camera.rs` — New: `TutorialCameraPlugin` for camera auto-focus
- `crates/ui/src/plugin_registration.rs` — Register `TutorialCameraPlugin`

## Test plan
- [ ] `cargo test --workspace` passes (new tests in `tutorial_ux_tests.rs` + existing `tutorial_trigger_tests.rs`)
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] Verify `TutorialStep::previous()` returns correct previous steps
- [ ] Verify `TutorialState::go_back()` navigates backward correctly
- [ ] Verify Back button is disabled on Welcome step
- [ ] Verify pulsing highlight shows correct toolbar category per step

Closes #1702

🤖 Generated with [Claude Code](https://claude.com/claude-code)