### PR TITLE
Scale garbage happiness penalties gradually

### DIFF
--- a/crates/simulation/src/happiness/systems.rs
+++ b/crates/simulation/src/happiness/systems.rs
@@ -206,15 +206,18 @@ fn compute_citizen_happiness(
     let poll_diminished = diminishing_returns(poll_ratio, DIMINISHING_K_NEGATIVE);
     happiness -= poll_diminished * (255.0 / 25.0) * weights.pollution;
 
-    // --- Garbage penalty ---
-    if garbage_grid.get(home.grid_x, home.grid_y) > 10 {
-        happiness -= GARBAGE_PENALTY;
+    // --- Garbage penalty (scaled linearly: 0 at level 10, full at level 100) ---
+    let garbage_level = garbage_grid.get(home.grid_x, home.grid_y) as f32;
+    if garbage_level > 10.0 {
+        let ratio = ((garbage_level - 10.0) / 90.0).clamp(0.0, 1.0);
+        happiness -= GARBAGE_PENALTY * ratio;
     }
 
-    // --- Uncollected waste penalty (WASTE-003) ---
+    // --- Uncollected waste penalty (WASTE-003, scaled: 0 at 100 lbs, full at 1000 lbs) ---
     let uncollected = waste_collection.uncollected(home.grid_x, home.grid_y);
     if uncollected > 100.0 {
-        happiness -= crate::garbage::UNCOLLECTED_WASTE_HAPPINESS_PENALTY;
+        let ratio = ((uncollected - 100.0) / 900.0).clamp(0.0, 1.0);
+        happiness -= crate::garbage::UNCOLLECTED_WASTE_HAPPINESS_PENALTY * ratio;
     }
 
     // --- Accumulated waste happiness penalty (WASTE-010) ---

--- a/crates/simulation/src/integration_tests/garbage_penalty_scaling_tests.rs
+++ b/crates/simulation/src/integration_tests/garbage_penalty_scaling_tests.rs
@@ -1,0 +1,103 @@
+//! Integration tests verifying that garbage happiness penalties scale gradually
+//! instead of using binary thresholds (issue #1961).
+
+use crate::garbage::GarbageGrid;
+use crate::test_harness::TestCity;
+use crate::waste_effects::WasteAccumulation;
+
+// ====================================================================
+// waste_happiness_penalty scaling (pure function tests)
+// ====================================================================
+
+#[test]
+fn test_waste_happiness_penalty_zero_waste_gives_zero_penalty() {
+    let penalty = crate::waste_effects::waste_happiness_penalty(0.0);
+    assert_eq!(penalty, 0.0, "Zero waste should give zero penalty");
+}
+
+#[test]
+fn test_waste_happiness_penalty_low_waste_gives_partial_penalty() {
+    // 100 lbs out of 500 max => 20% of full penalty => -1.0
+    let penalty = crate::waste_effects::waste_happiness_penalty(100.0);
+    assert!(
+        penalty > -2.0 && penalty < 0.0,
+        "100 lbs should give a small partial penalty, got {}",
+        penalty
+    );
+    assert!(
+        (penalty - (-1.0)).abs() < 0.01,
+        "100 lbs should give roughly -1.0, got {}",
+        penalty
+    );
+}
+
+#[test]
+fn test_waste_happiness_penalty_high_waste_gives_full_penalty() {
+    let penalty = crate::waste_effects::waste_happiness_penalty(500.0);
+    assert_eq!(penalty, -5.0, "500+ lbs should give full -5 penalty");
+
+    let penalty_over = crate::waste_effects::waste_happiness_penalty(1000.0);
+    assert_eq!(
+        penalty_over, -5.0,
+        "Over 500 lbs should still cap at -5 penalty"
+    );
+}
+
+// ====================================================================
+// GarbageGrid and WasteAccumulation resource defaults
+// ====================================================================
+
+#[test]
+fn test_garbage_grid_default_is_zero() {
+    let city = TestCity::new();
+    let grid = city.resource::<GarbageGrid>();
+    assert_eq!(
+        grid.get(50, 50),
+        0,
+        "Default garbage grid should be zero"
+    );
+}
+
+#[test]
+fn test_waste_accumulation_default_is_zero() {
+    let city = TestCity::new();
+    let acc = city.resource::<WasteAccumulation>();
+    assert_eq!(
+        acc.get(50, 50),
+        0.0,
+        "Default waste accumulation should be zero"
+    );
+}
+
+// ====================================================================
+// Scaling linearity verification
+// ====================================================================
+
+#[test]
+fn test_waste_penalty_scales_linearly() {
+    // Verify that the penalty at 250 lbs is half the penalty at 500 lbs
+    let half = crate::waste_effects::waste_happiness_penalty(250.0);
+    let full = crate::waste_effects::waste_happiness_penalty(500.0);
+    assert!(
+        (half - full / 2.0).abs() < 0.01,
+        "Penalty at 250 lbs ({}) should be half of penalty at 500 lbs ({})",
+        half,
+        full
+    );
+}
+
+#[test]
+fn test_waste_penalty_monotonically_increasing() {
+    let mut prev = crate::waste_effects::waste_happiness_penalty(0.0);
+    for lbs in (50..=500).step_by(50) {
+        let current = crate::waste_effects::waste_happiness_penalty(lbs as f32);
+        assert!(
+            current <= prev,
+            "Penalty should get more negative: at {} lbs got {}, prev was {}",
+            lbs,
+            current,
+            prev
+        );
+        prev = current;
+    }
+}


### PR DESCRIPTION
## Summary
- Replace binary garbage happiness penalties with linear scaling (issue #1961)
- GarbageGrid penalty: scales linearly from 0 to -5 for garbage levels 10-100 (was instant -5 at >10)
- Uncollected waste penalty: scales linearly from 0 to -5 for 100-1000 lbs (was instant -5 at >100)
- Accumulated waste penalty: scales linearly from 0 to -5 for 0-500 lbs (was instant -5 at >0)
- All three penalties now use `ratio.clamp(0.0, 1.0) * max_penalty` pattern

## Test plan
- [x] Updated unit tests in `waste_effects.rs` to verify linear scaling
- [x] Added integration tests in `garbage_penalty_scaling_tests.rs` covering:
  - Zero waste gives zero penalty
  - Low waste gives partial (not full) penalty
  - High waste gives full penalty
  - Linear scaling verified (250 lbs = half of 500 lbs penalty)
  - Monotonically increasing penalties

Closes #1961