### PR TITLE
Fix attractiveness services factor to only sample populated cells

### DIFF
--- a/crates/simulation/src/city_observation.rs
+++ b/crates/simulation/src/city_observation.rs
@@ -43,6 +43,16 @@ pub struct CityObservation {
     // -- Happiness ----------------------------------------------------------
     pub happiness: HappinessSnapshot,
 
+    // -- Attractiveness (immigration driver, 0-100) -------------------------
+    #[serde(default)]
+    pub attractiveness_score: f32,
+    #[serde(default)]
+    pub attractiveness: AttractivenessSnapshot,
+
+    // -- Building counts ----------------------------------------------------
+    #[serde(default)]
+    pub building_count: u32,
+
     // -- Warnings -----------------------------------------------------------
     pub warnings: Vec<CityWarning>,
 
@@ -86,6 +96,15 @@ pub struct ServiceCoverageSnapshot {
 pub struct HappinessSnapshot {
     pub overall: f32,
     pub components: Vec<(String, f32)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AttractivenessSnapshot {
+    pub employment: f32,
+    pub happiness: f32,
+    pub services: f32,
+    pub housing: f32,
+    pub tax: f32,
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +184,15 @@ mod tests {
                 overall: 65.0,
                 components: vec![("employment".into(), 80.0), ("safety".into(), 50.0)],
             },
+            attractiveness_score: 65.0,
+            attractiveness: AttractivenessSnapshot {
+                employment: 0.8,
+                happiness: 0.65,
+                services: 0.5,
+                housing: 0.6,
+                tax: 0.55,
+            },
+            building_count: 42,
             warnings: vec![CityWarning::NegativeBudget],
             recent_action_results: vec![ActionResultEntry {
                 action_summary: "Built road".into(),

--- a/crates/simulation/src/observation_builder.rs
+++ b/crates/simulation/src/observation_builder.rs
@@ -7,8 +7,8 @@ use bevy::prelude::*;
 
 use crate::ascii_map;
 use crate::city_observation::{
-    ActionResultEntry, CityObservation, CityWarning, HappinessSnapshot, PopulationSnapshot,
-    ServiceCoverageSnapshot, ZoneDemandSnapshot,
+    ActionResultEntry, AttractivenessSnapshot, CityObservation, CityWarning, HappinessSnapshot,
+    PopulationSnapshot, ServiceCoverageSnapshot, ZoneDemandSnapshot,
 };
 use crate::citizen::{Citizen, WorkLocation};
 use crate::coverage_metrics::CoverageMetrics;
@@ -16,6 +16,7 @@ use crate::crime::CrimeGrid;
 use crate::economy::CityBudget;
 use crate::game_actions::{ActionResult, ActionResultLog};
 use crate::grid::WorldGrid;
+use crate::immigration::CityAttractiveness;
 use crate::homelessness::HomelessnessStats;
 use crate::pollution::PollutionGrid;
 use crate::stats::CityStats;
@@ -58,6 +59,7 @@ pub fn build_observation(
     crime_grid: Res<CrimeGrid>,
     action_log: Res<ActionResultLog>,
     grid: Res<WorldGrid>,
+    attract: Res<CityAttractiveness>,
     employed_citizens: Query<(), (With<Citizen>, With<WorkLocation>)>,
     mut current: ResMut<CurrentObservation>,
 ) {
@@ -142,6 +144,21 @@ pub fn build_observation(
             // resource is added. For now, we only report the aggregate.
             components: Vec::new(),
         },
+
+        attractiveness_score: attract.overall_score,
+        attractiveness: AttractivenessSnapshot {
+            employment: attract.employment_factor,
+            happiness: attract.happiness_factor,
+            services: attract.services_factor,
+            housing: attract.housing_factor,
+            tax: attract.tax_factor,
+        },
+
+        building_count: stats.residential_buildings
+            + stats.commercial_buildings
+            + stats.industrial_buildings
+            + stats.office_buildings
+            + stats.mixed_use_buildings,
 
         warnings,
 


### PR DESCRIPTION
## Summary
- The `services_factor` in `compute_attractiveness` was sampling the **entire 256x256 grid** (65K cells), making service coverage appear near-zero for small/medium cities even with proper service placement. Now only samples **zoned cells**, so a well-serviced city gets proper credit for its coverage.
- Adds `attractiveness_score`, `attractiveness` breakdown (employment/happiness/services/housing/tax factors), and `building_count` to `CityObservation` so the LLM agent can see what's dragging down immigration.
- Improves `format_observation` in `llm_player.py` to show service coverage %, happiness, attractiveness breakdown, warnings, and recent failures to the LLM.

## Impact
Before: A city with 500+ people and services placed near all buildings had attractiveness ~53/100 (services_factor ≈ 0.01). Immigration couldn't fire (needs >60).

After: Same city should see services_factor reflect actual coverage of zoned area (e.g., 0.5-0.7), pushing attractiveness well above 60.

## Test plan
- [ ] Existing `bootstrap_attractiveness_tests` pass (they should benefit from this fix)
- [ ] All other integration tests pass (services_factor change is strictly more generous)
- [ ] LLM player shows richer observation data including attractiveness breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)