### PR TITLE
AGENT-C4: Deterministic state hashing for verification

### DIFF
--- a/crates/simulation/src/integration_tests/state_hash_tests.rs
+++ b/crates/simulation/src/integration_tests/state_hash_tests.rs
@@ -1,0 +1,76 @@
+//! Integration tests for deterministic state hashing (#1883).
+
+use crate::economy::CityBudget;
+use crate::state_hash::StateHash;
+use crate::test_harness::TestCity;
+
+#[test]
+fn test_identical_cities_produce_same_hash() {
+    let mut city_a = TestCity::new();
+    let mut city_b = TestCity::new();
+
+    // Advance both by the same number of ticks
+    city_a.tick(100);
+    city_b.tick(100);
+
+    let hash_a = city_a.resource::<StateHash>().clone();
+    let hash_b = city_b.resource::<StateHash>().clone();
+
+    assert_eq!(hash_a.tick, hash_b.tick, "Tick counters should match");
+    assert_eq!(
+        hash_a.hash, hash_b.hash,
+        "Identical cities after same ticks must produce identical hashes"
+    );
+}
+
+#[test]
+fn test_state_hash_changes_after_treasury_modification() {
+    let mut city = TestCity::new();
+
+    // Advance to get a baseline hash
+    city.tick(50);
+    let hash_before = city.resource::<StateHash>().hash;
+
+    // Modify treasury
+    {
+        let world = city.world_mut();
+        world.resource_mut::<CityBudget>().treasury += 999_999.0;
+    }
+
+    // Advance one more tick so the hash recomputes
+    city.tick(1);
+    let hash_after = city.resource::<StateHash>().hash;
+
+    assert_ne!(
+        hash_before, hash_after,
+        "Hash must change when treasury is modified"
+    );
+}
+
+#[test]
+fn test_state_hash_is_nonzero_after_ticks() {
+    let mut city = TestCity::new();
+    city.tick(10);
+
+    let hash = city.resource::<StateHash>();
+    assert_eq!(hash.tick, 10);
+    // The hash should not be zero (extremely unlikely with FNV-1a)
+    assert_ne!(hash.hash, 0, "Hash should be non-zero after simulation");
+}
+
+#[test]
+fn test_state_hash_differs_between_ticks() {
+    let mut city = TestCity::new();
+
+    city.tick(10);
+    let hash_at_10 = city.resource::<StateHash>().hash;
+
+    city.tick(1);
+    let hash_at_11 = city.resource::<StateHash>().hash;
+
+    // Since the tick counter itself is hashed, consecutive ticks should differ
+    assert_ne!(
+        hash_at_10, hash_at_11,
+        "Hash should differ between consecutive ticks"
+    );
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -363,4 +363,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
 
     // Input action recorder for deterministic replay (STAB-03)
     app.add_plugins(input_recorder::InputRecorderPlugin);
+
+    // Deterministic state hashing for replay verification (#1883)
+    app.add_plugins(state_hash::StateHashPlugin);
 }

--- a/crates/simulation/src/state_hash.rs
+++ b/crates/simulation/src/state_hash.rs
@@ -1,0 +1,214 @@
+//! Deterministic state hashing for replay verification.
+//!
+//! Computes a 64-bit hash of key simulation state every tick, stored in the
+//! `StateHash` resource. The hash is computed in a fixed order over:
+//!
+//! 1. Tick counter
+//! 2. Treasury (f64 → bits)
+//! 3. Population count
+//! 4. Average happiness (f32 → bits)
+//! 5. SimRng internal state (word_pos, stream)
+//! 6. Grid cells in row-major order (road_type, zone_type)
+//!
+//! All data is iterated in deterministic order (no HashMap, no entity IDs).
+//! Float values are converted to their bit representation before hashing.
+
+use std::hash::{Hash, Hasher};
+
+use bevy::prelude::*;
+
+use crate::economy::CityBudget;
+use crate::grid::WorldGrid;
+use crate::sim_rng::SimRng;
+use crate::stats::CityStats;
+use crate::SimulationSet;
+use crate::TickCounter;
+
+/// Stores the deterministic hash computed at the end of each simulation tick.
+#[derive(Resource, Default, Clone, Debug)]
+pub struct StateHash {
+    /// The tick at which this hash was computed.
+    pub tick: u64,
+    /// The 64-bit FNV-1a hash of simulation state.
+    pub hash: u64,
+}
+
+// ---------------------------------------------------------------------------
+// FNV-1a hasher (deterministic, no random seed)
+// ---------------------------------------------------------------------------
+
+/// A simple FNV-1a hasher that produces deterministic output regardless of
+/// platform or Rust version. Unlike `DefaultHasher`, this is not randomized.
+struct Fnv1aHasher {
+    state: u64,
+}
+
+impl Fnv1aHasher {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x00000100000001B3;
+
+    fn new() -> Self {
+        Self {
+            state: Self::FNV_OFFSET_BASIS,
+        }
+    }
+}
+
+impl Hasher for Fnv1aHasher {
+    fn finish(&self) -> u64 {
+        self.state
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.state ^= byte as u64;
+            self.state = self.state.wrapping_mul(Self::FNV_PRIME);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public convenience function
+// ---------------------------------------------------------------------------
+
+/// Compute a deterministic hash of the current simulation state.
+///
+/// This function can be called from tests or replay verification without
+/// needing the ECS system to have run.
+pub fn compute_state_hash(
+    tick: u64,
+    treasury: f64,
+    population: u32,
+    average_happiness: f32,
+    rng_word_pos: u128,
+    rng_stream: u64,
+    grid: &WorldGrid,
+) -> u64 {
+    let mut hasher = Fnv1aHasher::new();
+
+    // 1. Tick counter
+    tick.hash(&mut hasher);
+
+    // 2. Treasury (f64 → deterministic bits)
+    treasury.to_bits().hash(&mut hasher);
+
+    // 3. Population count
+    population.hash(&mut hasher);
+
+    // 4. Average happiness (f32 → deterministic bits)
+    average_happiness.to_bits().hash(&mut hasher);
+
+    // 5. SimRng state
+    rng_word_pos.hash(&mut hasher);
+    rng_stream.hash(&mut hasher);
+
+    // 6. Grid cells in row-major order
+    for cell in &grid.cells {
+        cell.road_type.hash(&mut hasher);
+        cell.zone.hash(&mut hasher);
+    }
+
+    hasher.finish()
+}
+
+// ---------------------------------------------------------------------------
+// ECS system
+// ---------------------------------------------------------------------------
+
+fn update_state_hash(
+    tick: Res<TickCounter>,
+    budget: Res<CityBudget>,
+    stats: Res<CityStats>,
+    sim_rng: Res<SimRng>,
+    grid: Res<WorldGrid>,
+    mut state_hash: ResMut<StateHash>,
+) {
+    let hash = compute_state_hash(
+        tick.0,
+        budget.treasury,
+        stats.population,
+        stats.average_happiness,
+        sim_rng.0.get_word_pos(),
+        sim_rng.0.get_stream(),
+        &grid,
+    );
+
+    state_hash.tick = tick.0;
+    state_hash.hash = hash;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+pub struct StateHashPlugin;
+
+impl Plugin for StateHashPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<StateHash>()
+            .add_systems(
+                FixedUpdate,
+                update_state_hash.in_set(SimulationSet::PostSim),
+            );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grid::WorldGrid;
+
+    #[test]
+    fn test_fnv1a_deterministic() {
+        let mut h1 = Fnv1aHasher::new();
+        let mut h2 = Fnv1aHasher::new();
+        42u64.hash(&mut h1);
+        42u64.hash(&mut h2);
+        assert_eq!(h1.finish(), h2.finish());
+    }
+
+    #[test]
+    fn test_fnv1a_different_inputs_differ() {
+        let mut h1 = Fnv1aHasher::new();
+        let mut h2 = Fnv1aHasher::new();
+        1u64.hash(&mut h1);
+        2u64.hash(&mut h2);
+        assert_ne!(h1.finish(), h2.finish());
+    }
+
+    #[test]
+    fn test_compute_state_hash_deterministic() {
+        let grid = WorldGrid::new(4, 4);
+        let h1 = compute_state_hash(10, 50000.0, 100, 75.0, 0, 0, &grid);
+        let h2 = compute_state_hash(10, 50000.0, 100, 75.0, 0, 0, &grid);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_compute_state_hash_differs_on_treasury() {
+        let grid = WorldGrid::new(4, 4);
+        let h1 = compute_state_hash(10, 50000.0, 100, 75.0, 0, 0, &grid);
+        let h2 = compute_state_hash(10, 50001.0, 100, 75.0, 0, 0, &grid);
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn test_compute_state_hash_differs_on_tick() {
+        let grid = WorldGrid::new(4, 4);
+        let h1 = compute_state_hash(10, 50000.0, 100, 75.0, 0, 0, &grid);
+        let h2 = compute_state_hash(11, 50000.0, 100, 75.0, 0, 0, &grid);
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn test_compute_state_hash_differs_on_population() {
+        let grid = WorldGrid::new(4, 4);
+        let h1 = compute_state_hash(10, 50000.0, 100, 75.0, 0, 0, &grid);
+        let h2 = compute_state_hash(10, 50000.0, 101, 75.0, 0, 0, &grid);
+        assert_ne!(h1, h2);
+    }
+}


### PR DESCRIPTION
## Summary
- New `StateHash` resource computed every tick in `PostSim`
- Deterministic FNV-1a hash of: tick counter, treasury, population, average happiness, SimRng state (word_pos + stream), and grid cells (road_type + zone in row-major order)
- Custom `Fnv1aHasher` instead of `DefaultHasher` (which uses random seeds) for cross-run determinism
- Float values hashed via `to_bits()` — no HashMap iteration anywhere
- Public `compute_state_hash()` convenience function for use in tests and replay verification
- Integration tests prove identical TestCity runs produce identical hashes, and state mutations produce different hashes

Closes #1883

## Test plan
- [x] Two identical TestCity runs produce same hash after 100 ticks
- [x] Modifying treasury produces different hash
- [x] Hash is non-zero after simulation ticks
- [x] Hash differs between consecutive ticks (tick counter itself is hashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)