### PR TITLE
Add error reason to ActionResultEntry in observations

### DIFF
--- a/crates/simulation/src/city_observation.rs
+++ b/crates/simulation/src/city_observation.rs
@@ -180,6 +180,10 @@ pub struct ActionResultEntry {
     /// the caller should be aware of (e.g. zone overwrites).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub warning: Option<String>,
+    /// When `success` is false, the specific error reason (e.g. "OutOfBounds",
+    /// "InsufficientFunds"). `None` when the action succeeded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[cfg(test)]
@@ -284,6 +288,7 @@ mod tests {
                 action_summary: "Built road".into(),
                 success: true,
                 warning: None,
+                error: None,
             }],
             overview_map: String::new(),
         };
@@ -302,6 +307,7 @@ mod tests {
             action_summary: "ZoneRect".into(),
             success: true,
             warning: Some("Overwrote 5 CommercialLow cells".into()),
+            error: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"warning\""));

--- a/crates/simulation/src/integration_tests/action_result_error_tests.rs
+++ b/crates/simulation/src/integration_tests/action_result_error_tests.rs
@@ -1,0 +1,136 @@
+//! Integration tests verifying that action error reasons appear in
+//! `CityObservation::recent_action_results` (#1949).
+
+use crate::game_actions::queue::ActionSource;
+use crate::game_actions::{ActionQueue, GameAction};
+use crate::grid::RoadType;
+use crate::observation_builder::CurrentObservation;
+use crate::test_harness::TestCity;
+
+#[test]
+fn test_action_error_reason_appears_in_observation() {
+    let mut city = TestCity::new().with_budget(100_000.0);
+
+    // Push an out-of-bounds road action that will fail
+    {
+        let world = city.world_mut();
+        let mut queue = world.resource_mut::<ActionQueue>();
+        queue.push(
+            0,
+            ActionSource::Agent,
+            GameAction::PlaceRoadLine {
+                start: (300, 300),
+                end: (310, 300),
+                road_type: RoadType::Local,
+            },
+        );
+    }
+
+    city.tick(1);
+
+    let obs = &city.resource::<CurrentObservation>().observation;
+    assert!(!obs.recent_action_results.is_empty(), "Should have action results");
+
+    let entry = &obs.recent_action_results.last().unwrap();
+    assert!(!entry.success, "Action should have failed");
+    assert_eq!(
+        entry.error.as_deref(),
+        Some("OutOfBounds"),
+        "Error reason should be OutOfBounds"
+    );
+}
+
+#[test]
+fn test_successful_action_has_no_error_field() {
+    let mut city = TestCity::new().with_budget(100_000.0);
+
+    // Push a valid road action that will succeed
+    {
+        let world = city.world_mut();
+        let mut queue = world.resource_mut::<ActionQueue>();
+        queue.push(
+            0,
+            ActionSource::Agent,
+            GameAction::PlaceRoadLine {
+                start: (10, 10),
+                end: (15, 10),
+                road_type: RoadType::Local,
+            },
+        );
+    }
+
+    city.tick(1);
+
+    let obs = &city.resource::<CurrentObservation>().observation;
+    assert!(!obs.recent_action_results.is_empty(), "Should have action results");
+
+    let entry = &obs.recent_action_results.last().unwrap();
+    assert!(entry.success, "Action should have succeeded");
+    assert!(
+        entry.error.is_none(),
+        "Successful action should not have an error"
+    );
+}
+
+#[test]
+fn test_insufficient_funds_error_in_observation() {
+    let mut city = TestCity::new().with_budget(0.0);
+
+    {
+        let world = city.world_mut();
+        let mut queue = world.resource_mut::<ActionQueue>();
+        queue.push(
+            0,
+            ActionSource::Agent,
+            GameAction::PlaceRoadLine {
+                start: (5, 5),
+                end: (50, 5),
+                road_type: RoadType::Highway,
+            },
+        );
+    }
+
+    city.tick(1);
+
+    let obs = &city.resource::<CurrentObservation>().observation;
+    let entry = &obs.recent_action_results.last().unwrap();
+    assert!(!entry.success);
+    assert_eq!(
+        entry.error.as_deref(),
+        Some("InsufficientFunds"),
+        "Error reason should be InsufficientFunds"
+    );
+}
+
+#[test]
+fn test_error_field_serializes_correctly() {
+    use crate::city_observation::ActionResultEntry;
+
+    // Error case: error field present
+    let entry_with_error = ActionResultEntry {
+        action_summary: "PlaceRoadLine".into(),
+        success: false,
+        warning: None,
+        error: Some("OutOfBounds".into()),
+    };
+    let json = serde_json::to_string(&entry_with_error).unwrap();
+    assert!(json.contains("\"error\":\"OutOfBounds\""));
+
+    // Success case: error field omitted from JSON
+    let entry_success = ActionResultEntry {
+        action_summary: "PlaceRoadLine".into(),
+        success: true,
+        warning: None,
+        error: None,
+    };
+    let json = serde_json::to_string(&entry_success).unwrap();
+    assert!(
+        !json.contains("error"),
+        "error field should be skipped when None"
+    );
+
+    // Backward compat: deserialize JSON without error field
+    let old_json = r#"{"action_summary":"test","success":true}"#;
+    let entry: ActionResultEntry = serde_json::from_str(old_json).unwrap();
+    assert!(entry.error.is_none());
+}

--- a/crates/simulation/src/observation_builder.rs
+++ b/crates/simulation/src/observation_builder.rs
@@ -15,7 +15,7 @@ use crate::citizen::{Citizen, WorkLocation};
 use crate::coverage_metrics::CoverageMetrics;
 use crate::crime::CrimeGrid;
 use crate::economy::CityBudget;
-use crate::game_actions::ActionResultLog;
+use crate::game_actions::{ActionResult, ActionResultLog};
 use crate::grid::{WorldGrid, ZoneType};
 use crate::happiness_breakdown::HappinessBreakdown;
 use crate::homelessness::HomelessnessStats;
@@ -127,6 +127,10 @@ pub fn build_observation(
                 action_summary: summary,
                 success: result.is_success(),
                 warning: result.warning().map(String::from),
+                error: match result {
+                    ActionResult::Error(e) => Some(format!("{:?}", e)),
+                    _ => None,
+                },
             }
         })
         .collect();


### PR DESCRIPTION
## Summary
- Added `error: Option<String>` field to `ActionResultEntry` in `city_observation.rs`, populated with the `ActionError` variant name (e.g. `"OutOfBounds"`, `"InsufficientFunds"`) when an action fails
- Updated `observation_builder.rs` to extract the error reason from `ActionResult::Error(e)` using `format!("{:?}", e)`
- Field uses `#[serde(default, skip_serializing_if = "Option::is_none")]` for backward compatibility — old JSON without the field deserializes fine, and successful actions omit it from serialized output

Closes #1949

## Test plan
- [x] Integration test: error reason appears in observation for out-of-bounds action
- [x] Integration test: successful action has `error: None`
- [x] Integration test: insufficient funds error reason appears correctly
- [x] Integration test: serde round-trip — error field serializes/deserializes correctly, backward-compatible with old JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)