### PR TITLE
PLAY-013: UI Visual Consistency and Theme Pass (#1710)

### DIFF
--- a/crates/ui/src/plugin_registration.rs
+++ b/crates/ui/src/plugin_registration.rs
@@ -20,6 +20,7 @@ pub(crate) fn register_ui_systems(app: &mut App) {
     app.add_plugins(EguiPlugin);
 
     // UI feature plugins
+    app.add_plugins(theme::ThemePlugin);
     app.add_plugins(cell_info_panel::CellInfoPanelPlugin);
     app.add_plugins(cell_tooltip::CellTooltipPlugin);
     app.add_plugins(citizen_info::CitizenInfoPlugin);
@@ -65,7 +66,6 @@ pub(crate) fn register_ui_systems(app: &mut App) {
     // UI systems — gated behind SaveLoadState::Idle because they query
     // game entities (buildings, services, citizens) that are despawned
     // during load/new-game transitions.
-    app.add_systems(Startup, theme::apply_cute_theme);
     app.add_systems(
         Update,
         (

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -1,35 +1,126 @@
+//! Centralized UI theme for Megacity.
+//!
+//! Provides a unified color palette, font sizes, and spacing constants
+//! for all egui-based UI panels. The `ThemePlugin` applies the theme on
+//! startup so every panel inherits consistent styling automatically.
+
+use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts};
 
-pub fn apply_cute_theme(mut contexts: EguiContexts) {
+// =============================================================================
+// Color Palette — dark-theme city-builder appropriate
+// =============================================================================
+
+/// Deep background for panels and windows.
+pub const BG_DARK: egui::Color32 = egui::Color32::from_rgb(25, 27, 35);
+/// Standard panel/window background.
+pub const BG_PANEL: egui::Color32 = egui::Color32::from_rgb(35, 37, 48);
+/// Slightly lighter surface for cards or nested sections.
+pub const BG_SURFACE: egui::Color32 = egui::Color32::from_rgb(45, 48, 60);
+/// Faint background used for input fields and code areas.
+pub const BG_FAINT: egui::Color32 = egui::Color32::from_rgb(40, 42, 52);
+
+/// Primary accent — cyan-blue (buttons, highlights, links).
+pub const PRIMARY: egui::Color32 = egui::Color32::from_rgb(70, 160, 230);
+/// Secondary accent — teal/green-blue.
+pub const SECONDARY: egui::Color32 = egui::Color32::from_rgb(60, 190, 180);
+
+/// Default text color.
+pub const TEXT: egui::Color32 = egui::Color32::from_rgb(220, 220, 230);
+/// Muted/secondary text color.
+pub const TEXT_MUTED: egui::Color32 = egui::Color32::from_rgb(140, 145, 160);
+/// Heading text color — slightly brighter than body text.
+pub const TEXT_HEADING: egui::Color32 = egui::Color32::from_rgb(240, 240, 250);
+
+/// Success / positive indicator.
+pub const SUCCESS: egui::Color32 = egui::Color32::from_rgb(50, 200, 80);
+/// Warning indicator.
+pub const WARNING: egui::Color32 = egui::Color32::from_rgb(230, 180, 50);
+/// Error / negative indicator.
+pub const ERROR: egui::Color32 = egui::Color32::from_rgb(220, 60, 60);
+
+/// Widget states — inactive, hover, active.
+pub const WIDGET_INACTIVE: egui::Color32 = egui::Color32::from_rgb(50, 55, 65);
+pub const WIDGET_HOVER: egui::Color32 = egui::Color32::from_rgb(65, 75, 95);
+pub const WIDGET_ACTIVE: egui::Color32 = egui::Color32::from_rgb(80, 140, 210);
+
+/// Separator / border color.
+pub const BORDER: egui::Color32 = egui::Color32::from_rgb(60, 65, 80);
+
+// =============================================================================
+// Font Sizes
+// =============================================================================
+
+/// Large heading (panel titles).
+pub const FONT_HEADING: f32 = 18.0;
+/// Sub-heading (section titles).
+pub const FONT_SUBHEADING: f32 = 15.0;
+/// Body text.
+pub const FONT_BODY: f32 = 13.0;
+/// Small / caption text.
+pub const FONT_SMALL: f32 = 11.0;
+
+// =============================================================================
+// Spacing
+// =============================================================================
+
+/// Standard inner padding for windows/panels.
+pub const PADDING: f32 = 8.0;
+/// Space between sections.
+pub const SECTION_SPACING: f32 = 12.0;
+/// Space between items in a list.
+pub const ITEM_SPACING: f32 = 4.0;
+/// Standard window corner radius.
+pub const CORNER_RADIUS: u8 = 8;
+/// Widget corner radius.
+pub const WIDGET_CORNER_RADIUS: u8 = 6;
+
+// =============================================================================
+// Theme application
+// =============================================================================
+
+/// Apply the Megacity dark theme to the egui context.
+///
+/// Called once at startup. Configures `Visuals`, widget styles, and colors
+/// so all panels inherit a consistent look without per-panel styling.
+pub fn setup_megacity_theme(mut contexts: EguiContexts) {
     let ctx = contexts.ctx_mut();
     let mut style = (*ctx.style()).clone();
 
-    // Dark warm background
-    let panel = egui::Color32::from_rgb(35, 37, 48);
-    let inactive = egui::Color32::from_rgb(50, 55, 65);
-    let hover = egui::Color32::from_rgb(70, 80, 100);
-    let active = egui::Color32::from_rgb(100, 160, 220);
+    // Window / panel backgrounds
+    style.visuals.window_fill = BG_PANEL;
+    style.visuals.panel_fill = BG_PANEL;
+    style.visuals.extreme_bg_color = BG_DARK;
+    style.visuals.faint_bg_color = BG_FAINT;
 
-    style.visuals.widgets.noninteractive.bg_fill = panel;
-    style.visuals.widgets.inactive.bg_fill = inactive;
-    style.visuals.widgets.hovered.bg_fill = hover;
-    style.visuals.widgets.active.bg_fill = active;
-    style.visuals.widgets.inactive.weak_bg_fill = inactive;
-    style.visuals.widgets.hovered.weak_bg_fill = hover;
-    style.visuals.widgets.active.weak_bg_fill = active;
+    // Widget colors
+    style.visuals.widgets.noninteractive.bg_fill = BG_PANEL;
+    style.visuals.widgets.inactive.bg_fill = WIDGET_INACTIVE;
+    style.visuals.widgets.inactive.weak_bg_fill = WIDGET_INACTIVE;
+    style.visuals.widgets.hovered.bg_fill = WIDGET_HOVER;
+    style.visuals.widgets.hovered.weak_bg_fill = WIDGET_HOVER;
+    style.visuals.widgets.active.bg_fill = WIDGET_ACTIVE;
+    style.visuals.widgets.active.weak_bg_fill = WIDGET_ACTIVE;
 
-    style.visuals.window_fill = panel;
-    style.visuals.panel_fill = panel;
-    style.visuals.extreme_bg_color = egui::Color32::from_rgb(30, 32, 40);
-    style.visuals.faint_bg_color = egui::Color32::from_rgb(40, 42, 52);
+    // Text colors per widget state
+    style.visuals.widgets.noninteractive.fg_stroke = egui::Stroke::new(1.0, TEXT);
+    style.visuals.widgets.inactive.fg_stroke = egui::Stroke::new(1.0, TEXT);
+    style.visuals.widgets.hovered.fg_stroke = egui::Stroke::new(1.0, TEXT_HEADING);
+    style.visuals.widgets.active.fg_stroke = egui::Stroke::new(1.0, TEXT_HEADING);
 
-    // Selection highlight
-    style.visuals.selection.bg_fill = active;
-    style.visuals.selection.stroke = egui::Stroke::new(1.0, active);
+    // Border strokes
+    style.visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0, BORDER);
+    style.visuals.widgets.inactive.bg_stroke = egui::Stroke::new(0.5, BORDER);
+    style.visuals.widgets.hovered.bg_stroke = egui::Stroke::new(1.0, PRIMARY);
+    style.visuals.widgets.active.bg_stroke = egui::Stroke::new(1.5, PRIMARY);
 
-    // Rounded corners (egui 0.31+ uses CornerRadius with u8 values)
-    let window_rounding = egui::CornerRadius::same(8);
-    let widget_rounding = egui::CornerRadius::same(6);
+    // Selection
+    style.visuals.selection.bg_fill = WIDGET_ACTIVE;
+    style.visuals.selection.stroke = egui::Stroke::new(1.0, PRIMARY);
+
+    // Rounding
+    let window_rounding = egui::CornerRadius::same(CORNER_RADIUS);
+    let widget_rounding = egui::CornerRadius::same(WIDGET_CORNER_RADIUS);
 
     style.visuals.window_corner_radius = window_rounding;
     style.visuals.widgets.noninteractive.corner_radius = widget_rounding;
@@ -37,5 +128,21 @@ pub fn apply_cute_theme(mut contexts: EguiContexts) {
     style.visuals.widgets.hovered.corner_radius = widget_rounding;
     style.visuals.widgets.active.corner_radius = widget_rounding;
 
+    // Window stroke
+    style.visuals.window_stroke = egui::Stroke::new(1.0, BORDER);
+
     ctx.set_style(style);
+}
+
+// =============================================================================
+// Plugin
+// =============================================================================
+
+/// Plugin that applies the Megacity UI theme at startup.
+pub struct ThemePlugin;
+
+impl Plugin for ThemePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, setup_megacity_theme);
+    }
 }

--- a/crates/ui/src/ui_widgets.rs
+++ b/crates/ui/src/ui_widgets.rs
@@ -1,0 +1,233 @@
+//! Reusable themed widget helpers for Megacity UI.
+//!
+//! These helpers wrap common egui patterns (windows, buttons, headers,
+//! stat rows, progress bars) with consistent styling from [`crate::theme`].
+//! Use them in new UI panels to maintain visual consistency without
+//! manually repeating color/spacing constants.
+
+use bevy_egui::egui;
+
+use crate::theme;
+
+// =============================================================================
+// Themed Window
+// =============================================================================
+
+/// Create a standard Megacity-styled window.
+///
+/// Applies consistent default width and styling. Returns the
+/// `Option<InnerResponse<R>>` from `egui::Window::show` so callers can
+/// check whether the window was rendered.
+///
+/// # Example
+/// ```ignore
+/// themed_window("Budget", ctx, |ui| {
+///     ui.label("Hello");
+/// });
+/// ```
+pub fn themed_window<R>(
+    title: &str,
+    ctx: &egui::Context,
+    add_contents: impl FnOnce(&mut egui::Ui) -> R,
+) -> Option<egui::InnerResponse<Option<R>>> {
+    egui::Window::new(title)
+        .default_width(280.0)
+        .resizable(true)
+        .show(ctx, add_contents)
+}
+
+/// Create a standard Megacity-styled window with an open/close boolean.
+///
+/// Like [`themed_window`] but the window can be closed via the X button,
+/// toggling `open` to `false`.
+pub fn themed_window_closeable<R>(
+    title: &str,
+    ctx: &egui::Context,
+    open: &mut bool,
+    add_contents: impl FnOnce(&mut egui::Ui) -> R,
+) -> Option<egui::InnerResponse<Option<R>>> {
+    egui::Window::new(title)
+        .open(open)
+        .default_width(280.0)
+        .resizable(true)
+        .show(ctx, add_contents)
+}
+
+// =============================================================================
+// Themed Button
+// =============================================================================
+
+/// A standard button with consistent theme styling.
+///
+/// Returns the `egui::Response` so callers can check `.clicked()`.
+pub fn themed_button(ui: &mut egui::Ui, text: &str) -> egui::Response {
+    let button = egui::Button::new(
+        egui::RichText::new(text).size(theme::FONT_BODY),
+    )
+    .corner_radius(egui::CornerRadius::same(theme::WIDGET_CORNER_RADIUS));
+    ui.add(button)
+}
+
+/// A primary (highlighted) button for the main action in a panel.
+pub fn themed_button_primary(ui: &mut egui::Ui, text: &str) -> egui::Response {
+    let button = egui::Button::new(
+        egui::RichText::new(text)
+            .size(theme::FONT_BODY)
+            .color(theme::TEXT_HEADING),
+    )
+    .fill(theme::PRIMARY)
+    .corner_radius(egui::CornerRadius::same(theme::WIDGET_CORNER_RADIUS));
+    ui.add(button)
+}
+
+// =============================================================================
+// Themed Headers
+// =============================================================================
+
+/// Render a section heading with consistent font size and color.
+pub fn themed_heading(ui: &mut egui::Ui, text: &str) {
+    ui.label(
+        egui::RichText::new(text)
+            .size(theme::FONT_HEADING)
+            .color(theme::TEXT_HEADING)
+            .strong(),
+    );
+}
+
+/// Render a sub-section heading.
+pub fn themed_subheading(ui: &mut egui::Ui, text: &str) {
+    ui.label(
+        egui::RichText::new(text)
+            .size(theme::FONT_SUBHEADING)
+            .color(theme::TEXT_HEADING),
+    );
+}
+
+// =============================================================================
+// Stat Row
+// =============================================================================
+
+/// A label-value row commonly used in info panels.
+///
+/// Renders as `label:  value` in a horizontal layout with the label in
+/// muted text and the value in normal text.
+pub fn stat_row(ui: &mut egui::Ui, label: &str, value: &str) {
+    ui.horizontal(|ui| {
+        ui.label(
+            egui::RichText::new(format!("{}:", label))
+                .size(theme::FONT_BODY)
+                .color(theme::TEXT_MUTED),
+        );
+        ui.label(
+            egui::RichText::new(value)
+                .size(theme::FONT_BODY)
+                .color(theme::TEXT),
+        );
+    });
+}
+
+/// A label-value row where the value is colored (e.g., green for positive,
+/// red for negative).
+pub fn stat_row_colored(
+    ui: &mut egui::Ui,
+    label: &str,
+    value: &str,
+    color: egui::Color32,
+) {
+    ui.horizontal(|ui| {
+        ui.label(
+            egui::RichText::new(format!("{}:", label))
+                .size(theme::FONT_BODY)
+                .color(theme::TEXT_MUTED),
+        );
+        ui.label(
+            egui::RichText::new(value)
+                .size(theme::FONT_BODY)
+                .color(color),
+        );
+    });
+}
+
+// =============================================================================
+// Progress Bar
+// =============================================================================
+
+/// A themed progress bar with an optional custom fill color.
+///
+/// `fraction` should be in the range `0.0..=1.0`. If `color` is `None`,
+/// the primary accent color is used.
+pub fn progress_bar(
+    ui: &mut egui::Ui,
+    fraction: f32,
+    color: Option<egui::Color32>,
+) -> egui::Response {
+    let fill = color.unwrap_or(theme::PRIMARY);
+    ui.add(
+        egui::ProgressBar::new(fraction.clamp(0.0, 1.0))
+            .fill(fill)
+            .desired_width(ui.available_width().min(200.0)),
+    )
+}
+
+/// A themed progress bar with a text overlay.
+pub fn progress_bar_with_text(
+    ui: &mut egui::Ui,
+    fraction: f32,
+    text: &str,
+    color: Option<egui::Color32>,
+) -> egui::Response {
+    let fill = color.unwrap_or(theme::PRIMARY);
+    ui.add(
+        egui::ProgressBar::new(fraction.clamp(0.0, 1.0))
+            .fill(fill)
+            .text(text)
+            .desired_width(ui.available_width().min(200.0)),
+    )
+}
+
+// =============================================================================
+// Section helpers
+// =============================================================================
+
+/// Add a separator with consistent spacing above and below.
+pub fn section_separator(ui: &mut egui::Ui) {
+    ui.add_space(theme::ITEM_SPACING);
+    ui.separator();
+    ui.add_space(theme::ITEM_SPACING);
+}
+
+/// Render a muted caption / small text line.
+pub fn caption(ui: &mut egui::Ui, text: &str) {
+    ui.label(
+        egui::RichText::new(text)
+            .size(theme::FONT_SMALL)
+            .color(theme::TEXT_MUTED),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_progress_bar_fraction_clamped() {
+        // Verify the clamping logic works for out-of-range values.
+        let clamped_low = (-0.5_f32).clamp(0.0, 1.0);
+        assert!((clamped_low - 0.0).abs() < f32::EPSILON);
+
+        let clamped_high = (1.5_f32).clamp(0.0, 1.0);
+        assert!((clamped_high - 1.0).abs() < f32::EPSILON);
+
+        let clamped_mid = (0.5_f32).clamp(0.0, 1.0);
+        assert!((clamped_mid - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_theme_colors_are_distinct() {
+        // Ensure key colors are not accidentally the same.
+        assert_ne!(theme::PRIMARY, theme::SECONDARY);
+        assert_ne!(theme::SUCCESS, theme::ERROR);
+        assert_ne!(theme::BG_DARK, theme::BG_PANEL);
+        assert_ne!(theme::TEXT, theme::TEXT_MUTED);
+    }
+}


### PR DESCRIPTION
## Summary
- Add centralized `ThemePlugin` with dark city-builder color palette (backgrounds, accents, text, status colors), font size constants, and spacing constants
- Add `ui_widgets.rs` with reusable themed helpers: `themed_window`, `themed_button`, `themed_heading`, `stat_row`, `progress_bar`, `section_separator`, `caption`
- Replace ad-hoc `apply_cute_theme` startup system with proper plugin registration via `ThemePlugin`
- Configure egui `Visuals` comprehensively on startup (widget states, text colors, border strokes, selection, rounding, window stroke)

## Test plan
- [ ] Verify compilation passes CI (cargo build, clippy, fmt)
- [ ] All existing tests pass (no behavioral changes)
- [ ] Visual inspection of UI panels in-game for consistent dark theme

Closes #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)