### PR TITLE
Cap trade deficit costs and add TradeDeficit warning

### DIFF
--- a/crates/simulation/src/city_observation.rs
+++ b/crates/simulation/src/city_observation.rs
@@ -131,6 +131,7 @@ pub enum CityWarning {
     NegativeBudget,
     HighHomelessness,
     TrafficCongestion,
+    TradeDeficit,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/simulation/src/integration_tests/trade_deficit_tests.rs
+++ b/crates/simulation/src/integration_tests/trade_deficit_tests.rs
@@ -1,0 +1,122 @@
+//! Integration tests for trade deficit cap and TradeDeficit warning (#1962).
+
+use crate::city_observation::CityWarning;
+use crate::economy::CityBudget;
+use crate::observation_builder::CurrentObservation;
+use crate::production::types::{CityGoods, GoodsType};
+use crate::test_harness::TestCity;
+
+/// With no industrial production, the city imports goods to meet population
+/// demand. After the fix, the treasury should not collapse catastrophically.
+#[test]
+fn test_trade_deficit_does_not_collapse_treasury() {
+    let mut city = TestCity::new().with_budget(50_000.0);
+
+    // Run 200 ticks (~20 production cycles at PRODUCTION_INTERVAL=10).
+    // Without the cap fix, this would drain hundreds of thousands.
+    city.tick(200);
+
+    let treasury = city.resource::<CityBudget>().treasury;
+
+    // Treasury should not have fallen below -10,000 from trade costs alone.
+    // With no population and no production, there should be zero trade costs.
+    // Even with population, the capped deficit (10.0 * 1.2x * 0.01) per goods
+    // per tick is manageable.
+    assert!(
+        treasury > -10_000.0,
+        "Treasury should not collapse from trade deficit; got {treasury}"
+    );
+}
+
+/// With population but no production, trade deficit should be moderate.
+/// Manually inject negative net rates to simulate a consuming city.
+#[test]
+fn test_trade_deficit_capped_with_consumption() {
+    let mut city = TestCity::new().with_budget(50_000.0);
+
+    // Manually set consumption rates high to simulate a large population
+    // consuming goods with no production.
+    {
+        let world = city.world_mut();
+        let mut goods = world.resource_mut::<CityGoods>();
+        for &g in GoodsType::all() {
+            goods.consumption_rate.insert(g, 100.0);
+            goods.production_rate.insert(g, 0.0);
+        }
+    }
+
+    // Run 100 production cycles (1000 ticks)
+    city.tick(1000);
+
+    let treasury = city.resource::<CityBudget>().treasury;
+
+    // With the cap (10.0 per goods type * 7 types * avg_import ~7.2 * 0.01
+    // = ~5.04 per tick, applied every 10 ticks = ~0.504 per tick average),
+    // over 1000 ticks that's ~504. Starting from 50K, treasury should stay
+    // well above -50K.
+    assert!(
+        treasury > -50_000.0,
+        "Trade deficit should be capped; treasury={treasury}, should be > -50000"
+    );
+}
+
+/// When trade_balance is significantly negative, the TradeDeficit warning
+/// should appear in the city observation.
+#[test]
+fn test_trade_deficit_warning_appears() {
+    let mut city = TestCity::new();
+
+    // Inject a negative trade balance directly to trigger the warning.
+    {
+        let world = city.world_mut();
+        let mut goods = world.resource_mut::<CityGoods>();
+        goods.trade_balance = -5.0; // well below the -0.5 threshold
+    }
+
+    // Tick so the observation builder runs and picks up the trade balance.
+    city.tick(1);
+
+    let obs = &city.resource::<CurrentObservation>().observation;
+    assert!(
+        obs.warnings.contains(&CityWarning::TradeDeficit),
+        "TradeDeficit warning should appear when trade_balance is negative; warnings={:?}",
+        obs.warnings,
+    );
+}
+
+/// When trade_balance is zero or positive, no TradeDeficit warning.
+#[test]
+fn test_no_trade_deficit_warning_when_balanced() {
+    let mut city = TestCity::new();
+
+    // Ensure trade balance is non-negative.
+    {
+        let world = city.world_mut();
+        let mut goods = world.resource_mut::<CityGoods>();
+        goods.trade_balance = 0.0;
+    }
+
+    city.tick(1);
+
+    let obs = &city.resource::<CurrentObservation>().observation;
+    assert!(
+        !obs.warnings.contains(&CityWarning::TradeDeficit),
+        "TradeDeficit warning should NOT appear when trade_balance >= 0; warnings={:?}",
+        obs.warnings,
+    );
+}
+
+/// The import price multiplier should be 1.2x (not the old 1.8x).
+#[test]
+fn test_import_price_is_1_2x_export() {
+    for &g in GoodsType::all() {
+        let export = g.export_price();
+        let import = g.import_price();
+        let ratio = import / export;
+        assert!(
+            (ratio - 1.2).abs() < 0.001,
+            "{:?} import/export ratio should be 1.2, got {ratio}",
+            g,
+        );
+    }
+}

--- a/crates/simulation/src/observation_builder.rs
+++ b/crates/simulation/src/observation_builder.rs
@@ -20,6 +20,7 @@ use crate::immigration::CityAttractiveness;
 use crate::happiness_breakdown::HappinessBreakdown;
 use crate::homelessness::HomelessnessStats;
 use crate::pollution::PollutionGrid;
+use crate::production::types::CityGoods;
 use crate::stats::CityStats;
 use crate::time_of_day::GameClock;
 use crate::traffic_congestion::TrafficCongestion;
@@ -60,6 +61,7 @@ pub fn build_observation(
         Res<TrafficCongestion>,
         Res<PollutionGrid>,
         Res<CrimeGrid>,
+        Res<CityGoods>,
     ),
     action_log: Res<ActionResultLog>,
     grid: Res<WorldGrid>,
@@ -69,7 +71,7 @@ pub fn build_observation(
     employed_citizens: Query<(), (With<Citizen>, With<WorkLocation>)>,
     mut current: ResMut<CurrentObservation>,
 ) {
-    let (traffic_congestion, pollution_grid, crime_grid) = grids;
+    let (traffic_congestion, pollution_grid, crime_grid, city_goods) = grids;
 
     let real_employed = employed_citizens.iter().count() as u32;
     let total_employed = real_employed + virtual_pop.virtual_employed;
@@ -89,6 +91,7 @@ pub fn build_observation(
         &traffic_congestion,
         &pollution_grid,
         &crime_grid,
+        &city_goods,
         population_total,
         unemployed,
     );
@@ -190,6 +193,7 @@ fn compute_warnings(
     traffic_congestion: &TrafficCongestion,
     pollution_grid: &PollutionGrid,
     crime_grid: &CrimeGrid,
+    city_goods: &CityGoods,
     population: u32,
     unemployed: u32,
 ) -> Vec<CityWarning> {
@@ -236,6 +240,11 @@ fn compute_warnings(
     let avg_crime = average_grid_level(&crime_grid.levels);
     if avg_crime > 128.0 {
         warnings.push(CityWarning::HighCrime);
+    }
+
+    // Trade deficit: negative trade balance indicates costly imports
+    if city_goods.trade_balance < -0.5 {
+        warnings.push(CityWarning::TradeDeficit);
     }
 
     warnings

--- a/crates/simulation/src/production/systems.rs
+++ b/crates/simulation/src/production/systems.rs
@@ -286,7 +286,7 @@ pub fn update_production_chains(
         let net = city_goods.net(g);
         if net < -0.1 {
             // City is consuming more than producing; import the deficit
-            let deficit = (-net).min(50.0); // cap auto-import rate
+            let deficit = (-net).min(10.0); // cap auto-import rate
             trade_balance -= deficit as f64 * g.import_price() * 0.01;
             // Add imported goods to stockpile
             *city_goods.available.entry(g).or_insert(0.0) += deficit * 0.5;

--- a/crates/simulation/src/production/types.rs
+++ b/crates/simulation/src/production/types.rs
@@ -121,7 +121,7 @@ impl GoodsType {
 
     /// Import price per unit of deficit (more expensive than export).
     pub fn import_price(self) -> f64 {
-        self.export_price() * 1.8
+        self.export_price() * 1.2
     }
 }
 


### PR DESCRIPTION
## Summary
- Reduce import price multiplier from 1.8x to 1.2x and cap per-goods auto-import deficit from 50.0 to 10.0, preventing catastrophic treasury collapse ($900K+ loss) when cities have no local production
- Add `TradeDeficit` variant to `CityWarning` enum and detect it in the observation builder when `trade_balance < -0.5`, so the LLM agent and UI can warn about costly imports
- Add integration tests verifying treasury stability under trade deficit conditions and correct warning behavior

Note: Investigated the reported loan double-charging. The two loan systems (`LoanBook` in `loans.rs` and `ExtendedBudget.loans` in `budget.rs`) manage separate independent loan sets — `LoanBook` handles the modern tier-based loans while `ExtendedBudget` handles legacy loans from the UI. No actual double-charging occurs on the same loan.

## Test plan
- [ ] `test_trade_deficit_does_not_collapse_treasury` — verifies treasury stays above -10K after 200 ticks with no production
- [ ] `test_trade_deficit_capped_with_consumption` — verifies treasury stays above -50K after 1000 ticks with high consumption
- [ ] `test_trade_deficit_warning_appears` — verifies TradeDeficit warning triggers when trade_balance < -0.5
- [ ] `test_no_trade_deficit_warning_when_balanced` — verifies no warning when trade_balance >= 0
- [ ] `test_import_price_is_1_2x_export` — verifies the import multiplier is 1.2x for all goods types

Closes #1962

🤖 Generated with [Claude Code](https://claude.com/claude-code)