### PR TITLE
Fix keybind conflict: move Advisor toggle from A to F2

### DIFF
--- a/crates/simulation/src/keybindings/bindings.rs
+++ b/crates/simulation/src/keybindings/bindings.rs
@@ -197,7 +197,7 @@ impl Default for KeyBindings {
             overlay_cycle_next: KeyBinding::simple(KeyCode::Tab),
             toggle_journal: KeyBinding::simple(KeyCode::KeyJ),
             toggle_charts: KeyBinding::simple(KeyCode::KeyC),
-            toggle_advisor: KeyBinding::simple(KeyCode::KeyA),
+            toggle_advisor: KeyBinding::simple(KeyCode::F2),
             toggle_policies: KeyBinding::simple(KeyCode::KeyP),
             toggle_settings: KeyBinding::simple(KeyCode::F10),
             toggle_search: KeyBinding::ctrl(KeyCode::KeyF),

--- a/crates/ui/src/info_panel/keybinds.rs
+++ b/crates/ui/src/info_panel/keybinds.rs
@@ -4,7 +4,7 @@ use bevy_egui::EguiContexts;
 use super::{AdvisorVisible, ChartsVisible, JournalVisible, PoliciesVisible};
 
 /// Toggles UI panel visibility when keybinds are pressed.
-/// J = Event Journal, C = Charts, A = Advisors, P = Policies.
+/// J = Event Journal, C = Charts, F2 = Advisors, P = Policies.
 /// Keys are ignored when egui has keyboard focus (e.g. text input).
 #[allow(clippy::too_many_arguments)]
 pub fn panel_keybinds(


### PR DESCRIPTION
## Summary
- **Fixed 'A' key conflict**: The 'A' key was bound to both camera pan left (WASD movement) and advisor panel toggle, causing the advisor panel to open/close unexpectedly during basic camera movement
- **Remapped advisor toggle to F2**: Consistent with settings panel on F10, and F2 was unused
- **Verified no other WASD conflicts exist**: W, S, D keys have no conflicting bindings across categories

## Changes
- `crates/simulation/src/keybindings/bindings.rs`: Changed `toggle_advisor` default from `KeyCode::KeyA` to `KeyCode::F2`
- `crates/ui/src/info_panel/keybinds.rs`: Updated doc comment to reflect the new keybind

## Test plan
- [ ] Data-only change (default key constant), no logic changes
- [ ] Existing keybinding serialization/deserialization tests cover the framework
- [ ] Users with custom keybindings saved will keep their custom bindings (only default changes)

Closes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)