### PR TITLE
PLAY-006: Pause Menu (ESC Key) (#1703)

### DIFF
--- a/crates/ui/src/pause_menu.rs
+++ b/crates/ui/src/pause_menu.rs
@@ -1,0 +1,189 @@
+//! Pause menu UI (PLAY-006).
+//!
+//! Pressing ESC toggles between `AppState::Playing` and `AppState::Paused`.
+//! While paused, a semi-transparent overlay with action buttons is shown.
+
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts};
+
+use save::{LoadGameEvent, SaveGameEvent};
+use simulation::app_state::AppState;
+use simulation::time_of_day::GameClock;
+
+// =============================================================================
+// Resources
+// =============================================================================
+
+/// Tracks whether the "Return to Main Menu" confirmation is showing.
+#[derive(Resource, Default)]
+struct MainMenuConfirm(bool);
+
+// =============================================================================
+// Plugin
+// =============================================================================
+
+pub struct PauseMenuPlugin;
+
+impl Plugin for PauseMenuPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<MainMenuConfirm>();
+        app.add_systems(Update, toggle_pause);
+        app.add_systems(
+            Update,
+            pause_menu_ui.run_if(in_state(AppState::Paused)),
+        );
+    }
+}
+
+// =============================================================================
+// Systems
+// =============================================================================
+
+/// Toggles between Playing and Paused when ESC is pressed.
+fn toggle_pause(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    app_state: Res<State<AppState>>,
+    mut next_state: ResMut<NextState<AppState>>,
+    mut game_clock: ResMut<GameClock>,
+    mut contexts: EguiContexts,
+    mut confirm: ResMut<MainMenuConfirm>,
+) {
+    // Don't intercept ESC if egui is consuming keyboard input (e.g. text fields).
+    if contexts.ctx_mut().wants_keyboard_input() {
+        return;
+    }
+
+    if !keyboard.just_pressed(KeyCode::Escape) {
+        return;
+    }
+
+    match app_state.get() {
+        AppState::Playing => {
+            game_clock.paused = true;
+            next_state.set(AppState::Paused);
+        }
+        AppState::Paused => {
+            // Reset confirmation state when unpausing via ESC.
+            confirm.0 = false;
+            game_clock.paused = false;
+            next_state.set(AppState::Playing);
+        }
+        AppState::MainMenu => {
+            // ESC does nothing on the main menu.
+        }
+    }
+}
+
+/// Renders the pause menu overlay and buttons.
+#[allow(clippy::too_many_arguments)]
+fn pause_menu_ui(
+    mut contexts: EguiContexts,
+    mut next_state: ResMut<NextState<AppState>>,
+    mut game_clock: ResMut<GameClock>,
+    mut save_events: EventWriter<SaveGameEvent>,
+    mut load_events: EventWriter<LoadGameEvent>,
+    mut confirm: ResMut<MainMenuConfirm>,
+    #[cfg(not(target_arch = "wasm32"))] mut exit: EventWriter<AppExit>,
+) {
+    let ctx = contexts.ctx_mut();
+
+    // Semi-transparent dark overlay covering the entire screen.
+    let screen_rect = ctx.screen_rect();
+    egui::Area::new(egui::Id::new("pause_overlay"))
+        .fixed_pos(screen_rect.min)
+        .order(egui::Order::Background)
+        .show(ctx, |ui| {
+            let painter = ui.painter();
+            painter.rect_filled(
+                screen_rect,
+                egui::CornerRadius::ZERO,
+                egui::Color32::from_black_alpha(160),
+            );
+            // Allocate the full rect so the area has the right size.
+            ui.allocate_rect(screen_rect, egui::Sense::hover());
+        });
+
+    // Centered panel with action buttons.
+    egui::Window::new("Paused")
+        .collapsible(false)
+        .resizable(false)
+        .title_bar(false)
+        .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+        .default_width(240.0)
+        .show(ctx, |ui| {
+            ui.vertical_centered(|ui| {
+                ui.spacing_mut().item_spacing.y = 10.0;
+
+                ui.add_space(8.0);
+                ui.heading("Paused");
+                ui.add_space(8.0);
+
+                let button_size = egui::Vec2::new(200.0, 36.0);
+
+                // Resume
+                if ui
+                    .add_sized(button_size, egui::Button::new("Resume"))
+                    .clicked()
+                {
+                    confirm.0 = false;
+                    game_clock.paused = false;
+                    next_state.set(AppState::Playing);
+                }
+
+                // Save Game
+                if ui
+                    .add_sized(button_size, egui::Button::new("Save Game"))
+                    .clicked()
+                {
+                    save_events.send(SaveGameEvent);
+                }
+
+                // Load Game
+                if ui
+                    .add_sized(button_size, egui::Button::new("Load Game"))
+                    .clicked()
+                {
+                    load_events.send(LoadGameEvent);
+                }
+
+                ui.add_space(4.0);
+                ui.separator();
+                ui.add_space(4.0);
+
+                // Main Menu — with confirmation step
+                if !confirm.0 {
+                    if ui
+                        .add_sized(button_size, egui::Button::new("Main Menu"))
+                        .clicked()
+                    {
+                        confirm.0 = true;
+                    }
+                } else {
+                    ui.label("Unsaved progress will be lost.");
+                    ui.horizontal(|ui| {
+                        if ui.button("Confirm").clicked() {
+                            confirm.0 = false;
+                            game_clock.paused = false;
+                            next_state.set(AppState::MainMenu);
+                        }
+                        if ui.button("Cancel").clicked() {
+                            confirm.0 = false;
+                        }
+                    });
+                }
+
+                // Quit — hidden on WASM (browsers don't support app exit)
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    if ui
+                        .add_sized(button_size, egui::Button::new("Quit"))
+                        .clicked()
+                    {
+                        exit.send(AppExit::Success);
+                    }
+                }
+
+                ui.add_space(8.0);
+            });
+        });
+}

--- a/crates/ui/src/plugin_registration.rs
+++ b/crates/ui/src/plugin_registration.rs
@@ -48,6 +48,7 @@ pub(crate) fn register_ui_systems(app: &mut App) {
     app.add_plugins(info_panel::budget::BudgetBreakdownPlugin);
     app.add_plugins(energy_dashboard::EnergyDashboardPlugin);
     app.add_plugins(tutorial_camera::TutorialCameraPlugin);
+    app.add_plugins(pause_menu::PauseMenuPlugin);
     // UI resources
     app.init_resource::<day_night_panel::DayNightPanelVisible>();
     app.init_resource::<milestones::Milestones>();


### PR DESCRIPTION
## Summary
- Add pause menu triggered by ESC key, transitioning between `AppState::Playing` and `AppState::Paused`
- Semi-transparent dark overlay covers the game world while paused
- Centered menu panel with buttons: Resume, Save Game, Load Game, Main Menu (with confirmation), Quit
- Quit button hidden on WASM builds (browsers don't support app exit)
- GameClock paused/unpaused alongside state transitions

## Test plan
- [ ] Verify compilation passes CI
- [ ] ESC during gameplay opens pause menu and freezes simulation
- [ ] ESC while paused closes menu and resumes simulation
- [ ] Resume button returns to gameplay
- [ ] Save Game sends SaveGameEvent
- [ ] Load Game sends LoadGameEvent
- [ ] Main Menu shows confirmation before transitioning
- [ ] Quit exits the application (native only)

Closes #1703

🤖 Generated with [Claude Code](https://claude.com/claude-code)