### PR TITLE
P0-13: Show explicit placement failure reasons in status messages

### DIFF
--- a/crates/rendering/src/auto_grid_draw.rs
+++ b/crates/rendering/src/auto_grid_draw.rs
@@ -111,7 +111,7 @@ pub fn handle_auto_grid_tool(
             if budget.treasury < plan.total_cost {
                 status.set(
                     format!(
-                        "Not enough money (need ${:.0}, have ${:.0})",
+                        "Not enough funds (need ${:.0}, have ${:.0})",
                         plan.total_cost, budget.treasury
                     ),
                     true,

--- a/crates/rendering/src/freehand_draw.rs
+++ b/crates/rendering/src/freehand_draw.rs
@@ -153,7 +153,7 @@ pub fn handle_freehand_draw(
         let total_cost = road_type.cost() * approx_cells as f64;
 
         if budget.treasury < total_cost {
-            status.set("Not enough money for freehand road", true);
+            status.set(format!("Not enough funds (need ${:.0}, have ${:.0})", total_cost, budget.treasury), true);
             freehand.reset_stroke();
             return;
         }

--- a/crates/rendering/src/input/keyboard.rs
+++ b/crates/rendering/src/input/keyboard.rs
@@ -207,7 +207,7 @@ pub fn handle_tree_tool(
                 status.set("Cell occupied by a building", true);
                 false
             } else if budget.treasury < simulation::trees::TREE_PLANT_COST {
-                status.set("Not enough money", true);
+                status.set(format!("Not enough funds (need ${:.0}, have ${:.0})", simulation::trees::TREE_PLANT_COST, budget.treasury), true);
                 false
             } else {
                 budget.treasury -= simulation::trees::TREE_PLANT_COST;

--- a/crates/rendering/src/input/placement.rs
+++ b/crates/rendering/src/input/placement.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use simulation::economy::CityBudget;
-use simulation::grid::{RoadType, WorldGrid, ZoneType};
+use simulation::grid::{CellType, RoadType, WorldGrid, ZoneType};
 use simulation::roads::RoadNetwork;
 use simulation::services::{self, ServiceType};
 use simulation::undo_redo::CityAction;
@@ -11,8 +11,37 @@ use simulation::utilities::UtilityType;
 use super::types::StatusMessage;
 
 // ---------------------------------------------------------------------------
+// Shared helpers for formatting money messages
+// ---------------------------------------------------------------------------
+
+fn not_enough_funds_msg(need: f64, have: f64) -> String {
+    format!("Not enough funds (need ${:.0}, have ${:.0})", need, have)
+}
+
+// ---------------------------------------------------------------------------
 // Helper: road placement with cost
 // ---------------------------------------------------------------------------
+
+/// Diagnose why a road cannot be placed at (gx, gy) and set a status message.
+fn diagnose_road_failure(
+    grid: &WorldGrid,
+    gx: usize,
+    gy: usize,
+    status: &mut StatusMessage,
+) {
+    if !grid.in_bounds(gx, gy) {
+        status.set("Cannot place road outside map bounds", true);
+        return;
+    }
+    let cell = grid.get(gx, gy);
+    if cell.cell_type == CellType::Water {
+        status.set("Cannot place road on water", true);
+    } else if cell.cell_type == CellType::Road {
+        status.set("Road already exists here", true);
+    } else {
+        status.set("Cannot place road here", true);
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn place_road_if_affordable(
@@ -38,11 +67,14 @@ pub(crate) fn place_road_if_affordable(
             });
             true
         } else {
+            if buttons.just_pressed(MouseButton::Left) {
+                diagnose_road_failure(grid, gx, gy, status);
+            }
             false
         }
     } else {
         if buttons.just_pressed(MouseButton::Left) {
-            status.set("Not enough money", true);
+            status.set(not_enough_funds_msg(cost, budget.treasury), true);
         }
         false
     }
@@ -57,6 +89,8 @@ pub(crate) enum ZoneResult {
     NotAdjacentToRoad,
     OutsideUgb,
     InvalidCell,
+    AlreadyZoned,
+    OccupiedByBuilding,
 }
 
 pub(crate) fn try_zone(
@@ -67,11 +101,14 @@ pub(crate) fn try_zone(
     ugb: &UrbanGrowthBoundary,
 ) -> ZoneResult {
     let cell = grid.get(x, y);
-    if cell.cell_type != simulation::grid::CellType::Grass {
+    if cell.building_id.is_some() {
+        return ZoneResult::OccupiedByBuilding;
+    }
+    if cell.cell_type != CellType::Grass {
         return ZoneResult::InvalidCell;
     }
     if cell.zone == zone {
-        return ZoneResult::InvalidCell;
+        return ZoneResult::AlreadyZoned;
     }
     // Urban Growth Boundary: block zoning outside the boundary (ZONE-009).
     if !ugb.allows_zoning(x, y) {
@@ -80,11 +117,32 @@ pub(crate) fn try_zone(
     let (n4, n4c) = grid.neighbors4(x, y);
     let has_road = n4[..n4c]
         .iter()
-        .any(|(nx, ny)| grid.get(*nx, *ny).cell_type == simulation::grid::CellType::Road);
+        .any(|(nx, ny)| grid.get(*nx, *ny).cell_type == CellType::Road);
     if !has_road {
         return ZoneResult::NotAdjacentToRoad;
     }
     ZoneResult::Success
+}
+
+fn zone_failure_message(result: &ZoneResult) -> Option<&'static str> {
+    match result {
+        ZoneResult::NotAdjacentToRoad => {
+            Some("Zone must be adjacent to a road")
+        }
+        ZoneResult::OutsideUgb => {
+            Some("Cannot zone outside urban growth boundary")
+        }
+        ZoneResult::InvalidCell => {
+            Some("Cannot zone here — invalid terrain")
+        }
+        ZoneResult::AlreadyZoned => {
+            Some("Already zoned as this type")
+        }
+        ZoneResult::OccupiedByBuilding => {
+            Some("Cannot zone — cell occupied by a building")
+        }
+        ZoneResult::Success => None,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -127,14 +185,9 @@ pub(crate) fn apply_zone_brush(
             let ux = cx as usize;
             let uy = cy as usize;
             if grid.in_bounds(ux, uy) {
-                match try_zone(grid, ux, uy, zone, ugb) {
-                    ZoneResult::NotAdjacentToRoad => {
-                        status.set("Zone must be adjacent to road", true);
-                    }
-                    ZoneResult::OutsideUgb => {
-                        status.set("Cannot zone outside urban growth boundary", true);
-                    }
-                    _ => {}
+                let result = try_zone(grid, ux, uy, zone, ugb);
+                if let Some(msg) = zone_failure_message(&result) {
+                    status.set(msg, true);
                 }
             }
         }
@@ -144,7 +197,10 @@ pub(crate) fn apply_zone_brush(
     let total_cost = valid_cells.len() as f64 * cost_per_cell;
     if budget.treasury < total_cost {
         if buttons.just_pressed(MouseButton::Left) {
-            status.set("Not enough money", true);
+            status.set(
+                not_enough_funds_msg(total_cost, budget.treasury),
+                true,
+            );
         }
         return Vec::new();
     }
@@ -155,6 +211,59 @@ pub(crate) fn apply_zone_brush(
         grid.get_mut(*gx, *gy).zone = zone;
     }
     valid_cells
+}
+
+// ---------------------------------------------------------------------------
+// Helper: diagnose building/utility placement failure
+// ---------------------------------------------------------------------------
+
+/// Check a single cell and return a specific error message if it cannot
+/// accept a building placement.
+fn diagnose_cell_failure(grid: &WorldGrid, gx: usize, gy: usize) -> &'static str {
+    if !grid.in_bounds(gx, gy) {
+        return "Cannot place outside map bounds";
+    }
+    let cell = grid.get(gx, gy);
+    if cell.building_id.is_some() {
+        return "Overlaps existing building";
+    }
+    match cell.cell_type {
+        CellType::Water => "Cannot place on water",
+        CellType::Road => "Cannot place on a road",
+        _ => "Cannot place here — invalid terrain",
+    }
+}
+
+/// Diagnose why a multi-cell service footprint cannot be placed and return
+/// the most relevant error message.
+fn diagnose_service_failure(
+    grid: &WorldGrid,
+    gx: usize,
+    gy: usize,
+    fw: usize,
+    fh: usize,
+) -> &'static str {
+    for dy in 0..fh {
+        for dx in 0..fw {
+            let cx = gx + dx;
+            let cy = gy + dy;
+            if !grid.in_bounds(cx, cy) {
+                return "Building footprint extends outside map bounds";
+            }
+            let cell = grid.get(cx, cy);
+            if cell.building_id.is_some() {
+                return "Overlaps existing building";
+            }
+            if cell.cell_type != CellType::Grass {
+                return match cell.cell_type {
+                    CellType::Water => "Cannot place on water",
+                    CellType::Road => "Building footprint overlaps a road",
+                    _ => "Cannot place here — invalid terrain",
+                };
+            }
+        }
+    }
+    "Cannot place here"
 }
 
 // ---------------------------------------------------------------------------
@@ -185,11 +294,15 @@ pub(crate) fn place_utility_if_affordable(
             });
             true
         } else {
+            if buttons.just_pressed(MouseButton::Left) {
+                let msg = diagnose_cell_failure(grid, gx, gy);
+                status.set(msg, true);
+            }
             false
         }
     } else {
         if buttons.just_pressed(MouseButton::Left) {
-            status.set("Not enough money", true);
+            status.set(not_enough_funds_msg(cost, budget.treasury), true);
         }
         false
     }
@@ -224,11 +337,16 @@ pub(crate) fn place_service_if_affordable(
             });
             true
         } else {
+            if buttons.just_pressed(MouseButton::Left) {
+                let (fw, fh) = ServiceBuilding::footprint(service_type);
+                let msg = diagnose_service_failure(grid, gx, gy, fw, fh);
+                status.set(msg, true);
+            }
             false
         }
     } else {
         if buttons.just_pressed(MouseButton::Left) {
-            status.set("Not enough money", true);
+            status.set(not_enough_funds_msg(cost, budget.treasury), true);
         }
         false
     }

--- a/crates/rendering/src/input/road_drawing.rs
+++ b/crates/rendering/src/input/road_drawing.rs
@@ -124,7 +124,13 @@ fn commit_straight_segment(
     let approx_cells = ((end_pos - start_pos).length() / CELL_SIZE).ceil() as usize;
     let total_cost = road_type.cost() * approx_cells as f64;
     if budget.treasury < total_cost {
-        status.set("Not enough money", true);
+        status.set(
+            format!(
+                "Not enough funds (need ${:.0}, have ${:.0})",
+                total_cost, budget.treasury
+            ),
+            true,
+        );
         return;
     }
 
@@ -183,7 +189,13 @@ fn commit_curved_segment(
     let approx_cells = (arc_len / CELL_SIZE).ceil() as usize;
     let total_cost = road_type.cost() * approx_cells as f64;
     if budget.treasury < total_cost {
-        status.set("Not enough money", true);
+        status.set(
+            format!(
+                "Not enough funds (need ${:.0}, have ${:.0})",
+                total_cost, budget.treasury
+            ),
+            true,
+        );
         return;
     }
 


### PR DESCRIPTION
## Summary
- Replace all generic "Not enough money" messages with specific amounts: "Not enough funds (need $X, have $Y)"
- Add diagnostic error messages when building/utility/road placement fails silently (overlaps, wrong terrain, water, existing road)
- Add more granular zone failure reasons (already zoned, occupied by building, invalid terrain)
- All error messages use `is_error: true` for red toast display

## Changes
- `crates/rendering/src/input/placement.rs` — Added `diagnose_road_failure`, `diagnose_cell_failure`, `diagnose_service_failure` helpers; enriched `ZoneResult` enum with `AlreadyZoned` and `OccupiedByBuilding` variants; added `zone_failure_message` helper; updated all money messages to include amounts
- `crates/rendering/src/input/road_drawing.rs` — Updated freeform road drawing money messages with amounts
- `crates/rendering/src/input/keyboard.rs` — Updated tree planting money message with amounts
- `crates/rendering/src/freehand_draw.rs` — Updated freehand road money message with amounts
- `crates/rendering/src/auto_grid_draw.rs` — Normalized wording to "funds" for consistency

Closes #1772

## Test plan
- [ ] Place a building on water — should show "Cannot place on water"
- [ ] Place a building overlapping another — should show "Overlaps existing building"
- [ ] Place a road on water — should show "Cannot place road on water"
- [ ] Place a road on existing road — should show "Road already exists here"
- [ ] Zone a cell not adjacent to road — should show "Zone must be adjacent to a road"
- [ ] Place any building with insufficient funds — should show "Not enough funds (need $X, have $Y)"
- [ ] Place a large service building partially off map — should show "Building footprint extends outside map bounds"

🤖 Generated with [Claude Code](https://claude.com/claude-code)