### PR TITLE
P0-09: Unify pause authority — sync AppState with GameClock.paused

### DIFF
--- a/crates/simulation/src/integration_tests/pause_authority_tests.rs
+++ b/crates/simulation/src/integration_tests/pause_authority_tests.rs
@@ -1,0 +1,161 @@
+//! Integration tests for P0-09: Unified pause authority.
+//!
+//! Verifies that `GameClock.paused` and `AppState` stay in sync regardless
+//! of which mechanism triggers the pause/unpause.
+
+use bevy::prelude::*;
+
+use crate::app_state::AppState;
+use crate::test_harness::TestCity;
+use crate::time_of_day::GameClock;
+use crate::TickCounter;
+
+/// When `GameClock.paused` is set to `true` (e.g. by toolbar/speed keybind),
+/// the sync system should transition `AppState` to `Paused`, which stops
+/// simulation systems from running.
+#[test]
+fn test_game_clock_pause_stops_simulation() {
+    let mut city = TestCity::new();
+
+    // Verify simulation is running initially.
+    let before = city.resource::<TickCounter>().0;
+    city.tick(5);
+    let after = city.resource::<TickCounter>().0;
+    assert!(after > before, "Simulation should tick while playing");
+
+    // Simulate what the toolbar || button does: only set GameClock.paused.
+    city.world_mut().resource_mut::<GameClock>().paused = true;
+
+    // Run Update schedule so the sync system fires and transitions AppState.
+    city.world_mut().run_schedule(Update);
+    city.world_mut().run_schedule(StateTransition);
+
+    // Verify AppState transitioned to Paused.
+    let state = *city.world_mut().resource::<State<AppState>>().get();
+    assert_eq!(
+        state,
+        AppState::Paused,
+        "AppState should be Paused after GameClock.paused = true"
+    );
+
+    // Verify simulation no longer ticks.
+    let before = city.resource::<TickCounter>().0;
+    city.tick(20);
+    let after = city.resource::<TickCounter>().0;
+    assert_eq!(
+        before, after,
+        "TickCounter should NOT advance when GameClock.paused is true"
+    );
+}
+
+/// When `GameClock.paused` is set back to `false`, the sync system should
+/// transition `AppState` back to `Playing`, resuming simulation.
+#[test]
+fn test_game_clock_unpause_resumes_simulation() {
+    let mut city = TestCity::new();
+
+    // Pause via GameClock.
+    city.world_mut().resource_mut::<GameClock>().paused = true;
+    city.world_mut().run_schedule(Update);
+    city.world_mut().run_schedule(StateTransition);
+
+    // Verify paused.
+    let state = *city.world_mut().resource::<State<AppState>>().get();
+    assert_eq!(state, AppState::Paused);
+
+    // Unpause via GameClock (simulate pressing a speed button).
+    city.world_mut().resource_mut::<GameClock>().paused = false;
+    city.world_mut().run_schedule(Update);
+    city.world_mut().run_schedule(StateTransition);
+
+    // Verify AppState is Playing again.
+    let state = *city.world_mut().resource::<State<AppState>>().get();
+    assert_eq!(
+        state,
+        AppState::Playing,
+        "AppState should be Playing after GameClock.paused = false"
+    );
+
+    // Verify simulation resumes.
+    let before = city.resource::<TickCounter>().0;
+    city.tick(10);
+    let after = city.resource::<TickCounter>().0;
+    assert!(
+        after > before,
+        "TickCounter should advance after unpausing"
+    );
+}
+
+/// When `AppState` is already `Paused` and `GameClock.paused` is also `true`,
+/// no extra state transition should occur.
+#[test]
+fn test_already_synced_pause_is_no_op() {
+    let mut city = TestCity::new();
+
+    // Pause via both mechanisms (mimicking the ESC pause menu behavior).
+    city.world_mut().resource_mut::<GameClock>().paused = true;
+    city.world_mut()
+        .resource_mut::<NextState<AppState>>()
+        .set(AppState::Paused);
+    city.world_mut().run_schedule(StateTransition);
+
+    // Run sync — should not panic or produce unexpected state.
+    city.world_mut().run_schedule(Update);
+    city.world_mut().run_schedule(StateTransition);
+
+    let state = *city.world_mut().resource::<State<AppState>>().get();
+    assert_eq!(state, AppState::Paused);
+}
+
+/// The sync system should not interfere with `AppState::MainMenu`.
+/// Setting `GameClock.paused = true` from MainMenu should NOT transition to Paused.
+#[test]
+fn test_sync_does_not_affect_main_menu() {
+    let mut app = bevy::app::App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_plugins(bevy::state::app::StatesPlugin);
+    app.insert_resource(crate::tutorial::TutorialState {
+        completed: true,
+        active: false,
+        ..Default::default()
+    });
+    // Stay in MainMenu (default state).
+    app.add_plugins(crate::SimulationPlugin);
+    app.update();
+
+    // Set GameClock.paused from MainMenu.
+    app.world_mut().resource_mut::<GameClock>().paused = true;
+    app.world_mut().run_schedule(Update);
+    app.world_mut().run_schedule(StateTransition);
+
+    // Should still be MainMenu, not Paused.
+    let state = *app.world().resource::<State<AppState>>().get();
+    assert_eq!(
+        state,
+        AppState::MainMenu,
+        "GameClock.paused should not transition MainMenu to Paused"
+    );
+}
+
+/// Game clock time should not advance when paused via the GameClock flag,
+/// confirming that both the clock tick and system execution are halted.
+#[test]
+fn test_game_clock_time_does_not_advance_when_paused() {
+    let mut city = TestCity::new();
+
+    let hour_before = city.clock().hour;
+
+    // Pause via GameClock (toolbar style).
+    city.world_mut().resource_mut::<GameClock>().paused = true;
+    city.world_mut().run_schedule(Update);
+    city.world_mut().run_schedule(StateTransition);
+
+    // Tick the simulation — systems are gated, clock won't advance.
+    city.tick(50);
+
+    let hour_after = city.clock().hour;
+    assert_eq!(
+        hour_before, hour_after,
+        "GameClock hour should not advance when paused"
+    );
+}

--- a/crates/simulation/src/pause_sync.rs
+++ b/crates/simulation/src/pause_sync.rs
@@ -1,0 +1,51 @@
+//! P0-09: Unify pause authority — keep `AppState` in sync with `GameClock.paused`.
+//!
+//! Two independent pause mechanisms exist:
+//! - `GameClock.paused` — toggled by toolbar speed controls and keybinds
+//! - `AppState::Paused` — toggled by the ESC pause menu
+//!
+//! This module adds a sync system that watches `GameClock.paused` and transitions
+//! `AppState` accordingly, so both mechanisms always agree.  When `GameClock.paused`
+//! is set to `true` while `AppState` is `Playing`, we transition to `Paused`.
+//! When `GameClock.paused` is set to `false` while `AppState` is `Paused`, we
+//! transition back to `Playing`.
+//!
+//! The sync is one-directional: `GameClock.paused` is the source of truth.
+//! Code that transitions `AppState` (e.g. the pause menu) must also set
+//! `GameClock.paused` — which it already does.
+
+use bevy::prelude::*;
+
+use crate::app_state::AppState;
+use crate::time_of_day::GameClock;
+
+/// Keeps `AppState` in sync with `GameClock.paused`.
+///
+/// Runs every frame (not gated by `AppState::Playing`) so it can detect
+/// when the toolbar or speed keybinds pause/unpause via `GameClock` and
+/// mirror the change to `AppState`.
+fn sync_pause_state(
+    clock: Res<GameClock>,
+    app_state: Res<State<AppState>>,
+    mut next_state: ResMut<NextState<AppState>>,
+) {
+    match app_state.get() {
+        AppState::Playing if clock.paused => {
+            next_state.set(AppState::Paused);
+        }
+        AppState::Paused if !clock.paused => {
+            next_state.set(AppState::Playing);
+        }
+        _ => {}
+    }
+}
+
+pub struct PauseSyncPlugin;
+
+impl Plugin for PauseSyncPlugin {
+    fn build(&self, app: &mut App) {
+        // Run in Update without any state gate — this system must observe
+        // transitions *from* any gameplay state.
+        app.add_systems(Update, sync_pause_state);
+    }
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -351,6 +351,8 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
 
     // App state machine (PLAY-001)
     app.add_plugins(app_state_plugin::AppStatePlugin);
+    // Pause authority sync (P0-09)
+    app.add_plugins(pause_sync::PauseSyncPlugin);
     // UI sound effects triggers (PLAY-008)
     app.add_plugins(sfx_triggers::SfxTriggersPlugin);
 


### PR DESCRIPTION
## Summary
- Adds `PauseSyncPlugin` with a system that keeps `AppState` in sync with `GameClock.paused`
- When `GameClock.paused` is set to `true` (by toolbar `||` button or Space keybind) while `AppState` is `Playing`, the system transitions `AppState` to `Paused`, stopping all simulation systems
- When `GameClock.paused` is cleared (by speed buttons/keybinds) while `AppState` is `Paused`, the system transitions back to `Playing`
- Does not affect `MainMenu` state — pausing from main menu is a no-op

## Problem
Two independent pause mechanisms existed that could get out of sync:
- `AppState::Paused` — gating system execution via `run_if(in_state(AppState::Playing))`
- `GameClock.paused` — preventing time advancement

The toolbar speed controls and keybinds only toggled `GameClock.paused` but did not change `AppState`, so simulation systems gated on `AppState::Playing` kept running when only `GameClock.paused` was set.

## Test plan
- [x] `test_game_clock_pause_stops_simulation` — toolbar-style pause (GameClock only) now stops simulation
- [x] `test_game_clock_unpause_resumes_simulation` — unpausing via GameClock resumes AppState and simulation
- [x] `test_already_synced_pause_is_no_op` — no conflict when both are already in sync (ESC menu)
- [x] `test_sync_does_not_affect_main_menu` — MainMenu state is not affected by GameClock.paused
- [x] `test_game_clock_time_does_not_advance_when_paused` — clock hour stays frozen when paused

Closes #1768

🤖 Generated with [Claude Code](https://claude.com/claude-code)