### PR TITLE
PLAY-025: Disable Simulation in MainMenu State (#1741)

### DIFF
--- a/crates/simulation/src/autosave.rs
+++ b/crates/simulation/src/autosave.rs
@@ -242,7 +242,7 @@ impl Plugin for AutosavePlugin {
                 FixedUpdate,
                 autosave_tick_system.in_set(crate::SimulationSet::PostSim),
             )
-            .add_systems(Update, autosave_notification_system);
+            .add_systems(Update, autosave_notification_system.in_set(crate::SimulationUpdateSet::Visual));
 
         // Register for save/load via the SaveableRegistry
         app.init_resource::<crate::SaveableRegistry>();

--- a/crates/simulation/src/coverage_metrics.rs
+++ b/crates/simulation/src/coverage_metrics.rs
@@ -39,7 +39,7 @@ pub struct CoverageMetricsPlugin;
 impl Plugin for CoverageMetricsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CoverageMetrics>();
-        app.add_systems(Update, update_coverage_metrics);
+        app.add_systems(Update, update_coverage_metrics.in_set(crate::SimulationUpdateSet::Visual));
     }
 }
 

--- a/crates/simulation/src/play_time.rs
+++ b/crates/simulation/src/play_time.rs
@@ -38,7 +38,7 @@ pub struct PlayTimePlugin;
 impl Plugin for PlayTimePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<PlayTime>()
-            .add_systems(Update, tick_play_time);
+            .add_systems(Update, tick_play_time.in_set(crate::SimulationUpdateSet::Visual));
 
         // Register for save/load
         let mut registry = app

--- a/crates/simulation/src/tutorial_hints.rs
+++ b/crates/simulation/src/tutorial_hints.rs
@@ -68,7 +68,7 @@ pub struct TutorialHintsPlugin;
 impl Plugin for TutorialHintsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<TutorialUiHint>()
-            .add_systems(Update, update_tutorial_hints);
+            .add_systems(Update, update_tutorial_hints.in_set(crate::SimulationUpdateSet::Visual));
     }
 }
 


### PR DESCRIPTION
## Summary
- Gate 4 ungated `Update` systems behind `SimulationUpdateSet::Visual` so they inherit the existing `AppState::Playing` run condition
- `autosave_notification_system`, `update_coverage_metrics`, `tick_play_time`, and `update_tutorial_hints` no longer tick on the main menu or pause screens
- `save_slots` systems intentionally remain ungated — they must operate from any `AppState`

## Context
The `SimulationSet` (FixedUpdate) and `SimulationUpdateSet` (Update) were already configured with `run_if(in_state(AppState::Playing))` in `SimulationPlugin::build()`. However, 4 systems were registered directly in `Update` without being placed in any set, bypassing this gate.

## Test plan
- [ ] Verify compilation passes CI
- [ ] Existing integration tests still pass (no behavioral change during `AppState::Playing`)
- [ ] Autosave, coverage metrics, play time, and tutorial hints stop ticking when not in `Playing` state

Closes #1741

🤖 Generated with [Claude Code](https://claude.com/claude-code)