### PR TITLE
P0: Reject road-overlap utility/service placements

### DIFF
--- a/crates/simulation/src/game_actions/executor.rs
+++ b/crates/simulation/src/game_actions/executor.rs
@@ -304,6 +304,9 @@ fn execute_place_service(
             if cell.cell_type == CellType::Water {
                 return ActionResult::Error(ActionError::BlockedByWater);
             }
+            if cell.cell_type == CellType::Road {
+                return ActionResult::Error(ActionError::BlockedByRoad);
+            }
             if cell.building_id.is_some() {
                 return ActionResult::Error(ActionError::AlreadyExists);
             }
@@ -347,6 +350,9 @@ fn validate_building_placement(
     let cell = grid.get(x, y);
     if cell.cell_type == CellType::Water {
         return Err(ActionResult::Error(ActionError::BlockedByWater));
+    }
+    if cell.cell_type == CellType::Road {
+        return Err(ActionResult::Error(ActionError::BlockedByRoad));
     }
     if cell.building_id.is_some() {
         return Err(ActionResult::Error(ActionError::AlreadyExists));

--- a/crates/simulation/src/game_actions/results.rs
+++ b/crates/simulation/src/game_actions/results.rs
@@ -30,6 +30,7 @@ pub enum ActionError {
     OutOfBounds,
     InsufficientFunds,
     BlockedByWater,
+    BlockedByRoad,
     BlockedByBuilding,
     InvalidRoadGeometry,
     ZoneNotAdjacentToRoad,

--- a/crates/simulation/src/integration_tests/road_overlap_guards.rs
+++ b/crates/simulation/src/integration_tests/road_overlap_guards.rs
@@ -1,0 +1,153 @@
+//! Guards against illegal road/building overlap in the action executor.
+
+use crate::game_actions::queue::ActionSource;
+use crate::game_actions::result_log::ActionResultLog;
+use crate::game_actions::{ActionError, ActionQueue, ActionResult, GameAction};
+use crate::grid::{CellType, RoadType};
+use crate::services::ServiceType;
+use crate::test_harness::TestCity;
+use crate::utilities::UtilityType;
+
+#[test]
+fn test_place_utility_on_road_returns_blocked_by_road() {
+    let mut city = TestCity::new()
+        .with_budget(100_000.0)
+        .with_road(20, 20, 30, 20, RoadType::Local);
+
+    {
+        let world = city.world_mut();
+        let mut queue = world.resource_mut::<ActionQueue>();
+        queue.push(
+            0,
+            ActionSource::Agent,
+            GameAction::PlaceUtility {
+                pos: (25, 20),
+                utility_type: UtilityType::PowerPlant,
+            },
+        );
+    }
+
+    city.tick(1);
+
+    assert_eq!(
+        city.cell(25, 20).building_id,
+        None,
+        "utility should not be placeable on a road cell"
+    );
+    let log = city.resource::<ActionResultLog>();
+    let last = log.last_n(1);
+    assert_eq!(last.len(), 1);
+    assert_eq!(last[0].1, ActionResult::Error(ActionError::BlockedByRoad));
+}
+
+#[test]
+fn test_place_service_on_road_returns_blocked_by_road() {
+    let mut city = TestCity::new()
+        .with_budget(100_000.0)
+        .with_road(40, 40, 50, 40, RoadType::Local);
+
+    {
+        let world = city.world_mut();
+        let mut queue = world.resource_mut::<ActionQueue>();
+        queue.push(
+            0,
+            ActionSource::Agent,
+            GameAction::PlaceService {
+                pos: (45, 40),
+                service_type: ServiceType::FireStation,
+            },
+        );
+    }
+
+    city.tick(1);
+
+    assert_eq!(
+        city.cell(45, 40).building_id,
+        None,
+        "service should not be placeable on a road cell"
+    );
+    let log = city.resource::<ActionResultLog>();
+    let last = log.last_n(1);
+    assert_eq!(last[0].1, ActionResult::Error(ActionError::BlockedByRoad));
+}
+
+#[test]
+fn test_place_multi_cell_service_overlapping_road_returns_blocked_by_road() {
+    let mut city = TestCity::new()
+        .with_budget(100_000.0)
+        .with_road(60, 60, 70, 60, RoadType::Local);
+
+    // FireHQ has a 3x3 footprint. Top-left (62,59) overlaps road row y=60.
+    {
+        let world = city.world_mut();
+        let mut queue = world.resource_mut::<ActionQueue>();
+        queue.push(
+            0,
+            ActionSource::Agent,
+            GameAction::PlaceService {
+                pos: (62, 59),
+                service_type: ServiceType::FireHQ,
+            },
+        );
+    }
+
+    city.tick(1);
+
+    for y in 59..=61 {
+        for x in 62..=64 {
+            assert_eq!(
+                city.cell(x, y).building_id,
+                None,
+                "no footprint cell should receive a building when overlap is rejected"
+            );
+        }
+    }
+    let log = city.resource::<ActionResultLog>();
+    let last = log.last_n(1);
+    assert_eq!(last[0].1, ActionResult::Error(ActionError::BlockedByRoad));
+}
+
+#[test]
+fn test_place_road_line_does_not_overwrite_existing_building_cell() {
+    let mut city = TestCity::new().with_budget(100_000.0);
+
+    {
+        let world = city.world_mut();
+        let mut queue = world.resource_mut::<ActionQueue>();
+        queue.push(
+            0,
+            ActionSource::Agent,
+            GameAction::PlaceUtility {
+                pos: (80, 80),
+                utility_type: UtilityType::PowerPlant,
+            },
+        );
+        queue.push(
+            0,
+            ActionSource::Agent,
+            GameAction::PlaceRoadLine {
+                start: (75, 80),
+                end: (85, 80),
+                road_type: RoadType::Local,
+            },
+        );
+    }
+
+    city.tick(1);
+
+    assert_eq!(
+        city.cell(80, 80).cell_type,
+        CellType::Grass,
+        "road placement should not overwrite an occupied building cell"
+    );
+    assert!(
+        city.cell(80, 80).building_id.is_some(),
+        "the original building should remain on the occupied cell"
+    );
+    assert_eq!(
+        city.cell(79, 80).cell_type,
+        CellType::Road,
+        "adjacent unoccupied cells should still receive road placement"
+    );
+    assert_eq!(city.cell(81, 80).cell_type, CellType::Road);
+}

--- a/crates/simulation/src/roads.rs
+++ b/crates/simulation/src/roads.rs
@@ -51,6 +51,9 @@ impl RoadNetwork {
         if cell.cell_type == CellType::Road {
             return false; // already a road
         }
+        if cell.building_id.is_some() {
+            return false;
+        }
 
         grid.get_mut(x, y).cell_type = CellType::Road;
         grid.get_mut(x, y).road_type = road_type;


### PR DESCRIPTION
## Summary
- add `ActionError::BlockedByRoad` for placement attempts on road cells
- update action executor building validation to reject utility/service placement on road cells
- update service footprint validation to reject any road overlap across the footprint
- prevent `RoadNetwork::place_road_typed` from placing roads on cells already occupied by a building
- add `road_overlap_guards.rs` integration tests covering utility-on-road, service-on-road, service-footprint-road overlap, and road-over-building behavior

Closes #1966

## Replay audit evidence
- `sessions/nemotron-3-nano-30b-a3b:free_42_1772299118.replay` contains 357 utility-on-road actions and 35 service-origin-on-road actions (detected by replay action trace in chronological road state)

## Test plan
- [ ] CI: simulation integration tests include `road_overlap_guards.rs`
- [ ] Manual replay spot-check: invalid placements are rejected instead of spawning on roads

Generated with Codex