### PR TITLE
CR-04: Resolve keybinding conflicts (WASD, M, G)

### DIFF
--- a/crates/rendering/src/input/keyboard.rs
+++ b/crates/rendering/src/input/keyboard.rs
@@ -33,7 +33,7 @@ pub fn toggle_grid_snap(
     }
 }
 
-/// Toggle curve drawing mode with the G key (configurable via keybindings).
+/// Toggle curve drawing mode with Shift+G (configurable via keybindings).
 pub fn toggle_curve_draw_mode(
     keys: Res<ButtonInput<KeyCode>>,
     mut curve_mode: ResMut<CurveDrawMode>,
@@ -48,7 +48,7 @@ pub fn toggle_curve_draw_mode(
             draw_state.phase = DrawPhase::Idle;
         }
         if curve_mode.enabled {
-            status.set("Curve drawing mode ON (G to toggle off)", false);
+            status.set("Curve drawing mode ON (Shift+G to toggle off)", false);
         } else {
             status.set("Curve drawing mode OFF", false);
         }

--- a/crates/simulation/src/audio_settings.rs
+++ b/crates/simulation/src/audio_settings.rs
@@ -175,7 +175,7 @@ impl Saveable for AudioSettings {
 // Mute toggle system
 // =============================================================================
 
-/// System that listens for the `M` key to toggle audio mute.
+/// System that listens for `Shift+M` to toggle audio mute.
 ///
 /// Uses `Option<Res<ButtonInput<KeyCode>>>` so the system is a no-op in
 /// headless test contexts where Bevy's `InputPlugin` is not present.
@@ -187,8 +187,9 @@ fn mute_toggle_system(
     let Some(keys) = keys else {
         return;
     };
-    // M key for mute toggle (not bound in the keybindings system).
-    if keys.just_pressed(KeyCode::KeyM) {
+    // Shift+M for mute toggle (plain M is used for minimap).
+    let shift_held = keys.pressed(KeyCode::ShiftLeft) || keys.pressed(KeyCode::ShiftRight);
+    if keys.just_pressed(KeyCode::KeyM) && shift_held {
         settings.toggle_mute();
     }
 }

--- a/crates/simulation/src/keybindings/bindings.rs
+++ b/crates/simulation/src/keybindings/bindings.rs
@@ -191,7 +191,7 @@ impl Default for KeyBindings {
             tool_bulldoze: KeyBinding::simple(KeyCode::KeyB),
             tool_inspect: KeyBinding::simple(KeyCode::KeyI),
             toggle_grid_snap: KeyBinding::simple(KeyCode::KeyF),
-            toggle_curve_draw: KeyBinding::simple(KeyCode::KeyG),
+            toggle_curve_draw: KeyBinding { key: KeyCode::KeyG, ctrl: false, shift: true },
             delete_building: KeyBinding::simple(KeyCode::Delete),
             delete_building_alt: KeyBinding::simple(KeyCode::Backspace),
             escape: KeyBinding::simple(KeyCode::Escape),

--- a/crates/ui/src/minimap.rs
+++ b/crates/ui/src/minimap.rs
@@ -124,7 +124,8 @@ fn minimap_toggle_keybind(
     if contexts.ctx_mut().wants_keyboard_input() {
         return;
     }
-    if keyboard.just_pressed(KeyCode::KeyM) {
+    let shift_held = keyboard.pressed(KeyCode::ShiftLeft) || keyboard.pressed(KeyCode::ShiftRight);
+    if keyboard.just_pressed(KeyCode::KeyM) && !shift_held {
         state.visible = !state.visible;
     }
 }

--- a/crates/ui/src/two_key_shortcuts/categories/placement.rs
+++ b/crates/ui/src/two_key_shortcuts/categories/placement.rs
@@ -202,9 +202,9 @@ pub(super) fn placement_categories() -> Vec<ShortcutCategory> {
             ],
         },
         ShortcutCategory {
-            key: KeyCode::KeyS,
+            key: KeyCode::KeyH,
             label: "Education",
-            key_hint: "S",
+            key_hint: "H",
             items: vec![
                 ShortcutItem {
                     name: "Kindergarten",

--- a/crates/ui/src/two_key_shortcuts/categories/views_and_tools.rs
+++ b/crates/ui/src/two_key_shortcuts/categories/views_and_tools.rs
@@ -84,9 +84,9 @@ pub(super) fn views_and_tools_categories() -> Vec<ShortcutCategory> {
             ],
         },
         ShortcutCategory {
-            key: KeyCode::KeyW,
+            key: KeyCode::KeyY,
             label: "Terrain",
-            key_hint: "W",
+            key_hint: "Y",
             items: vec![
                 ShortcutItem {
                     name: "Raise",
@@ -111,9 +111,9 @@ pub(super) fn views_and_tools_categories() -> Vec<ShortcutCategory> {
             ],
         },
         ShortcutCategory {
-            key: KeyCode::KeyD,
+            key: KeyCode::KeyO,
             label: "Districts",
-            key_hint: "D",
+            key_hint: "O",
             items: vec![
                 ShortcutItem {
                     name: "Downtown",

--- a/crates/ui/src/two_key_shortcuts/input.rs
+++ b/crates/ui/src/two_key_shortcuts/input.rs
@@ -144,6 +144,12 @@ pub(crate) fn two_key_input_system(
     }
 
     // --- No pending category: check for category key presses ---
+    // Skip if modifier keys are held — those are separate bindings (e.g. Shift+G for curve draw).
+    let shift_held = keyboard.pressed(KeyCode::ShiftLeft) || keyboard.pressed(KeyCode::ShiftRight);
+    let ctrl_held = keyboard.pressed(KeyCode::ControlLeft) || keyboard.pressed(KeyCode::ControlRight);
+    if shift_held || ctrl_held {
+        return;
+    }
     for (idx, cat) in categories.iter().enumerate() {
         if keyboard.just_pressed(cat.key) {
             state.pending_category = Some(idx);


### PR DESCRIPTION
## Summary
- Reassigned two-key shortcut categories that conflicted with WASD camera pan keys: **Terrain W->Y**, **Education S->H**, **Districts D->O**
- Fixed M dual-bind: **minimap stays on plain M**, **audio mute moved to Shift+M**
- Fixed G dual-bind: **curve draw toggle moved to Shift+G**, **Sanitation category stays on plain G**
- Added modifier guard in two-key input system so Shift/Ctrl+key combos don't accidentally trigger category popups
- Updated minimap toggle to ignore Shift+M (so muting audio doesn't toggle minimap)

Closes #1821

## Test plan
- [ ] WASD moves camera without triggering shortcut popups (Terrain, Education, Districts)
- [ ] Y opens Terrain two-key category, H opens Education, O opens Districts
- [ ] M toggles minimap only (no audio mute side-effect)
- [ ] Shift+M toggles audio mute only (no minimap side-effect)
- [ ] G opens Sanitation two-key category (no curve draw toggle)
- [ ] Shift+G toggles curve draw mode (no Sanitation popup)
- [ ] Help overlay (F1) shows updated keybindings (Shift+G for curve draw)
- [ ] All other keybindings still function as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)