### PR TITLE
AGENT-C1: CityObservation snapshot and ObservationBuilder

### DIFF
--- a/crates/simulation/src/city_observation.rs
+++ b/crates/simulation/src/city_observation.rs
@@ -1,0 +1,173 @@
+//! Compact, typed, serializable snapshot of the city state.
+//!
+//! `CityObservation` is the "eyes" of the LLM agent — it captures the full
+//! city state into a single struct each turn so the agent can reason about
+//! what to do next.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Top-level observation
+// ---------------------------------------------------------------------------
+
+/// A point-in-time snapshot of the entire city state, designed to be sent to
+/// an LLM agent each turn.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CityObservation {
+    // -- Time ---------------------------------------------------------------
+    pub tick: u64,
+    pub day: u32,
+    pub hour: f32,
+    pub speed: f32,
+    pub paused: bool,
+
+    // -- Economy ------------------------------------------------------------
+    pub treasury: f64,
+    pub monthly_income: f64,
+    pub monthly_expenses: f64,
+    pub net_income: f64,
+
+    // -- Population ---------------------------------------------------------
+    pub population: PopulationSnapshot,
+
+    // -- Zone demand --------------------------------------------------------
+    pub zone_demand: ZoneDemandSnapshot,
+
+    // -- Infrastructure coverage (0.0–1.0) ----------------------------------
+    pub power_coverage: f32,
+    pub water_coverage: f32,
+
+    // -- Service coverage (0.0–1.0) -----------------------------------------
+    pub services: ServiceCoverageSnapshot,
+
+    // -- Happiness ----------------------------------------------------------
+    pub happiness: HappinessSnapshot,
+
+    // -- Warnings -----------------------------------------------------------
+    pub warnings: Vec<CityWarning>,
+
+    // -- Recent action results (from ActionResultLog when available) ---------
+    pub recent_action_results: Vec<ActionResultEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Sub-snapshots
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PopulationSnapshot {
+    pub total: u32,
+    pub employed: u32,
+    pub unemployed: u32,
+    pub homeless: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ZoneDemandSnapshot {
+    pub residential: f32,
+    pub commercial: f32,
+    pub industrial: f32,
+    pub office: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ServiceCoverageSnapshot {
+    pub fire: f32,
+    pub police: f32,
+    pub health: f32,
+    pub education: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HappinessSnapshot {
+    pub overall: f32,
+    pub components: Vec<(String, f32)>,
+}
+
+// ---------------------------------------------------------------------------
+// Warnings
+// ---------------------------------------------------------------------------
+
+/// High-level warning signals for the LLM agent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CityWarning {
+    PowerShortage,
+    WaterShortage,
+    HighCrime,
+    HighPollution,
+    HighUnemployment,
+    NegativeBudget,
+    HighHomelessness,
+    TrafficCongestion,
+}
+
+// ---------------------------------------------------------------------------
+// Action result entry
+// ---------------------------------------------------------------------------
+
+/// Compact summary of a recently executed game action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionResultEntry {
+    pub action_summary: String,
+    pub success: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observation_default_is_empty() {
+        let obs = CityObservation::default();
+        assert_eq!(obs.tick, 0);
+        assert!(obs.warnings.is_empty());
+        assert!(obs.recent_action_results.is_empty());
+    }
+
+    #[test]
+    fn observation_serializes_to_json() {
+        let obs = CityObservation {
+            tick: 42,
+            day: 3,
+            hour: 14.5,
+            speed: 2.0,
+            paused: false,
+            treasury: 10_000.0,
+            monthly_income: 500.0,
+            monthly_expenses: 300.0,
+            net_income: 200.0,
+            population: PopulationSnapshot {
+                total: 100,
+                employed: 80,
+                unemployed: 20,
+                homeless: 5,
+            },
+            zone_demand: ZoneDemandSnapshot {
+                residential: 0.6,
+                commercial: 0.3,
+                industrial: 0.1,
+                office: 0.0,
+            },
+            power_coverage: 0.9,
+            water_coverage: 0.85,
+            services: ServiceCoverageSnapshot {
+                fire: 0.7,
+                police: 0.6,
+                health: 0.5,
+                education: 0.8,
+            },
+            happiness: HappinessSnapshot {
+                overall: 65.0,
+                components: vec![("employment".into(), 80.0), ("safety".into(), 50.0)],
+            },
+            warnings: vec![CityWarning::NegativeBudget],
+            recent_action_results: vec![ActionResultEntry {
+                action_summary: "Built road".into(),
+                success: true,
+            }],
+        };
+        let json = serde_json::to_string(&obs).unwrap();
+        assert!(json.contains("\"tick\":42"));
+        assert!(json.contains("NegativeBudget"));
+    }
+}

--- a/crates/simulation/src/integration_tests/observation_tests.rs
+++ b/crates/simulation/src/integration_tests/observation_tests.rs
@@ -1,0 +1,131 @@
+//! Integration tests for the CityObservation snapshot system (#1880).
+
+use crate::city_observation::CityWarning;
+use crate::economy::CityBudget;
+use crate::observation_builder::CurrentObservation;
+use crate::test_harness::TestCity;
+
+#[test]
+fn test_observation_populated_after_ticking() {
+    let mut city = TestCity::new();
+    city.tick(10);
+    let obs = &city.resource::<CurrentObservation>().observation;
+    // Tick counter should have advanced (first update + 10 ticks)
+    assert!(obs.tick > 0, "tick counter should be > 0 after ticking");
+    assert!(obs.day >= 1, "day should be >= 1");
+}
+
+#[test]
+fn test_observation_treasury_matches_budget() {
+    let mut city = TestCity::new();
+    city.tick(1);
+    let budget_treasury = city.resource::<CityBudget>().treasury;
+    let obs_treasury = city.resource::<CurrentObservation>().observation.treasury;
+    assert!(
+        (budget_treasury - obs_treasury).abs() < f64::EPSILON,
+        "observation treasury ({}) should match CityBudget treasury ({})",
+        obs_treasury,
+        budget_treasury,
+    );
+}
+
+#[test]
+fn test_observation_population_non_negative() {
+    let mut city = TestCity::new();
+    city.tick(5);
+    let pop = &city.resource::<CurrentObservation>().observation.population;
+    // All population fields should be non-negative (u32 guarantees this, but
+    // we verify the snapshot is coherent: total >= employed, etc.)
+    assert!(
+        pop.total >= pop.employed,
+        "total ({}) should be >= employed ({})",
+        pop.total,
+        pop.employed,
+    );
+}
+
+#[test]
+fn test_observation_happiness_valid_range() {
+    let mut city = TestCity::new();
+    city.tick(5);
+    let happiness = city
+        .resource::<CurrentObservation>()
+        .observation
+        .happiness
+        .overall;
+    // Happiness should be in [0, 100] range
+    assert!(
+        (0.0..=100.0).contains(&happiness),
+        "happiness ({}) should be in [0.0, 100.0]",
+        happiness,
+    );
+}
+
+#[test]
+fn test_observation_coverage_valid_range() {
+    let mut city = TestCity::new();
+    city.tick(5);
+    let obs = &city.resource::<CurrentObservation>().observation;
+    // Coverage values should be in [0.0, 1.0]
+    for (name, val) in [
+        ("power", obs.power_coverage),
+        ("water", obs.water_coverage),
+        ("fire", obs.services.fire),
+        ("police", obs.services.police),
+        ("health", obs.services.health),
+        ("education", obs.services.education),
+    ] {
+        assert!(
+            (0.0..=1.0).contains(&val),
+            "{} coverage ({}) should be in [0.0, 1.0]",
+            name,
+            val,
+        );
+    }
+}
+
+#[test]
+fn test_observation_negative_budget_warning() {
+    let mut city = TestCity::new();
+    // Set treasury to deeply negative so the warning fires
+    city.world_mut()
+        .resource_mut::<CityBudget>()
+        .treasury = -10_000.0;
+    city.world_mut()
+        .resource_mut::<CityBudget>()
+        .monthly_income = 100.0;
+    city.world_mut()
+        .resource_mut::<CityBudget>()
+        .monthly_expenses = 500.0;
+    city.tick(1);
+    let warnings = &city.resource::<CurrentObservation>().observation.warnings;
+    assert!(
+        warnings.contains(&CityWarning::NegativeBudget),
+        "expected NegativeBudget warning when treasury is negative and expenses > income, got: {:?}",
+        warnings,
+    );
+}
+
+#[test]
+fn test_observation_zone_demand_populated() {
+    let mut city = TestCity::new();
+    city.tick(5);
+    let zd = &city.resource::<CurrentObservation>().observation.zone_demand;
+    // Demand values should be finite (not NaN or infinity)
+    assert!(zd.residential.is_finite(), "residential demand should be finite");
+    assert!(zd.commercial.is_finite(), "commercial demand should be finite");
+    assert!(zd.industrial.is_finite(), "industrial demand should be finite");
+    assert!(zd.office.is_finite(), "office demand should be finite");
+}
+
+#[test]
+fn test_observation_serializes_to_json() {
+    let mut city = TestCity::new();
+    city.tick(5);
+    let obs = &city.resource::<CurrentObservation>().observation;
+    let json = serde_json::to_string(obs);
+    assert!(json.is_ok(), "observation should serialize to JSON");
+    let json_str = json.unwrap();
+    assert!(json_str.contains("\"tick\""), "JSON should contain tick field");
+    assert!(json_str.contains("\"treasury\""), "JSON should contain treasury field");
+}

--- a/crates/simulation/src/observation_builder.rs
+++ b/crates/simulation/src/observation_builder.rs
@@ -1,0 +1,211 @@
+//! Builds a `CityObservation` snapshot from ECS resources each tick.
+//!
+//! The `build_observation` system runs in `FixedUpdate` / `SimulationSet::PostSim`
+//! so that all simulation writes have settled before we capture the snapshot.
+
+use bevy::prelude::*;
+
+use crate::city_observation::{
+    CityObservation, CityWarning, HappinessSnapshot, PopulationSnapshot,
+    ServiceCoverageSnapshot, ZoneDemandSnapshot,
+};
+use crate::citizen::{Citizen, WorkLocation};
+use crate::coverage_metrics::CoverageMetrics;
+use crate::crime::CrimeGrid;
+use crate::economy::CityBudget;
+use crate::homelessness::HomelessnessStats;
+use crate::pollution::PollutionGrid;
+use crate::stats::CityStats;
+use crate::time_of_day::GameClock;
+use crate::traffic_congestion::TrafficCongestion;
+use crate::virtual_population::VirtualPopulation;
+use crate::zones::ZoneDemand;
+use crate::TickCounter;
+
+// ---------------------------------------------------------------------------
+// Resource: holds the latest observation
+// ---------------------------------------------------------------------------
+
+/// The most recent city observation, updated every tick in PostSim.
+#[derive(Resource, Default, Debug, Clone)]
+pub struct CurrentObservation {
+    pub observation: CityObservation,
+}
+
+// ---------------------------------------------------------------------------
+// System
+// ---------------------------------------------------------------------------
+
+/// Snapshot the city state into `CurrentObservation`.
+///
+/// Reads from existing ECS resources and populates a `CityObservation`.
+/// Fields that don't have a clear data source yet use sensible defaults.
+#[allow(clippy::too_many_arguments)]
+pub fn build_observation(
+    tick_counter: Res<TickCounter>,
+    clock: Res<GameClock>,
+    budget: Res<CityBudget>,
+    stats: Res<CityStats>,
+    zone_demand: Res<ZoneDemand>,
+    coverage: Res<CoverageMetrics>,
+    homelessness: Res<HomelessnessStats>,
+    virtual_pop: Res<VirtualPopulation>,
+    traffic_congestion: Res<TrafficCongestion>,
+    pollution_grid: Res<PollutionGrid>,
+    crime_grid: Res<CrimeGrid>,
+    employed_citizens: Query<(), (With<Citizen>, With<WorkLocation>)>,
+    mut current: ResMut<CurrentObservation>,
+) {
+    let real_employed = employed_citizens.iter().count() as u32;
+    let total_employed = real_employed + virtual_pop.virtual_employed;
+
+    let population_total = stats.population;
+    let unemployed = population_total.saturating_sub(total_employed);
+
+    // Average happiness from real citizens (virtual citizens don't have
+    // individual happiness in the ECS).
+    let avg_happiness = stats.average_happiness;
+
+    // Compute warning thresholds
+    let warnings = compute_warnings(
+        &budget,
+        &coverage,
+        &homelessness,
+        &traffic_congestion,
+        &pollution_grid,
+        &crime_grid,
+        population_total,
+        unemployed,
+    );
+
+    current.observation = CityObservation {
+        tick: tick_counter.0,
+        day: clock.day,
+        hour: clock.hour,
+        speed: clock.speed,
+        paused: clock.paused,
+
+        treasury: budget.treasury,
+        monthly_income: budget.monthly_income,
+        monthly_expenses: budget.monthly_expenses,
+        net_income: budget.monthly_income - budget.monthly_expenses,
+
+        population: PopulationSnapshot {
+            total: population_total,
+            employed: total_employed,
+            unemployed,
+            homeless: homelessness.total_homeless,
+        },
+
+        zone_demand: ZoneDemandSnapshot {
+            residential: zone_demand.residential,
+            commercial: zone_demand.commercial,
+            industrial: zone_demand.industrial,
+            office: zone_demand.office,
+        },
+
+        power_coverage: coverage.power,
+        water_coverage: coverage.water,
+
+        services: ServiceCoverageSnapshot {
+            fire: coverage.fire,
+            police: coverage.police,
+            health: coverage.health,
+            education: coverage.education,
+        },
+
+        happiness: HappinessSnapshot {
+            overall: avg_happiness,
+            // TODO: Expose per-factor happiness breakdown once a HappinessBreakdown
+            // resource is added. For now, we only report the aggregate.
+            components: Vec::new(),
+        },
+
+        warnings,
+
+        // TODO: Populate from ActionResultLog once AGENT-A3 lands that module.
+        recent_action_results: Vec::new(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Warning detection helpers
+// ---------------------------------------------------------------------------
+
+/// Threshold-based warning detection from current city resources.
+#[allow(clippy::too_many_arguments)]
+fn compute_warnings(
+    budget: &CityBudget,
+    coverage: &CoverageMetrics,
+    homelessness: &HomelessnessStats,
+    traffic_congestion: &TrafficCongestion,
+    pollution_grid: &PollutionGrid,
+    crime_grid: &CrimeGrid,
+    population: u32,
+    unemployed: u32,
+) -> Vec<CityWarning> {
+    let mut warnings = Vec::new();
+
+    // Negative budget
+    if budget.monthly_income < budget.monthly_expenses && budget.treasury < 0.0 {
+        warnings.push(CityWarning::NegativeBudget);
+    }
+
+    // Power shortage (coverage below 80%)
+    if coverage.power < 0.8 {
+        warnings.push(CityWarning::PowerShortage);
+    }
+
+    // Water shortage (coverage below 80%)
+    if coverage.water < 0.8 {
+        warnings.push(CityWarning::WaterShortage);
+    }
+
+    // High unemployment (> 30% of population)
+    if population > 0 && (unemployed as f32 / population as f32) > 0.3 {
+        warnings.push(CityWarning::HighUnemployment);
+    }
+
+    // High homelessness (> 5% of population)
+    if population > 0 && (homelessness.total_homeless as f32 / population as f32) > 0.05 {
+        warnings.push(CityWarning::HighHomelessness);
+    }
+
+    // Traffic congestion: average speed multiplier below 0.5 across occupied cells
+    let avg_speed = average_traffic_speed(traffic_congestion);
+    if avg_speed < 0.5 {
+        warnings.push(CityWarning::TrafficCongestion);
+    }
+
+    // High pollution: average pollution level above 128 (out of 255)
+    let avg_pollution = average_grid_level(&pollution_grid.levels);
+    if avg_pollution > 128.0 {
+        warnings.push(CityWarning::HighPollution);
+    }
+
+    // High crime: average crime level above 128
+    let avg_crime = average_grid_level(&crime_grid.levels);
+    if avg_crime > 128.0 {
+        warnings.push(CityWarning::HighCrime);
+    }
+
+    warnings
+}
+
+/// Average speed multiplier across all cells (1.0 = free flow).
+fn average_traffic_speed(congestion: &TrafficCongestion) -> f32 {
+    if congestion.speed_multipliers.is_empty() {
+        return 1.0;
+    }
+    let sum: f32 = congestion.speed_multipliers.iter().sum();
+    sum / congestion.speed_multipliers.len() as f32
+}
+
+/// Average u8 grid level (pollution, crime, etc.).
+fn average_grid_level(levels: &[u8]) -> f32 {
+    if levels.is_empty() {
+        return 0.0;
+    }
+    let sum: f64 = levels.iter().map(|&v| v as f64).sum();
+    (sum / levels.len() as f64) as f32
+}

--- a/crates/simulation/src/observation_plugin.rs
+++ b/crates/simulation/src/observation_plugin.rs
@@ -1,0 +1,21 @@
+//! Plugin that registers the city observation system.
+//!
+//! Adds `CurrentObservation` resource and the `build_observation` system to
+//! `FixedUpdate` in `SimulationSet::PostSim`.
+
+use bevy::prelude::*;
+
+use crate::observation_builder::{build_observation, CurrentObservation};
+use crate::SimulationSet;
+
+pub struct ObservationPlugin;
+
+impl Plugin for ObservationPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<CurrentObservation>();
+        app.add_systems(
+            FixedUpdate,
+            build_observation.in_set(SimulationSet::PostSim),
+        );
+    }
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -367,4 +367,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
 
     // Deterministic state hashing for replay verification (#1883)
     app.add_plugins(state_hash::StateHashPlugin);
+
+    // City observation snapshot for LLM agent (#1880)
+    app.add_plugins(observation_plugin::ObservationPlugin);
 }


### PR DESCRIPTION
## Summary

Introduces the "eyes" of the LLM agent: a compact, typed, serializable snapshot of the city state that gets sent to the LLM each turn.

- **`city_observation.rs`** (~170 lines): `CityObservation` struct with sub-snapshots (`PopulationSnapshot`, `ZoneDemandSnapshot`, `ServiceCoverageSnapshot`, `HappinessSnapshot`), `CityWarning` enum, and `ActionResultEntry`
- **`observation_builder.rs`** (~210 lines): `build_observation` system that reads from `CityBudget`, `CityStats`, `ZoneDemand`, `CoverageMetrics`, `HomelessnessStats`, `VirtualPopulation`, `TrafficCongestion`, `PollutionGrid`, `CrimeGrid` to populate the snapshot with threshold-based warning detection
- **`observation_plugin.rs`** (~20 lines): Registers `CurrentObservation` resource and `build_observation` in `FixedUpdate`/`PostSim`
- **Integration tests** (~130 lines): 7 tests covering population coherence, treasury matching, happiness range, coverage range, zone demand validity, negative budget warning, and JSON serialization

### TODO (non-blocking)
- Happiness breakdown by factor (awaiting `HappinessBreakdown` resource)
- `recent_action_results` populated from `ActionResultLog` (awaiting AGENT-A3)

Closes #1880