### PR TITLE
Fix tutorial control text — references incorrect keys

### DIFF
--- a/crates/simulation/src/tutorial.rs
+++ b/crates/simulation/src/tutorial.rs
@@ -114,7 +114,7 @@ impl TutorialStep {
             }
             TutorialStep::ManageBudget => {
                 "As your city grows, you will earn tax revenue and incur \
-                 expenses. Press 'B' or check the info panel to review your \
+                 expenses. Check the info panel to review your \
                  budget. You can adjust the tax rate to balance income and \
                  spending. Your treasury is shown in the top bar."
             }
@@ -150,7 +150,7 @@ impl TutorialStep {
             TutorialStep::ObserveGrowth => {
                 "Hint: Press Space to unpause. Wait for buildings and population to reach 5."
             }
-            TutorialStep::ManageBudget => "Hint: Press 'B' to open the budget panel.",
+            TutorialStep::ManageBudget => "Hint: Click 'Budget Details...' in the info panel to see the full budget.",
             TutorialStep::Completed => "You can now close this window.",
         }
     }


### PR DESCRIPTION
## Summary
- The tutorial ManageBudget step incorrectly told players to "Press 'B'" to open the budget panel, but `B` is bound to the **Bulldoze tool** (since issue #905)
- The budget panel has no keyboard shortcut — it is accessed via the "Budget Details..." button in the info panel
- Updated both the step description and hint text to reference the correct UI path instead of the wrong key

## Changes
- `crates/simulation/src/tutorial.rs`: Removed incorrect `Press 'B'` reference from ManageBudget description; updated hint to say "Click 'Budget Details...' in the info panel"

## Test plan
- [ ] Launch the game with tutorial active and reach the ManageBudget step
- [ ] Verify the description no longer mentions pressing 'B'
- [ ] Verify the hint correctly directs players to the info panel's Budget Details button
- [ ] Verify pressing 'B' activates the Bulldoze tool (not the budget panel)

Closes #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)