### PR TITLE
AGENT-A2: Add saveable action queue resource

### DIFF
--- a/crates/simulation/src/game_actions/actions.rs
+++ b/crates/simulation/src/game_actions/actions.rs
@@ -1,53 +1,54 @@
+use bitcode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::grid::{RoadType, ZoneType};
-use crate::utilities::UtilityType;
 use crate::services::ServiceType;
+use crate::utilities::UtilityType;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Encode, Decode)]
 pub enum GameAction {
-    NewGame { 
-        seed: u64, 
-        map_size: Option<u32> 
+    NewGame {
+        seed: u64,
+        map_size: Option<u32>,
     },
-    SetPaused { 
-        paused: bool 
+    SetPaused {
+        paused: bool,
     },
-    SetSpeed { 
-        speed: u32 
+    SetSpeed {
+        speed: u32,
     },
-    PlaceRoadLine { 
-        start: (u32, u32), 
-        end: (u32, u32), 
-        road_type: RoadType 
+    PlaceRoadLine {
+        start: (u32, u32),
+        end: (u32, u32),
+        road_type: RoadType,
     },
-    ZoneRect { 
-        min: (u32, u32), 
-        max: (u32, u32), 
-        zone_type: ZoneType 
+    ZoneRect {
+        min: (u32, u32),
+        max: (u32, u32),
+        zone_type: ZoneType,
     },
-    PlaceUtility { 
-        pos: (u32, u32), 
-        utility_type: UtilityType 
+    PlaceUtility {
+        pos: (u32, u32),
+        utility_type: UtilityType,
     },
-    PlaceService { 
-        pos: (u32, u32), 
-        service_type: ServiceType 
+    PlaceService {
+        pos: (u32, u32),
+        service_type: ServiceType,
     },
-    BulldozeRect { 
-        min: (u32, u32), 
-        max: (u32, u32) 
+    BulldozeRect {
+        min: (u32, u32),
+        max: (u32, u32),
     },
-    SetTaxRates { 
-        residential: f32, 
-        commercial: f32, 
-        industrial: f32, 
-        office: f32 
+    SetTaxRates {
+        residential: f32,
+        commercial: f32,
+        industrial: f32,
+        office: f32,
     },
-    Save { 
-        path: String 
+    Save {
+        path: String,
     },
-    Load { 
-        path: String 
+    Load {
+        path: String,
     },
 }

--- a/crates/simulation/src/game_actions/mod.rs
+++ b/crates/simulation/src/game_actions/mod.rs
@@ -1,7 +1,9 @@
 pub mod actions;
+pub mod queue;
 pub mod results;
 
 pub use actions::*;
+pub use queue::*;
 pub use results::*;
 
 #[cfg(test)]

--- a/crates/simulation/src/game_actions/queue.rs
+++ b/crates/simulation/src/game_actions/queue.rs
@@ -1,0 +1,165 @@
+use bevy::prelude::*;
+use bitcode::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+use super::GameAction;
+use crate::Saveable;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
+pub enum ActionSource {
+    Player,
+    Agent,
+    Replay,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode)]
+pub struct QueuedAction {
+    pub tick: u64,
+    pub source: ActionSource,
+    pub action: GameAction,
+}
+
+#[derive(Resource, Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ActionQueue {
+    pending: Vec<QueuedAction>,
+}
+
+impl ActionQueue {
+    pub fn push(&mut self, tick: u64, source: ActionSource, action: GameAction) {
+        self.pending.push(QueuedAction {
+            tick,
+            source,
+            action,
+        });
+    }
+
+    pub fn push_queued(&mut self, queued: QueuedAction) {
+        self.pending.push(queued);
+    }
+
+    pub fn drain(&mut self) -> Vec<QueuedAction> {
+        self.pending.drain(..).collect()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.pending.len()
+    }
+}
+
+#[derive(Encode, Decode, Default)]
+struct ActionQueueSave {
+    pending: Vec<QueuedAction>,
+}
+
+impl Saveable for ActionQueue {
+    const SAVE_KEY: &'static str = "action_queue";
+
+    fn save_to_bytes(&self) -> Option<Vec<u8>> {
+        if self.pending.is_empty() {
+            return None;
+        }
+        let save = ActionQueueSave {
+            pending: self.pending.clone(),
+        };
+        Some(bitcode::encode(&save))
+    }
+
+    fn load_from_bytes(bytes: &[u8]) -> Self {
+        let save: ActionQueueSave = crate::decode_or_warn(Self::SAVE_KEY, bytes);
+        Self {
+            pending: save.pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Saveable;
+    use crate::grid::{RoadType, ZoneType};
+
+    #[test]
+    fn push_and_drain_preserves_fifo() {
+        let mut queue = ActionQueue::default();
+        queue.push(10, ActionSource::Player, GameAction::SetPaused { paused: true });
+        queue.push(
+            10,
+            ActionSource::Agent,
+            GameAction::SetSpeed { speed: 2 },
+        );
+        queue.push(
+            11,
+            ActionSource::Replay,
+            GameAction::PlaceRoadLine {
+                start: (5, 5),
+                end: (10, 5),
+                road_type: RoadType::Local,
+            },
+        );
+
+        assert_eq!(queue.len(), 3);
+        assert!(!queue.is_empty());
+
+        let drained = queue.drain();
+        assert_eq!(drained.len(), 3);
+        assert!(queue.is_empty());
+
+        assert_eq!(drained[0].tick, 10);
+        assert_eq!(drained[0].source, ActionSource::Player);
+        assert_eq!(drained[0].action, GameAction::SetPaused { paused: true });
+
+        assert_eq!(drained[1].tick, 10);
+        assert_eq!(drained[1].source, ActionSource::Agent);
+        assert_eq!(drained[1].action, GameAction::SetSpeed { speed: 2 });
+
+        assert_eq!(drained[2].tick, 11);
+        assert_eq!(drained[2].source, ActionSource::Replay);
+        assert_eq!(
+            drained[2].action,
+            GameAction::PlaceRoadLine {
+                start: (5, 5),
+                end: (10, 5),
+                road_type: RoadType::Local
+            }
+        );
+    }
+
+    #[test]
+    fn saveable_roundtrip_restores_pending_actions() {
+        let mut queue = ActionQueue::default();
+        queue.push(
+            42,
+            ActionSource::Player,
+            GameAction::ZoneRect {
+                min: (1, 2),
+                max: (3, 4),
+                zone_type: ZoneType::ResidentialLow,
+            },
+        );
+
+        let bytes = queue
+            .save_to_bytes()
+            .expect("non-empty queue should produce save bytes");
+        let restored = ActionQueue::load_from_bytes(&bytes);
+
+        assert_eq!(restored.len(), 1);
+        assert_eq!(
+            restored,
+            ActionQueue {
+                pending: vec![QueuedAction {
+                    tick: 42,
+                    source: ActionSource::Player,
+                    action: GameAction::ZoneRect {
+                        min: (1, 2),
+                        max: (3, 4),
+                        zone_type: ZoneType::ResidentialLow,
+                    },
+                }],
+            }
+        );
+    }
+}

--- a/crates/simulation/src/game_actions/results.rs
+++ b/crates/simulation/src/game_actions/results.rs
@@ -1,12 +1,13 @@
+use bitcode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Encode, Decode)]
 pub enum ActionResult {
     Success,
     Error(ActionError),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Encode, Decode)]
 pub enum ActionError {
     OutOfBounds,
     InsufficientFunds,

--- a/crates/simulation/src/grid.rs
+++ b/crates/simulation/src/grid.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bitcode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{CELL_SIZE, GRID_HEIGHT, GRID_WIDTH};
@@ -10,7 +11,9 @@ pub enum CellType {
     Road,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, Encode, Decode,
+)]
 pub enum ZoneType {
     #[default]
     None,
@@ -24,7 +27,9 @@ pub enum ZoneType {
     MixedUse,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, Encode, Decode,
+)]
 pub enum RoadType {
     #[default]
     Local, // 2-lane, speed 30, $10, enables zoning

--- a/crates/simulation/src/services/service_type.rs
+++ b/crates/simulation/src/services/service_type.rs
@@ -1,6 +1,7 @@
+use bitcode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub enum ServiceType {
     FireStation,
     PoliceStation,

--- a/crates/simulation/src/utilities.rs
+++ b/crates/simulation/src/utilities.rs
@@ -1,12 +1,13 @@
 use std::collections::VecDeque;
 
 use bevy::prelude::*;
+use bitcode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::grid::{CellType, WorldGrid};
 use crate::roads::RoadNetwork;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub enum UtilityType {
     PowerPlant,
     SolarFarm,


### PR DESCRIPTION
## Summary
- add `crates/simulation/src/game_actions/` module with `GameAction` enum, `ActionResult`, and `ActionError` types
- add `crates/simulation/src/game_actions/queue.rs` with `ActionQueue`, `QueuedAction`, and `ActionSource`
- implement required queue API (`push`, `drain`, `is_empty`, `len`) with FIFO drain behavior
- implement `Saveable` for `ActionQueue` using bitcode, plus unit tests for FIFO and save/load roundtrip
- derive `bitcode::Encode/Decode` for `GameAction` and dependent enums (`RoadType`, `ZoneType`, `UtilityType`, `ServiceType`)

Closes #1871
Closes #1872

## Test plan
- [ ] CI passes
- [ ] Follow-up executor ticket can drain and execute `ActionQueue` deterministically

Generated with Codex