### PR TITLE
Add --replay flag for graphical replay playback

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -214,9 +214,20 @@ fn load_replay_file(
     mut player: ResMut<simulation::replay::ReplayPlayer>,
 ) {
     info!("Loading replay from: {}", replay_path.0);
-    let contents = std::fs::read_to_string(&replay_path.0).expect("Failed to read replay file");
-    let replay =
-        simulation::replay::ReplayFile::from_json(&contents).expect("Failed to parse replay file");
+    let contents = match std::fs::read_to_string(&replay_path.0) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to read replay file '{}': {e}", replay_path.0);
+            return;
+        }
+    };
+    let replay = match simulation::replay::ReplayFile::from_json(&contents) {
+        Ok(r) => r,
+        Err(e) => {
+            error!("Failed to parse replay file '{}': {e}", replay_path.0);
+            return;
+        }
+    };
     if let Err(e) = replay.validate() {
         warn!("Replay validation warning: {}", e);
     }


### PR DESCRIPTION
## Summary
- Adds `--replay <path>` CLI flag to start the game in graphical mode with automatic replay playback
- When set, skips the main menu and boots directly into `AppState::Playing` with a blank grid
- A startup system reads the JSON replay file, validates it, and loads it into `ReplayPlayer`
- The existing `feed_replay_actions` system handles injecting actions each tick automatically

Closes #1914

## Test plan
- [ ] Run `cargo build --workspace` to verify compilation
- [ ] Run `cargo test --workspace` to verify tests pass
- [ ] Run `cargo clippy --workspace -- -D warnings` for lint checks
- [ ] Manual test: `cargo run -- --replay path/to/replay.json` loads and plays back a recorded session

🤖 Generated with [Claude Code](https://claude.com/claude-code)