### PR TITLE
Add WorldSnapshot spatial state serialization

### DIFF
--- a/crates/simulation/src/integration_tests/world_snapshot_tests.rs
+++ b/crates/simulation/src/integration_tests/world_snapshot_tests.rs
@@ -1,0 +1,122 @@
+//! Integration tests for WorldSnapshot spatial state serialization (#1903).
+
+use crate::grid::{RoadType, ZoneType};
+use crate::services::ServiceType;
+use crate::test_harness::TestCity;
+use crate::utilities::UtilityType;
+use crate::world_snapshot::build_world_snapshot;
+use crate::world_snapshot_format::format_buildings;
+
+#[test]
+fn test_empty_city_snapshot_is_empty() {
+    let mut city = TestCity::new();
+    let snapshot = build_world_snapshot(city.world_mut());
+
+    assert!(snapshot.buildings.is_empty(), "No buildings in empty city");
+    assert!(snapshot.services.is_empty(), "No services in empty city");
+    assert!(snapshot.utilities.is_empty(), "No utilities in empty city");
+    assert!(
+        snapshot.road_cells.is_empty(),
+        "No road cells in empty city"
+    );
+    assert!(
+        snapshot.zone_regions.is_empty(),
+        "No zone regions in empty city"
+    );
+}
+
+#[test]
+fn test_road_cells_captured() {
+    let mut city = TestCity::new().with_road(10, 10, 15, 10, RoadType::Local);
+
+    let snapshot = build_world_snapshot(city.world_mut());
+
+    assert!(
+        !snapshot.road_cells.is_empty(),
+        "Should have road cells after placing roads"
+    );
+
+    // All road cells should be Local type
+    for rc in &snapshot.road_cells {
+        assert_eq!(rc.road_type, RoadType::Local);
+    }
+}
+
+#[test]
+fn test_zone_regions_detected() {
+    let mut city = TestCity::new().with_zone_rect(5, 5, 8, 8, ZoneType::ResidentialLow);
+
+    let snapshot = build_world_snapshot(city.world_mut());
+
+    assert!(
+        !snapshot.zone_regions.is_empty(),
+        "Should detect zone regions"
+    );
+
+    // The 4x4 zone should be captured as a single region
+    let region = &snapshot.zone_regions[0];
+    assert_eq!(region.zone_type, ZoneType::ResidentialLow);
+    assert_eq!(region.min, (5, 5));
+    assert_eq!(region.max, (8, 8));
+}
+
+#[test]
+fn test_building_in_snapshot() {
+    let mut city =
+        TestCity::new().with_building(20, 20, ZoneType::CommercialLow, 2);
+
+    let snapshot = build_world_snapshot(city.world_mut());
+
+    assert_eq!(snapshot.buildings.len(), 1);
+    let b = &snapshot.buildings[0];
+    assert_eq!(b.pos, (20, 20));
+    assert_eq!(b.zone_type, ZoneType::CommercialLow);
+    assert_eq!(b.level, 2);
+    assert!(b.capacity > 0, "Building should have non-zero capacity");
+    assert_eq!(b.occupancy, 0, "New building should have 0 occupants");
+}
+
+#[test]
+fn test_service_in_snapshot() {
+    let mut city = TestCity::new().with_service(30, 30, ServiceType::Hospital);
+
+    let snapshot = build_world_snapshot(city.world_mut());
+
+    assert_eq!(snapshot.services.len(), 1);
+    let s = &snapshot.services[0];
+    assert_eq!(s.pos, (30, 30));
+    assert_eq!(s.service_type, ServiceType::Hospital);
+    assert!(s.radius > 0.0, "Hospital should have non-zero radius");
+}
+
+#[test]
+fn test_utility_in_snapshot() {
+    let mut city = TestCity::new().with_utility(40, 40, UtilityType::PowerPlant);
+
+    let snapshot = build_world_snapshot(city.world_mut());
+
+    assert_eq!(snapshot.utilities.len(), 1);
+    let u = &snapshot.utilities[0];
+    assert_eq!(u.pos, (40, 40));
+    assert_eq!(u.utility_type, UtilityType::PowerPlant);
+    assert!(u.range > 0, "Power plant should have non-zero range");
+}
+
+#[test]
+fn test_format_buildings_readable() {
+    let mut city =
+        TestCity::new().with_building(10, 10, ZoneType::ResidentialHigh, 3);
+
+    let snapshot = build_world_snapshot(city.world_mut());
+    let output = format_buildings(&snapshot.buildings);
+
+    assert!(!output.is_empty(), "Format output should not be empty");
+    assert!(
+        output.contains("Buildings"),
+        "Output should contain header"
+    );
+    assert!(
+        output.contains("1 total"),
+        "Output should mention count"
+    );
+}

--- a/crates/simulation/src/plugin_registration.rs
+++ b/crates/simulation/src/plugin_registration.rs
@@ -379,4 +379,7 @@ pub(crate) fn register_feature_plugins(app: &mut App) {
 
     // ASCII map rendering for debugging and LLM observation (#1902)
     app.add_plugins(ascii_map::AsciiMapPlugin);
+
+    // WorldSnapshot spatial state serialization (#1903)
+    app.add_plugins(world_snapshot::WorldSnapshotPlugin);
 }

--- a/crates/simulation/src/world_snapshot.rs
+++ b/crates/simulation/src/world_snapshot.rs
@@ -1,0 +1,305 @@
+//! WorldSnapshot — spatial state serialization for LLM-readable city summaries.
+//!
+//! Provides [`build_world_snapshot`] to capture the current state of the city
+//! (buildings, services, utilities, roads, zones, water) into a serializable
+//! struct. Formatting helpers live in [`crate::world_snapshot_format`].
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::buildings::Building;
+use crate::grid::{CellType, RoadType, WorldGrid, ZoneType};
+use crate::services::{ServiceBuilding, ServiceType};
+use crate::utilities::{UtilitySource, UtilityType};
+
+// ---------------------------------------------------------------------------
+// Data structures
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorldSnapshot {
+    pub buildings: Vec<BuildingEntry>,
+    pub services: Vec<ServiceEntry>,
+    pub utilities: Vec<UtilityEntry>,
+    pub road_cells: Vec<RoadCellEntry>,
+    pub zone_regions: Vec<ZoneRegion>,
+    pub water_regions: Vec<WaterRegion>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildingEntry {
+    pub pos: (u32, u32),
+    pub zone_type: ZoneType,
+    pub level: u8,
+    pub capacity: u32,
+    pub occupancy: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceEntry {
+    pub pos: (u32, u32),
+    pub service_type: ServiceType,
+    pub radius: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UtilityEntry {
+    pub pos: (u32, u32),
+    pub utility_type: UtilityType,
+    pub range: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoadCellEntry {
+    pub pos: (u32, u32),
+    pub road_type: RoadType,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZoneRegion {
+    pub min: (u32, u32),
+    pub max: (u32, u32),
+    pub zone_type: ZoneType,
+    pub building_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaterRegion {
+    pub min: (u32, u32),
+    pub max: (u32, u32),
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot builder
+// ---------------------------------------------------------------------------
+
+/// Build a [`WorldSnapshot`] from the current ECS world state.
+///
+/// Queries `Building`, `ServiceBuilding`, and `UtilitySource` entities, then
+/// scans the `WorldGrid` for road cells, zone regions, and water regions.
+pub fn build_world_snapshot(world: &mut World) -> WorldSnapshot {
+    let buildings = collect_buildings(world);
+    let services = collect_services(world);
+    let utilities = collect_utilities(world);
+
+    let grid = world.resource::<WorldGrid>();
+    let road_cells = collect_road_cells(grid);
+    let zone_regions = collect_zone_regions(grid);
+    let water_regions = collect_water_regions(grid);
+
+    WorldSnapshot {
+        buildings,
+        services,
+        utilities,
+        road_cells,
+        zone_regions,
+        water_regions,
+    }
+}
+
+fn collect_buildings(world: &mut World) -> Vec<BuildingEntry> {
+    let mut entries = Vec::new();
+    let mut query = world.query::<&Building>();
+    for building in query.iter(world) {
+        entries.push(BuildingEntry {
+            pos: (building.grid_x as u32, building.grid_y as u32),
+            zone_type: building.zone_type,
+            level: building.level,
+            capacity: building.capacity,
+            occupancy: building.occupants,
+        });
+    }
+    entries
+}
+
+fn collect_services(world: &mut World) -> Vec<ServiceEntry> {
+    let mut entries = Vec::new();
+    let mut query = world.query::<&ServiceBuilding>();
+    for service in query.iter(world) {
+        entries.push(ServiceEntry {
+            pos: (service.grid_x as u32, service.grid_y as u32),
+            service_type: service.service_type,
+            radius: service.radius,
+        });
+    }
+    entries
+}
+
+fn collect_utilities(world: &mut World) -> Vec<UtilityEntry> {
+    let mut entries = Vec::new();
+    let mut query = world.query::<&UtilitySource>();
+    for utility in query.iter(world) {
+        entries.push(UtilityEntry {
+            pos: (utility.grid_x as u32, utility.grid_y as u32),
+            utility_type: utility.utility_type,
+            range: utility.range,
+        });
+    }
+    entries
+}
+
+fn collect_road_cells(grid: &WorldGrid) -> Vec<RoadCellEntry> {
+    let mut entries = Vec::new();
+    for y in 0..grid.height {
+        for x in 0..grid.width {
+            let cell = grid.get(x, y);
+            if cell.cell_type == CellType::Road {
+                entries.push(RoadCellEntry {
+                    pos: (x as u32, y as u32),
+                    road_type: cell.road_type,
+                });
+            }
+        }
+    }
+    entries
+}
+
+// ---------------------------------------------------------------------------
+// Zone clustering (row-scan rectangular merge)
+// ---------------------------------------------------------------------------
+
+/// Cluster zone cells into rectangular regions by scanning row-by-row and
+/// extending runs downward where possible.
+fn collect_zone_regions(grid: &WorldGrid) -> Vec<ZoneRegion> {
+    let w = grid.width;
+    let h = grid.height;
+    let mut visited = vec![false; w * h];
+    let mut regions = Vec::new();
+
+    for y in 0..h {
+        let mut x = 0;
+        while x < w {
+            let idx = y * w + x;
+            let cell = grid.get(x, y);
+            if visited[idx] || cell.zone == ZoneType::None {
+                x += 1;
+                continue;
+            }
+
+            let zone = cell.zone;
+
+            // Find the end of this horizontal run of the same zone type
+            let mut x_end = x;
+            while x_end + 1 < w
+                && !visited[y * w + x_end + 1]
+                && grid.get(x_end + 1, y).zone == zone
+            {
+                x_end += 1;
+            }
+
+            // Extend downward
+            let mut y_end = y;
+            'outer: loop {
+                if y_end + 1 >= h {
+                    break;
+                }
+                let next_y = y_end + 1;
+                for cx in x..=x_end {
+                    let ci = next_y * w + cx;
+                    if visited[ci] || grid.get(cx, next_y).zone != zone {
+                        break 'outer;
+                    }
+                }
+                y_end = next_y;
+            }
+
+            // Count buildings in this region and mark visited
+            let mut building_count = 0u32;
+            for ry in y..=y_end {
+                for rx in x..=x_end {
+                    visited[ry * w + rx] = true;
+                    if grid.get(rx, ry).building_id.is_some() {
+                        building_count += 1;
+                    }
+                }
+            }
+
+            regions.push(ZoneRegion {
+                min: (x as u32, y as u32),
+                max: (x_end as u32, y_end as u32),
+                zone_type: zone,
+                building_count,
+            });
+
+            x = x_end + 1;
+        }
+    }
+
+    regions
+}
+
+// ---------------------------------------------------------------------------
+// Water region detection
+// ---------------------------------------------------------------------------
+
+/// Detect contiguous water regions by scanning row-by-row and merging adjacent
+/// water runs into bounding boxes.
+fn collect_water_regions(grid: &WorldGrid) -> Vec<WaterRegion> {
+    let w = grid.width;
+    let h = grid.height;
+    let mut visited = vec![false; w * h];
+    let mut regions = Vec::new();
+
+    for y in 0..h {
+        let mut x = 0;
+        while x < w {
+            let idx = y * w + x;
+            let cell = grid.get(x, y);
+            if visited[idx] || cell.cell_type != CellType::Water {
+                x += 1;
+                continue;
+            }
+
+            // Find horizontal run of water
+            let mut x_end = x;
+            while x_end + 1 < w
+                && !visited[y * w + x_end + 1]
+                && grid.get(x_end + 1, y).cell_type == CellType::Water
+            {
+                x_end += 1;
+            }
+
+            // Extend downward
+            let mut y_end = y;
+            'outer: loop {
+                if y_end + 1 >= h {
+                    break;
+                }
+                let next_y = y_end + 1;
+                for cx in x..=x_end {
+                    let ci = next_y * w + cx;
+                    if visited[ci] || grid.get(cx, next_y).cell_type != CellType::Water {
+                        break 'outer;
+                    }
+                }
+                y_end = next_y;
+            }
+
+            // Mark visited
+            for ry in y..=y_end {
+                for rx in x..=x_end {
+                    visited[ry * w + rx] = true;
+                }
+            }
+
+            regions.push(WaterRegion {
+                min: (x as u32, y as u32),
+                max: (x_end as u32, y_end as u32),
+            });
+
+            x = x_end + 1;
+        }
+    }
+
+    regions
+}
+
+// ---------------------------------------------------------------------------
+// Plugin (empty — snapshot is built on demand)
+// ---------------------------------------------------------------------------
+
+pub struct WorldSnapshotPlugin;
+
+impl Plugin for WorldSnapshotPlugin {
+    fn build(&self, _app: &mut App) {}
+}

--- a/crates/simulation/src/world_snapshot_format.rs
+++ b/crates/simulation/src/world_snapshot_format.rs
@@ -1,0 +1,167 @@
+//! Formatting helpers for [`WorldSnapshot`] data — produces human/LLM-readable
+//! text summaries of city spatial state.
+
+use std::collections::BTreeMap;
+use std::fmt::Write;
+
+use crate::world_snapshot::{
+    BuildingEntry, RoadCellEntry, ServiceEntry, UtilityEntry, WaterRegion, ZoneRegion,
+};
+
+/// Format building entries as a human-readable table.
+pub fn format_buildings(entries: &[BuildingEntry]) -> String {
+    if entries.is_empty() {
+        return "No buildings.".to_string();
+    }
+
+    let mut out = String::new();
+    writeln!(
+        out,
+        "Buildings ({} total):",
+        entries.len()
+    )
+    .ok();
+    writeln!(
+        out,
+        "  {:>8} {:>8}  {:>16}  {:>5}  {:>8}  {:>9}",
+        "X", "Y", "Zone", "Level", "Capacity", "Occupancy"
+    )
+    .ok();
+    for b in entries {
+        writeln!(
+            out,
+            "  {:>8} {:>8}  {:>16?}  {:>5}  {:>8}  {:>9}",
+            b.pos.0, b.pos.1, b.zone_type, b.level, b.capacity, b.occupancy,
+        )
+        .ok();
+    }
+    out
+}
+
+/// Format service entries as a human-readable list.
+pub fn format_services(entries: &[ServiceEntry]) -> String {
+    if entries.is_empty() {
+        return "No services.".to_string();
+    }
+
+    let mut out = String::new();
+    writeln!(out, "Services ({} total):", entries.len()).ok();
+    for s in entries {
+        writeln!(
+            out,
+            "  ({:>3},{:>3})  {:?}  radius={:.0}",
+            s.pos.0, s.pos.1, s.service_type, s.radius,
+        )
+        .ok();
+    }
+    out
+}
+
+/// Format utility entries as a human-readable list.
+pub fn format_utilities(entries: &[UtilityEntry]) -> String {
+    if entries.is_empty() {
+        return "No utilities.".to_string();
+    }
+
+    let mut out = String::new();
+    writeln!(out, "Utilities ({} total):", entries.len()).ok();
+    for u in entries {
+        writeln!(
+            out,
+            "  ({:>3},{:>3})  {:?}  range={}",
+            u.pos.0, u.pos.1, u.utility_type, u.range,
+        )
+        .ok();
+    }
+    out
+}
+
+/// Format road cells as a summary count by road type.
+pub fn format_roads_summary(entries: &[RoadCellEntry]) -> String {
+    if entries.is_empty() {
+        return "No roads.".to_string();
+    }
+
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for r in entries {
+        *counts.entry(format!("{:?}", r.road_type)).or_default() += 1;
+    }
+
+    let mut out = String::new();
+    writeln!(
+        out,
+        "Roads ({} total cells):",
+        entries.len()
+    )
+    .ok();
+    for (road_type, count) in &counts {
+        writeln!(out, "  {road_type}: {count} cells").ok();
+    }
+    out
+}
+
+/// Format zone regions as a summary table.
+pub fn format_zones_summary(regions: &[ZoneRegion]) -> String {
+    if regions.is_empty() {
+        return "No zoned areas.".to_string();
+    }
+
+    let mut out = String::new();
+    writeln!(
+        out,
+        "Zone Regions ({} total):",
+        regions.len()
+    )
+    .ok();
+    for z in regions {
+        let w = z.max.0 - z.min.0 + 1;
+        let h = z.max.1 - z.min.1 + 1;
+        writeln!(
+            out,
+            "  ({},{})-({},{})  {:?}  {}x{} ({} cells, {} buildings)",
+            z.min.0,
+            z.min.1,
+            z.max.0,
+            z.max.1,
+            z.zone_type,
+            w,
+            h,
+            w * h,
+            z.building_count,
+        )
+        .ok();
+    }
+    out
+}
+
+/// Format water regions as a summary.
+pub fn format_terrain(water: &[WaterRegion]) -> String {
+    if water.is_empty() {
+        return "No water bodies.".to_string();
+    }
+
+    let mut out = String::new();
+    writeln!(
+        out,
+        "Water Regions ({} total):",
+        water.len()
+    )
+    .ok();
+    for w_region in water {
+        let w = w_region.max.0 - w_region.min.0 + 1;
+        let h = w_region.max.1 - w_region.min.1 + 1;
+        writeln!(
+            out,
+            "  ({},{})-({},{})  {}x{} ({} cells)",
+            w_region.min.0,
+            w_region.min.1,
+            w_region.max.0,
+            w_region.max.1,
+            w,
+            h,
+            w * h,
+        )
+        .ok();
+    }
+    out
+}


### PR DESCRIPTION
## Summary
- Adds `WorldSnapshot` struct and `build_world_snapshot()` to capture city spatial state (buildings, services, utilities, roads, zones, water) into a serializable snapshot
- Adds formatting helpers (`format_buildings`, `format_services`, `format_utilities`, `format_roads_summary`, `format_zones_summary`, `format_terrain`) for LLM-readable output
- Zone clustering algorithm merges adjacent same-type zone cells into rectangular regions; water detection does the same for water cells
- Includes 7 integration tests covering empty city, roads, zones, buildings, services, utilities, and format output

## Test plan
- [x] `test_empty_city_snapshot_is_empty` — empty TestCity produces empty snapshot
- [x] `test_road_cells_captured` — roads appear in snapshot after placement
- [x] `test_zone_regions_detected` — zone rect is captured as a single region
- [x] `test_building_in_snapshot` — building entity captured with correct fields
- [x] `test_service_in_snapshot` — service building captured with type and radius
- [x] `test_utility_in_snapshot` — utility source captured with type and range
- [x] `test_format_buildings_readable` — format output is non-empty and readable

Closes #1903

🤖 Generated with [Claude Code](https://claude.com/claude-code)