### PR TITLE
AGENT-A1+A2: Define GameAction types, ActionResult, and ActionQueue

### DIFF
--- a/crates/simulation/src/game_actions/actions.rs
+++ b/crates/simulation/src/game_actions/actions.rs
@@ -1,0 +1,75 @@
+//! The canonical `GameAction` enum — every gameplay-affecting operation the
+//! player, AI agent, or replay system can perform.
+
+use serde::{Deserialize, Serialize};
+
+use crate::grid::{RoadType, ZoneType};
+use crate::services::ServiceType;
+use crate::utilities::UtilityType;
+
+/// A single, atomic game action.
+///
+/// Every mutation of simulation state should eventually flow through this
+/// enum so that actions can be recorded, replayed, and validated uniformly.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum GameAction {
+    // ── Session ──────────────────────────────────────────────────────────
+    /// Start a new game with the given random seed.
+    NewGame { seed: u64 },
+
+    // ── Simulation control ──────────────────────────────────────────────
+    /// Pause or unpause the simulation.
+    SetPaused { paused: bool },
+
+    /// Set the simulation speed multiplier (1 = normal, 2 = fast, 3 = fastest).
+    SetSpeed { speed: u32 },
+
+    // ── Road building ───────────────────────────────────────────────────
+    /// Place a straight road line between two grid cells (inclusive).
+    PlaceRoadLine {
+        start: (u32, u32),
+        end: (u32, u32),
+        road_type: RoadType,
+    },
+
+    // ── Zoning ──────────────────────────────────────────────────────────
+    /// Paint a zone over an axis-aligned rectangle of cells.
+    ZoneRect {
+        min: (u32, u32),
+        max: (u32, u32),
+        zone_type: ZoneType,
+    },
+
+    // ── Infrastructure placement ────────────────────────────────────────
+    /// Place a utility building (power plant, water tower, etc.).
+    PlaceUtility {
+        pos: (u32, u32),
+        utility_type: UtilityType,
+    },
+
+    /// Place a service building (fire station, school, park, etc.).
+    PlaceService {
+        pos: (u32, u32),
+        service_type: ServiceType,
+    },
+
+    // ── Demolition ──────────────────────────────────────────────────────
+    /// Bulldoze everything inside an axis-aligned rectangle.
+    BulldozeRect { min: (u32, u32), max: (u32, u32) },
+
+    // ── Economy ─────────────────────────────────────────────────────────
+    /// Set per-zone tax rates (values are fractions, e.g. 0.09 = 9 %).
+    SetTaxRates {
+        residential: f32,
+        commercial: f32,
+        industrial: f32,
+        office: f32,
+    },
+
+    // ── Persistence ─────────────────────────────────────────────────────
+    /// Save the current game to disk.
+    Save { path: String },
+
+    /// Load a saved game from disk.
+    Load { path: String },
+}

--- a/crates/simulation/src/game_actions/mod.rs
+++ b/crates/simulation/src/game_actions/mod.rs
@@ -1,0 +1,13 @@
+//! Canonical gameplay action types, error codes, and action queue.
+//!
+//! This module defines the `GameAction` enum representing every player or
+//! agent action, `ActionResult` / `ActionError` for structured outcomes,
+//! and `ActionQueue` for enqueuing actions from any source.
+
+mod actions;
+mod queue;
+mod results;
+
+pub use actions::*;
+pub use queue::*;
+pub use results::*;

--- a/crates/simulation/src/game_actions/queue.rs
+++ b/crates/simulation/src/game_actions/queue.rs
@@ -1,0 +1,61 @@
+//! Action queue resource for batching actions from any source.
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::GameAction;
+
+/// Identifies the origin of an action — useful for logging, replay
+/// filtering, and trust decisions.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ActionSource {
+    /// Direct player input (mouse/keyboard/UI).
+    Player,
+    /// An autonomous AI agent operating on the city.
+    Agent,
+    /// A replayed action from a recorded session.
+    Replay,
+}
+
+/// A single action together with metadata about when and who enqueued it.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueuedAction {
+    /// The simulation tick at which this action was enqueued.
+    pub tick: u64,
+    /// Who or what submitted this action.
+    pub source: ActionSource,
+    /// The action payload.
+    pub action: GameAction,
+}
+
+/// FIFO queue of pending game actions.
+///
+/// Systems that accept player input, agent commands, or replay data push
+/// actions here. A future executor system will drain and apply them each
+/// frame.
+#[derive(Resource, Default, Debug)]
+pub struct ActionQueue {
+    pending: Vec<QueuedAction>,
+}
+
+impl ActionQueue {
+    /// Enqueue a new action.
+    pub fn push(&mut self, action: QueuedAction) {
+        self.pending.push(action);
+    }
+
+    /// Drain all pending actions in FIFO order, leaving the queue empty.
+    pub fn drain(&mut self) -> Vec<QueuedAction> {
+        std::mem::take(&mut self.pending)
+    }
+
+    /// Returns `true` when there are no pending actions.
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    /// Number of pending actions.
+    pub fn len(&self) -> usize {
+        self.pending.len()
+    }
+}

--- a/crates/simulation/src/game_actions/results.rs
+++ b/crates/simulation/src/game_actions/results.rs
@@ -1,0 +1,38 @@
+//! Structured outcomes for executed game actions.
+
+use serde::{Deserialize, Serialize};
+
+/// The outcome of executing a [`super::GameAction`].
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum ActionResult {
+    /// The action was applied successfully.
+    Success,
+    /// The action failed for a known reason.
+    Error(ActionError),
+}
+
+/// Fine-grained error codes returned when an action cannot be applied.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ActionError {
+    /// A coordinate in the action falls outside the world grid.
+    OutOfBounds,
+    /// The city treasury cannot cover the cost of this action.
+    InsufficientFunds,
+    /// One or more target cells are occupied by a structure that prevents
+    /// placement.
+    BlockedByExistingStructure,
+    /// The requested road segment has invalid geometry (e.g. zero length,
+    /// non-axis-aligned when straight lines are required).
+    InvalidRoadGeometry,
+    /// Zones must be adjacent to at least one road cell.
+    ZoneNotAdjacentToRoad,
+    /// The requested feature is not yet unlocked (milestones, research, etc.).
+    FeatureLocked,
+    /// One or more parameters are semantically invalid (e.g. negative tax
+    /// rate, unknown speed level).
+    InvalidParameters,
+    /// A save operation failed.
+    SaveFailed(String),
+    /// A load operation failed.
+    LoadFailed(String),
+}


### PR DESCRIPTION
## Summary
- New `game_actions/` module with canonical gameplay action types
- `GameAction` enum: MVP set (roads, zones, utilities, services, bulldoze, tax, speed, save/load)
- `ActionResult` with structured error codes (OutOfBounds, InsufficientFunds, etc.)
- `ActionQueue` resource for enqueuing actions from any source (player, agent, replay)
- All types are Serialize + Deserialize for protocol and replay use
- Foundation for agent mode, replay system, and canonical action authority

Closes #1871
Closes #1872

## Test plan
- [ ] Types compile and are importable from simulation crate
- [ ] Serde roundtrip works for all variants
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)