### PR TITLE
PLAY-024: Add in-game help overlay with keybindings reference

### DIFF
--- a/crates/simulation/src/keybindings/actions.rs
+++ b/crates/simulation/src/keybindings/actions.rs
@@ -44,6 +44,7 @@ pub enum BindableAction {
     TogglePolicies,
     ToggleSettings,
     ToggleSearch,
+    ToggleHelp,
 
     // Save/Load (ctrl-modified)
     QuickSave,
@@ -86,6 +87,7 @@ impl BindableAction {
             Self::TogglePolicies => "Toggle Policies",
             Self::ToggleSettings => "Toggle Settings",
             Self::ToggleSearch => "Toggle Search",
+            Self::ToggleHelp => "Toggle Help",
             Self::QuickSave => "Quick Save",
             Self::QuickLoad => "Quick Load",
             Self::NewGame => "New Game",
@@ -124,7 +126,8 @@ impl BindableAction {
             | Self::ToggleAdvisor
             | Self::TogglePolicies
             | Self::ToggleSettings
-            | Self::ToggleSearch => "Panels",
+            | Self::ToggleSearch
+            | Self::ToggleHelp => "Panels",
 
             Self::QuickSave | Self::QuickLoad | Self::NewGame | Self::Screenshot => "System",
         }
@@ -160,6 +163,7 @@ impl BindableAction {
         Self::TogglePolicies,
         Self::ToggleSettings,
         Self::ToggleSearch,
+        Self::ToggleHelp,
         Self::QuickSave,
         Self::QuickLoad,
         Self::NewGame,

--- a/crates/simulation/src/keybindings/bindings.rs
+++ b/crates/simulation/src/keybindings/bindings.rs
@@ -157,6 +157,7 @@ pub struct KeyBindings {
     pub toggle_policies: KeyBinding,
     pub toggle_settings: KeyBinding,
     pub toggle_search: KeyBinding,
+    pub toggle_help: KeyBinding,
 
     // System
     pub quick_save: KeyBinding,
@@ -201,6 +202,7 @@ impl Default for KeyBindings {
             toggle_policies: KeyBinding::simple(KeyCode::KeyP),
             toggle_settings: KeyBinding::simple(KeyCode::F10),
             toggle_search: KeyBinding::ctrl(KeyCode::KeyF),
+            toggle_help: KeyBinding::simple(KeyCode::F1),
             quick_save: KeyBinding::simple(KeyCode::F5),
             quick_load: KeyBinding::simple(KeyCode::F9),
             new_game: KeyBinding::ctrl(KeyCode::KeyN),
@@ -241,6 +243,7 @@ impl KeyBindings {
             BindableAction::TogglePolicies => self.toggle_policies,
             BindableAction::ToggleSettings => self.toggle_settings,
             BindableAction::ToggleSearch => self.toggle_search,
+            BindableAction::ToggleHelp => self.toggle_help,
             BindableAction::QuickSave => self.quick_save,
             BindableAction::QuickLoad => self.quick_load,
             BindableAction::NewGame => self.new_game,
@@ -279,6 +282,7 @@ impl KeyBindings {
             BindableAction::TogglePolicies => self.toggle_policies = binding,
             BindableAction::ToggleSettings => self.toggle_settings = binding,
             BindableAction::ToggleSearch => self.toggle_search = binding,
+            BindableAction::ToggleHelp => self.toggle_help = binding,
             BindableAction::QuickSave => self.quick_save = binding,
             BindableAction::QuickLoad => self.quick_load = binding,
             BindableAction::NewGame => self.new_game = binding,

--- a/crates/ui/src/help_overlay.rs
+++ b/crates/ui/src/help_overlay.rs
@@ -1,0 +1,124 @@
+//! PLAY-024: In-game help overlay showing all keybindings grouped by category.
+//!
+//! Toggled via F1 (or the user's configured `toggle_help` binding).
+//! Displays a read-only reference of all current keybindings in a centered
+//! egui window, grouped by category. Can be dismissed with the Close button,
+//! Escape, or pressing F1 again.
+
+use bevy::prelude::*;
+use bevy_egui::{egui, EguiContexts};
+
+use simulation::app_state::AppState;
+use simulation::keybindings::{BindableAction, KeyBindings};
+
+/// Whether the help overlay is currently visible.
+#[derive(Resource, Default)]
+pub struct HelpOverlayOpen(pub bool);
+
+/// System: toggle the help overlay when the configured key is pressed.
+fn toggle_help_overlay(
+    keys: Option<Res<ButtonInput<KeyCode>>>,
+    bindings: Res<KeyBindings>,
+    mut open: ResMut<HelpOverlayOpen>,
+) {
+    let Some(keys) = keys else {
+        return;
+    };
+    if bindings.toggle_help.just_pressed(&keys) {
+        open.0 = !open.0;
+    }
+    // Also close on Escape when open
+    if open.0 && bindings.escape.just_pressed(&keys) {
+        open.0 = false;
+    }
+}
+
+/// System: render the help overlay egui window.
+fn help_overlay_ui(
+    mut contexts: EguiContexts,
+    mut open: ResMut<HelpOverlayOpen>,
+    bindings: Res<KeyBindings>,
+) {
+    if !open.0 {
+        return;
+    }
+
+    let mut should_close = false;
+
+    egui::Window::new("Help — Keyboard Shortcuts")
+        .collapsible(false)
+        .resizable(true)
+        .default_width(480.0)
+        .min_width(380.0)
+        .max_height(600.0)
+        .vscroll(true)
+        .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+        .show(contexts.ctx_mut(), |ui| {
+            ui.spacing_mut().item_spacing.y = 2.0;
+
+            ui.colored_label(
+                egui::Color32::from_gray(160),
+                "Press F1 or Escape to close. Bindings can be changed in Settings.",
+            );
+            ui.add_space(8.0);
+
+            let mut current_category = "";
+
+            for &action in BindableAction::ALL {
+                let category = action.category();
+                if category != current_category {
+                    if !current_category.is_empty() {
+                        ui.add_space(6.0);
+                    }
+                    ui.heading(category);
+                    ui.separator();
+                    current_category = category;
+                }
+
+                let binding = bindings.get(action);
+                ui.horizontal(|ui| {
+                    ui.colored_label(
+                        egui::Color32::from_gray(220),
+                        action.label(),
+                    );
+                    ui.with_layout(
+                        egui::Layout::right_to_left(egui::Align::Center),
+                        |ui| {
+                            ui.colored_label(
+                                egui::Color32::from_rgb(130, 200, 255),
+                                egui::RichText::new(binding.display_label())
+                                    .monospace(),
+                            );
+                        },
+                    );
+                });
+            }
+
+            ui.add_space(12.0);
+            ui.separator();
+            ui.add_space(4.0);
+
+            ui.horizontal(|ui| {
+                if ui.button("Close").clicked() {
+                    should_close = true;
+                }
+            });
+        });
+
+    if should_close {
+        open.0 = false;
+    }
+}
+
+pub struct HelpOverlayPlugin;
+
+impl Plugin for HelpOverlayPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<HelpOverlayOpen>().add_systems(
+            Update,
+            (toggle_help_overlay, help_overlay_ui)
+                .chain()
+                .run_if(in_state(AppState::Playing)),
+        );
+    }
+}

--- a/crates/ui/src/plugin_registration.rs
+++ b/crates/ui/src/plugin_registration.rs
@@ -59,6 +59,7 @@ pub(crate) fn register_ui_systems(app: &mut App) {
     app.add_plugins(main_menu::MainMenuPlugin);
     app.add_plugins(settings_menu::SettingsMenuPlugin);
     app.add_plugins(loading_screen::LoadingScreenPlugin);
+    app.add_plugins(help_overlay::HelpOverlayPlugin);
     // UI resources
     app.init_resource::<day_night_panel::DayNightPanelVisible>();
     app.init_resource::<milestones::Milestones>();


### PR DESCRIPTION
## Summary
- Add `ToggleHelp` bindable action mapped to F1
- Create `help_overlay.rs` UI module with a centered egui window showing all keybindings grouped by category (Camera, Speed, Tools, Overlays, Panels, System)
- Overlay reads live from `KeyBindings` resource so it reflects user customizations
- Dismissible via F1, Escape, or Close button

Closes #1740

## Test plan
- [ ] Press F1 during gameplay to verify the help overlay appears
- [ ] Verify all keybindings are displayed grouped by category
- [ ] Press F1 again or Escape to dismiss
- [ ] Rebind a key in Settings and verify the help overlay shows the updated binding
- [ ] Verify the overlay does not appear on the main menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)